### PR TITLE
fix(dashboard): show message for custom fields when organisation not encrypted

### DIFF
--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -108,18 +108,32 @@ const View = () => {
                   <ButtonCustom title={'Mettre à jour'} loading={isSubmitting} onClick={handleSubmit} width={200} />
                 </div>
                 <hr />
+                <Title>Réglage des Observations de Territoires</Title>
                 {/* this custom fields is only working if encryption is enabled */}
-                {organisation.encryptionEnabled && (
-                  <>
-                    <Title>Réglage des Observations</Title>
+                <>
+                  {organisation.encryptionEnabled ? (
                     <Row>
                       <TableCustomFields
                         customFields="customFieldsObs"
                         data={organisation.customFieldsObs ? JSON.parse(organisation.customFieldsObs) : defaultCustomFields}
                       />
                     </Row>
-                  </>
-                )}
+                  ) : (
+                    <>
+                      <Row>
+                        <Col md={10}>
+                          <p>
+                            Désolé, cette fonctionnalité qui consiste à personnaliser les champs disponibles pour les observations de territoires,
+                            n'existe que pour les organisations chiffrées.
+                          </p>
+                        </Col>
+                      </Row>
+                      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 40 }}>
+                        <EncryptionKey />
+                      </div>
+                    </>
+                  )}
+                </>
               </>
             );
           }}


### PR DESCRIPTION
https://trello.com/c/S7AqabGO/492-impossible-de-parametrer-les-champs-dans-orga-non-chiffrée
<img width="1055" alt="Screen Shot 2021-11-02 at 06 03 38" src="https://user-images.githubusercontent.com/31724752/139789496-0f29a6e3-2d2c-4335-8c42-9ee5745050d6.png">


