### PR TITLE
fix(ci): semantic release update package.json

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,7 @@ jobs:
         extra_plugins: |
           @semantic-release/changelog@5.0.1
           @semantic-release/git@9.0.0
+          @google/semantic-release-replace-plugin@1.1.0
         branches: |
           [
             '+([0-9])?(.{+([0-9]),x}).x',

--- a/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env dev.ts.snap
@@ -278,6 +278,7 @@ spec:
               path: /healthz
               port: http
             periodSeconds: 5
+            initialDelaySeconds: 30
       imagePullSecrets:
         - name: regcred
 ---

--- a/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env preprod.ts.snap
@@ -306,6 +306,7 @@ spec:
               path: /healthz
               port: http
             periodSeconds: 5
+            initialDelaySeconds: 30
       imagePullSecrets:
         - name: regcred
 ---

--- a/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
+++ b/.k8s/__tests__/__snapshots__/kosko generate --env prod.ts.snap
@@ -276,6 +276,7 @@ spec:
               path: /healthz
               port: http
             periodSeconds: 5
+            initialDelaySeconds: 30
       imagePullSecrets:
         - name: regcred
 ---

--- a/.k8s/components/dashboard.ts
+++ b/.k8s/components/dashboard.ts
@@ -24,6 +24,9 @@ const manifests = create("dashboard", {
           memory: "128Mi",
         },
       },
+      startupProbe: {
+        initialDelaySeconds: 30,
+      },
     },
   },
 });

--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -2,9 +2,34 @@ plugins:
   - "@semantic-release/commit-analyzer"
   - "@semantic-release/release-notes-generator"
   - "@semantic-release/changelog"
+  - - "@google/semantic-release-replace-plugin"
+    - replacements:
+      - files:
+        - api/package.json
+        - website/package.json
+        - dashboard/package.json
+        from: "\"version\": \".*\""
+        to: "\"version\": \"${nextRelease.version}\""
+        results:
+        - file: api/package.json
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
+        - file: website/package.json
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
+        - file: dashboard/package.json
+          hasChanged: true
+          numMatches: 1
+          numReplacements: 1
+        countMatches: true
   - - "@semantic-release/git"
     - assets:
         - CHANGELOG.md
         - README.md
+        - api/package.json
+        - website/package.json
+        - dashboard/package.json
       message: "chore(release): version ${nextRelease.version}\n\n${nextRelease.notes}"
   - "@semantic-release/github"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Mano
