### PR TITLE
fix(dashboard): due at in action

### DIFF
--- a/dashboard/src/components/DateBloc.js
+++ b/dashboard/src/components/DateBloc.js
@@ -1,17 +1,16 @@
-import React from "react";
-import styled from "styled-components";
+import React from 'react';
+import styled from 'styled-components';
 
-const ShowDate = ({ date }) => {
+const DateBloc = ({ date }) => {
   if (!date) return <div />;
-  const d = new Date(date);
-  const utcDate = new Date(Date.UTC(d.getFullYear(), d.getMonth(), d.getDate(), d.getHours(), d.getMinutes(), 0, 0));
+  date = new Date(date);
   return (
     <Container>
-      <DayText>{date && utcDate.toLocaleString("fr-FR", { weekday: "long" })}</DayText>
-      <DayNum>{date && utcDate.getDate()}</DayNum>
+      <DayText>{date && date.toLocaleString('fr-FR', { weekday: 'long' })}</DayText>
+      <DayNum>{date && date.getDate()}</DayNum>
       <MonthText>
-        {date && utcDate.toLocaleString("fr-FR", { month: "long" })}
-        {date && utcDate.getFullYear() !== new Date().getFullYear() && `\u00A0${utcDate.getFullYear()}`}
+        {date && date.toLocaleString('fr-FR', { month: 'long' })}
+        {date && date.getFullYear() !== new Date().getFullYear() && `\u00A0${date.getFullYear()}`}
       </MonthText>
     </Container>
   );
@@ -49,4 +48,4 @@ const DayText = styled.span`
   font-size: 14px;
 `;
 
-export default ShowDate;
+export default DateBloc;

--- a/dashboard/src/scenes/action/view.js
+++ b/dashboard/src/scenes/action/view.js
@@ -86,7 +86,7 @@ const View = () => {
                           selected={values.dueAt ? new Date(values.dueAt) : new Date()}
                           onChange={(date) => handleChange({ target: { value: date, name: 'dueAt' } })}
                           dateFormat={values.withTime ? 'dd/MM/yyyy HH:mm' : 'dd/MM/yyyy'}
-                          showTimeInput
+                          showTimeInput={values.withTime}
                         />
                       </div>
                     </FormGroup>


### PR DESCRIPTION
Trello: https://trello.com/c/o3AEKsvU/472-bug-action-%C3%A0-realiser-dans-laction-%C3%A0-r%C3%A9aliser-le-12-affich%C3%A9-dans-les-actions-%C3%A0-realiser-le-13

A priori il n'y a pas besoin de convertir en UTC étant donné que c'est déjà en UTC. Le bug arrivait par exemple si je crée une action à 23h sur mon poste. Ça a l'air de corriger.

Au passage j'ai corrigé le composant pour qu'il n'affiche l'heure que si on a choisi l'option.