### PR TITLE
chore(app): do not load reports in app

### DIFF
--- a/app/src/contexts/refresh.js
+++ b/app/src/contexts/refresh.js
@@ -75,9 +75,11 @@ export const RefreshProvider = ({ children }) => {
       await relsPersonPlaceContext.refreshRelsPersonPlace(initialLoad);
       setProgress((p) => (p * total + relsPersonPlace) / total);
 
-      setLoading('Chargement des rapports');
-      await reportsContext.refreshReports(initialLoad);
-      setProgress((p) => (p * total + reports) / total);
+      // We currently don't need the rapports in loading.
+
+      // setLoading('Chargement des rapports');
+      // await reportsContext.refreshReports(initialLoad);
+      // setProgress((p) => (p * total + reports) / total);
 
       setFullScreen(false);
 


### PR DESCRIPTION
Voir : https://trello.com/c/UepeXmmc/476-ne-pas-charger-les-rapports-tant-quon-nen-a-pas-besoin-sur-mobile