### PR TITLE
fix: customFields as object not string

### DIFF
--- a/api/src/controllers/organisation.js
+++ b/api/src/controllers/organisation.js
@@ -106,7 +106,8 @@ router.put(
     if (req.body.hasOwnProperty("name")) updateOrg.name = req.body.name;
     if (req.body.hasOwnProperty("categories")) updateOrg.categories = req.body.categories;
     if (req.body.hasOwnProperty("collaborations")) updateOrg.collaborations = req.body.collaborations;
-    if (req.body.hasOwnProperty("customFieldsObs")) updateOrg.customFieldsObs = req.body.customFieldsObs;
+    if (req.body.hasOwnProperty("customFieldsObs"))
+      updateOrg.customFieldsObs = typeof req.body.customFieldsObs === "string" ? JSON.parse(req.body.customFieldsObs) : req.body.customFieldsObs;
     if (req.body.hasOwnProperty("encryptedVerificationKey")) updateOrg.encryptedVerificationKey = req.body.encryptedVerificationKey;
     if (req.body.hasOwnProperty("encryptionEnabled")) updateOrg.encryptionEnabled = req.body.encryptionEnabled;
     if (req.body.hasOwnProperty("encryptionLastUpdateAt")) updateOrg.encryptionLastUpdateAt = req.body.encryptionLastUpdateAt;

--- a/api/src/db/migrations/2021-11-16_observations-as-json.js
+++ b/api/src/db/migrations/2021-11-16_observations-as-json.js
@@ -1,0 +1,22 @@
+const { QueryTypes } = require("sequelize");
+const sequelize = require("../sequelize");
+
+(async () => {
+  try {
+    const rows = await sequelize.query(`select * from "mano"."Organisation" where "customFieldsObs" is not null`, { type: QueryTypes.SELECT });
+
+    // For each rows, check if the customFieldsObs is a JSON string
+    // If it is, convert it to a JSON object
+    // If it is not, do nothing
+    for (const row of rows) {
+      if (typeof JSON.parse(row.customFieldsObs) === "string") {
+        const customFieldsObs = JSON.parse(row.customFieldsObs);
+        await sequelize.query(`update "mano"."Organisation" set "customFieldsObs" = ? where _id = ?`, {
+          replacements: [customFieldsObs, row._id],
+        });
+      }
+    }
+  } catch (error) {
+    console.error(error);
+  }
+})();

--- a/api/src/db/migrations/index.js
+++ b/api/src/db/migrations/index.js
@@ -7,3 +7,4 @@ require("./2021-10-11_add-out-of-active-list");
 require("./2021-10-01-custom-fields-obs.js");
 require("./2021-11-05_multiple-collaborations");
 require("./2021-10-22_encrypted-verification-key");
+require("./2021-11-16_observations-as-json");

--- a/app/src/contexts/territoryObservations.js
+++ b/app/src/contexts/territoryObservations.js
@@ -12,7 +12,11 @@ export const TerritoryObservationsProvider = ({ children }) => {
 
   const { organisation } = useContext(AuthContext);
 
-  const customFieldsObs = typeof organisation.customFieldsObs === 'string' ? JSON.parse(organisation.customFieldsObs) : defaultCustomFields;
+  let customFieldsObs;
+  if (Array.isArray(organisation.custom_fields)) customFieldsObs = organisation.custom_fields;
+  // It should not be a string but required for legacy reasons.
+  else if (typeof organisation.customFieldsObs === 'string') customFieldsObs = JSON.parse(organisation.customFieldsObs);
+  return (customFieldsObs = defaultCustomFields);
 
   const setTerritoryObs = (territoryObservations) => {
     if (territoryObservations) {

--- a/app/src/contexts/territoryObservations.js
+++ b/app/src/contexts/territoryObservations.js
@@ -13,7 +13,7 @@ export const TerritoryObservationsProvider = ({ children }) => {
   const { organisation } = useContext(AuthContext);
 
   let customFieldsObs;
-  if (Array.isArray(organisation.custom_fields)) customFieldsObs = organisation.custom_fields;
+  if (Array.isArray(organisation.customFieldsObs)) customFieldsObs = organisation.customFieldsObs;
   // It should not be a string but required for legacy reasons.
   else if (typeof organisation.customFieldsObs === 'string') customFieldsObs = JSON.parse(organisation.customFieldsObs);
   else customFieldsObs = defaultCustomFields;

--- a/app/src/contexts/territoryObservations.js
+++ b/app/src/contexts/territoryObservations.js
@@ -16,7 +16,7 @@ export const TerritoryObservationsProvider = ({ children }) => {
   if (Array.isArray(organisation.custom_fields)) customFieldsObs = organisation.custom_fields;
   // It should not be a string but required for legacy reasons.
   else if (typeof organisation.customFieldsObs === 'string') customFieldsObs = JSON.parse(organisation.customFieldsObs);
-  return (customFieldsObs = defaultCustomFields);
+  else customFieldsObs = defaultCustomFields;
 
   const setTerritoryObs = (territoryObservations) => {
     if (territoryObservations) {

--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -73,12 +73,12 @@ const TableCustomFields = ({ data, customFields }) => {
     try {
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
-        body: { [customFields]: JSON.stringify(newData) },
+        body: { [customFields]: newData },
       });
       if (response.ok) {
         toastr.success('Mise à jour !');
         setOrganisation(response.data);
-        setMutableData(JSON.parse(response.data[customFields]));
+        setMutableData(response.data[customFields]);
       }
     } catch (orgUpdateError) {
       console.log('error in updating organisation', orgUpdateError);

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -18,7 +18,10 @@ export const customFieldsObsSelector = selector({
   key: 'customFieldsObsSelector',
   get: ({ get }) => {
     const organisation = get(organisationState);
-    return typeof organisation.customFieldsObs === 'string' ? JSON.parse(organisation.customFieldsObs) : defaultCustomFields;
+    if (Array.isArray(organisation.custom_fields)) return organisation.custom_fields;
+    // It should not be a string but required for legacy reasons.
+    else if (typeof organisation.customFieldsObs === 'string') return JSON.parse(organisation.customFieldsObs);
+    return defaultCustomFields;
   },
 });
 

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -18,7 +18,7 @@ export const customFieldsObsSelector = selector({
   key: 'customFieldsObsSelector',
   get: ({ get }) => {
     const organisation = get(organisationState);
-    if (Array.isArray(organisation.custom_fields)) return organisation.custom_fields;
+    if (Array.isArray(organisation.customFieldsObs)) return organisation.customFieldsObs;
     // It should not be a string but required for legacy reasons.
     else if (typeof organisation.customFieldsObs === 'string') return JSON.parse(organisation.customFieldsObs);
     return defaultCustomFields;

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -116,7 +116,12 @@ const View = () => {
                     <Row>
                       <TableCustomFields
                         customFields="customFieldsObs"
-                        data={organisation.customFieldsObs ? JSON.parse(organisation.customFieldsObs) : defaultCustomFields}
+                        data={(() => {
+                          if (Array.isArray(organisation.custom_fields)) return organisation.custom_fields;
+                          // It should not be a string but required for legacy reasons.
+                          else if (typeof organisation.customFieldsObs === 'string') return JSON.parse(organisation.customFieldsObs);
+                          return defaultCustomFields;
+                        })()}
                       />
                     </Row>
                   ) : (

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -117,7 +117,7 @@ const View = () => {
                       <TableCustomFields
                         customFields="customFieldsObs"
                         data={(() => {
-                          if (Array.isArray(organisation.custom_fields)) return organisation.custom_fields;
+                          if (Array.isArray(organisation.customFieldsObs)) return organisation.customFieldsObs;
                           // It should not be a string but required for legacy reasons.
                           else if (typeof organisation.customFieldsObs === 'string') return JSON.parse(organisation.customFieldsObs);
                           return defaultCustomFields;


### PR DESCRIPTION
J'ai mis trèèèès longtemps avant de comprendre ce qui se passait.

En fait, pour une raison obscure, les `customFieldsObs` étaient stringuifiées. En résulte des opérations de stringification/déstringifications qui peuvent amener à des incohérence, car rien n'empèche de stringifier une chaine indéfiniment sans s'en rendre compte.

Du coup la solution proposée est de ne rien stringifier, vu que ce qu'on veut stocker c'est un objet et pas une chaine (les custom fields sont un array d'object, pas une chaine de caractères).

Le problème, c'est que comme actuellement les champs sont enregistrés en base de données pour les users en strings (sauf pour moi je ne comprends pas pourquoi), il faut garder une sorte de rétro-compatibilité d'où mon if chelou. Si tu as mieux je prends. On pourrait aussi faire migrer tout le monde...