### PR TITLE
fix(dashboard): fix utc problem for display date

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -17,7 +17,7 @@
     "base-64": "^1.0.0",
     "base64-js": "^1.5.1",
     "bootstrap": "^4.6.0",
-    "dayjs": "^1.10.4",
+    "dayjs": "^1.10.7",
     "formik": "^2.2.6",
     "libsodium": "^0.7.9",
     "libsodium-wrappers": "^0.7.9",

--- a/dashboard/src/components/DateBloc.js
+++ b/dashboard/src/components/DateBloc.js
@@ -1,16 +1,22 @@
 import React from 'react';
 import styled from 'styled-components';
+import dayjs from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import 'dayjs/locale/fr';
+
+dayjs.extend(utc);
+dayjs.locale('fr');
 
 const DateBloc = ({ date }) => {
   if (!date) return <div />;
-  date = new Date(date);
+  date = dayjs.utc(date);
   return (
     <Container>
-      <DayText>{date && date.toLocaleString('fr-FR', { weekday: 'long' })}</DayText>
-      <DayNum>{date && date.getDate()}</DayNum>
+      <DayText>{date && date.format('dddd')}</DayText>
+      <DayNum>{date && date.format('D')}</DayNum>
       <MonthText>
-        {date && date.toLocaleString('fr-FR', { month: 'long' })}
-        {date && date.getFullYear() !== new Date().getFullYear() && `\u00A0${date.getFullYear()}`}
+        {date && date.format('MMMM')}
+        {date && date.format('YYYY') !== dayjs.utc().format('YYYY') && ` ${date.format('YYYY')}`}
       </MonthText>
     </Container>
   );

--- a/dashboard/yarn.lock
+++ b/dashboard/yarn.lock
@@ -4688,10 +4688,10 @@ date-fns@^2.0.1:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
   integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
-dayjs@^1.10.4:
-  version "1.10.5"
-  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.5.tgz#5600df4548fc2453b3f163ebb2abbe965ccfb986"
-  integrity sha512-BUFis41ikLz+65iH6LHQCDm4YPMj5r1YFLdupPIyM4SGcXMmtiLQ7U37i+hGS8urIuqe7I/ou3IS1jVc4nbN4g==
+dayjs@^1.10.7:
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/dayjs/-/dayjs-1.10.7.tgz#2cf5f91add28116748440866a0a1d26f3a6ce468"
+  integrity sha512-P6twpd70BcPK34K26uJ1KT3wlhpuOAPoMwJzpsIWUxHZ7wpmbdZL/hQqBDfz7hGurYSa5PhzdhDHtt319hL3ig==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.3.3, debug@^2.6.0, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
Cette fois-ci ça va être bon !

Je me suis permis d'intégrer [`dayjs`](https://day.js.org/en/) (qu'on utilise aussi au SNU) et qui permet de manipuler les dates de manière plus agréable (je trouve). 

Maintenant pour décrire le problème et pourquoi je ne l'avais qu'à moitié résolu : 

En gros, d'après ce que j'ai compris, on stocke toujours les dates en UTC. Si on réutilise des fonctions de dates dessus, ça change tout le temps en réapliquant le temps du jour. Donc il faut à la fois récupérer la date en UTC **et** la manipuler en UTC (et ne jamais lacher ça). Ou alors appliquer une troncature pour retirer la timezone [comme ici](https://github.com/SocialGouv/mano/blob/main/dashboard/src/components/ActionsCalendar.js#L27-L35) mais ça fait plus hack. En fait peut-être que la solution aurait été de stocker des dates SANS timezone en base de données (plus d'info ici : https://www.postgresql.org/docs/current/datatype-datetime.html). Comme on ne travaille que sur des dates "absolues" ç'aurait été probablement plus simple.

Source : https://trello.com/c/44UW9KJn/448-actions-pr%C3%A9vues-pour-ce-jour-saffichent-dans-hier