+![Mobile version](https://img.shields.io/badge/mobile%20app%20version-2.5.0-blue)
 
 Code source de [Mano](https://mano-app.fabrique.social.gouv.fr/), organisé en plusieurs services : 
  - [Application mobile](https://github.com/SocialGouv/mano/tree/main/app)

--- a/api/package.json
+++ b/api/package.json
@@ -1,6 +1,7 @@
 {
   "name": "api_mano",
   "version": "2.3.26",
+  "mobileAppVersion": "2.5.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/api/src/config.js
+++ b/api/src/config.js
@@ -1,4 +1,4 @@
-const { version } = require("../package.json");
+const { version, mobileAppVersion } = require("../package.json");
 
 const PORT = process.env.PORT || 3000;
 const SECRET = process.env.SECRET || "not_so_secret_4";
@@ -8,6 +8,7 @@ const PGHOST = process.env.PGHOST;
 const PGPORT = process.env.PGPORT;
 const PGUSER = process.env.PGUSER;
 const VERSION = version;
+const MOBILE_APP_VERSION = mobileAppVersion;
 const PGPASSWORD = process.env.PGPASSWORD || null;
 const SENTRY_KEY = process.env.SENTRY_KEY || "https://e3eb487403dd4789b47cf6da857bb4bf@sentry.fabrique.social.gouv.fr/52";
 const PGDATABASE = process.env.PGDATABASE;
@@ -37,6 +38,7 @@ module.exports = {
   PGDATABASE,
   SENTRY_KEY,
   VERSION,
+  MOBILE_APP_VERSION,
   ENCRYPTED_FIELDS_ONLY,
   X_TIPIMAIL_APIUSER,
   X_TIPIMAIL_APIKEY,

--- a/api/src/controllers/utils.js
+++ b/api/src/controllers/utils.js
@@ -1,7 +1,7 @@
 const express = require("express");
 const router = express.Router();
 const passport = require("passport");
-const { VERSION } = require("../config");
+const { MOBILE_APP_VERSION } = require("../config");
 
 router.get("/check-auth", passport.authenticate("user", { session: false }), async (req, res) => {
   // called when the app / the dashboard get from unfocused to focused
@@ -9,8 +9,12 @@ router.get("/check-auth", passport.authenticate("user", { session: false }), asy
   res.status(200).send({ ok: true });
 });
 
+// Get mobile app version suggested by the server.
+// When a new version of the mobile app is released, the server will send the version number
+// so the mobile app can send a notification to the user.
+// See: app/src/scenes/Login/Login.js
 router.get("/version", async (req, res) => {
-  res.status(200).send({ ok: true, data: VERSION });
+  res.status(200).send({ ok: true, data: MOBILE_APP_VERSION });
 });
 
 module.exports = router;

--- a/api/src/middleware/versionCheck.js
+++ b/api/src/middleware/versionCheck.js
@@ -1,4 +1,4 @@
-const MIN_VER = [2, 3, 11];
+const MINIMUM_MOBILE_APP_VERSION = [2, 3, 11];
 
 module.exports = ({ headers: { version, platform } }, res, next) => {
   if (platform === "dashboard") return next();
@@ -8,9 +8,9 @@ module.exports = ({ headers: { version, platform } }, res, next) => {
   const appVer = version.split(".").map((d) => parseInt(d));
 
   for (let i = 0; i < 3; i++) {
-    if (appVer[i] > MIN_VER[i]) {
+    if (appVer[i] > MINIMUM_MOBILE_APP_VERSION[i]) {
       return next();
-    } else if (appVer[i] < MIN_VER[i]) {
+    } else if (appVer[i] < MINIMUM_MOBILE_APP_VERSION[i]) {
       return res.status(403).send({ ok: false, message: "Veuillez mettre à jour votre application!" });
     }
   }

--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -140,7 +140,7 @@ android {
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true
         versionCode 3
-        versionName "2.3.26"
+        versionName "2.5.0"
     }
     packagingOptions {
        pickFirst 'lib/x86/libc++_shared.so'

--- a/app/package.json
+++ b/app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mano",
-  "version": "2.3.26",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "get-ip": "./get-ip.sh",
@@ -20,7 +20,8 @@
     "build:android-apk-preproduction": "echo -p \"please update either .env.production with the preproduction values until we found a better solution 🥸\" && cd android && ./gradlew clean && ./gradlew assembleRelease && cd ../",
     "deploy:android": "./upload.sh",
     "build-and-deploy:android": "npm run build:android-apk && ./upload.sh",
-    "build-and-deploy-preprod:android": "npm run build:android-apk-preproduction && ./upload-preprod.sh"
+    "build-and-deploy-preprod:android": "npm run build:android-apk-preproduction && ./upload-preprod.sh",
+    "update-mobile-app-version": "node ./update-mobile-app-version.js"
   },
   "dependencies": {
     "@expo/react-native-action-sheet": "^3.9.0",
@@ -78,7 +79,8 @@
     "eslint": "7.14.0",
     "jest": "^27.0.4",
     "metro-react-native-babel-preset": "^0.64.0",
-    "react-test-renderer": "17.0.1"
+    "react-test-renderer": "17.0.1",
+    "semver": "^7.3.5"
   },
   "jest": {
     "preset": "react-native",

--- a/app/update-mobile-app-version.js
+++ b/app/update-mobile-app-version.js
@@ -1,0 +1,34 @@
+const semver = require('semver');
+const fs = require('fs');
+const currentVersion = require('./package.json').version;
+
+let release = process.argv[2] || 'minor';
+const validRelease = ['minor', 'major', 'patch'];
+if (!validRelease.includes(release)) {
+  console.error('😢 invalid release, must be ' + validRelease.join(', '));
+  process.exit(1);
+}
+
+const newVersion = semver.inc(currentVersion, release);
+
+// Replace the version in the package.json file via regex and save it
+const packageJson = fs.readFileSync('package.json', 'utf8');
+const newPackageJson = packageJson.replace(/"version": "[^"]+"/, `"version": "${newVersion}"`);
+fs.writeFileSync('package.json', newPackageJson);
+
+// Replace the version in the android/app/build.graddle file via regex and save it
+const buildGradle = fs.readFileSync('android/app/build.gradle', 'utf8');
+const newBuildGradle = buildGradle.replace(/versionName "[^"]+"/, `versionName "${newVersion}"`);
+fs.writeFileSync('android/app/build.gradle', newBuildGradle);
+
+// Replace the mobileAppVersion in the ../api/package.json file via regex and save it
+const apiPackageJson = fs.readFileSync('../api/package.json', 'utf8');
+const newApiPackageJson = apiPackageJson.replace(/"mobileAppVersion": "[^"]+"/, `"mobileAppVersion": "${newVersion}"`);
+fs.writeFileSync('../api/package.json', newApiPackageJson);
+
+// Replace the version in the badge in ../README.md via regex and save it
+const readme = fs.readFileSync('../README.md', 'utf8');
+const newReadme = readme.replace(/version-(\d+\.\d+\.\d+)-blue/, `version-${newVersion}-blue`);
+fs.writeFileSync('../README.md', newReadme);
+
+console.log('🥳 Updated version to ' + newVersion);


### PR DESCRIPTION
Le but c'est de mettre à jour le package.json de l'API, du dashboard et du site automatiquement à chaque release. Mais pas celui de l'app mobile car il a un impact sur la mise à jour. On pourra voir plus tard comment gérer ce cas en attendant il faut continuer à le mettre à la main à chaque fois qu'on veut le livrer, même si il est ailleurs que le reste. J'ai des pistes pour améliorer. En attendant  : 

AVANT de merger cette PR : 
- api : 2.3.26
- dashboard : 2.3.28
- website : 2.1.18
- tag: 1.10.0
(4 versions différentes)

APRES avoir mergé cette PR : 
- api : 1.10.0
- dashboard : 1.10.0
- website : 1.10.0
- tag: 1.10.0
(4 versions pareilles, et plus de modifs à faire à la main dans les 3 fichiers)

WDYT?