### PR TITLE
Reformulation "password reset"

### DIFF
--- a/dashboard/src/scenes/auth/forgot.js
+++ b/dashboard/src/scenes/auth/forgot.js
@@ -23,7 +23,7 @@ const View = () => {
     return (
       <AuthWrapper>
         <Title>Réinitialiser le mot de passe</Title>
-        <HowReset>Un lien pour réinitialiser votre mot de passe a été envoyé dans votre boîte mail.</HowReset>
+        <HowReset>Si l'adresse de courriel que vous avez saisie correspond effectivement à un compte utilisateur.rice MANO, alors un lien pour réinitialiser le mot de passe de ce compte a été envoyé à l'instant à cette adresse.</HowReset>
       </AuthWrapper>
     );
   }


### PR DESCRIPTION
Hello,
Dans le cas où le mail renseigné ne correspond pas à un compte, actuellement le message d'info laisse croire au user que le mail renseigné va tout de même recevoir un mail. Comme ce n'est pas le cas, des users se plaignent de ne rien recevoir.
Je propose cette reformulation pour attirer leur attention sur le fait que s'il ne reçoive pas de mail c'est peut-être que ce n'est pas le bon mail qu'ils ont entré.
Bonne journée,