### PR TITLE
chore(poc): encrypted only

### DIFF
--- a/dashboard/src/services/api.js
+++ b/dashboard/src/services/api.js
@@ -36,6 +36,8 @@ class ApiService {
         };
       }
 
+      if (this.enableEncrypt && !skipEncryption) query = { ...query, encryptedOnly: '1' };
+
       const url = this.getUrl(path, query);
       const response = await fetch(url, options);
 


### PR DESCRIPTION
Cette PR est juste pour discuter : pourquoi on renvoie tous les champs même quand la base est encryptée ? On pourrait en renvoyer moins, ça accélère le SQL, l'API, le réseau et le front. WDYT?