### PR TITLE
fix(dashboard): slow search

### DIFF
--- a/dashboard/src/components/search.js
+++ b/dashboard/src/components/search.js
@@ -10,7 +10,7 @@ const Search = React.forwardRef(({ value = '', onChange = Function.prototype, pl
     clearTimeout(searchDebounce.current);
     searchDebounce.current = setTimeout(() => {
       if (value !== cachedValue) onChange(cachedValue);
-    }, 250);
+    }, 500);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [cachedValue]);
 

--- a/dashboard/src/scenes/search/index.js
+++ b/dashboard/src/scenes/search/index.js
@@ -53,6 +53,7 @@ const View = () => {
 
   const renderContent = () => {
     if (!search) return 'Pas de recherche, pas de résultat !';
+    if (search.length < 3) return 'Recherche trop courte (moins de 3 caractères), pas de résultat !';
     return (
       <>
         <Nav tabs fill style={{ marginBottom: 20 }}>


### PR DESCRIPTION
Suite à un constat sur mon poste : 

Si je tape seulement 1 ou 2 caractères (je tape lentement), ça fait quasiment planter mon navigateur, parce qu'il y a trop de résultats et si je reprends à taper tout mon ordi part dans les choux

On peut considérer que la recherche commence à 3 caractères et qu'elle a un debounce un tout petit peu plus long.

Je trouve ça plus cool, mais dis moi.