### PR TITLE
fix(dashboard): hashedOrgEncryptionKey === null even after setting good key

### DIFF
--- a/dashboard/src/app.js
+++ b/dashboard/src/app.js
@@ -1,6 +1,6 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useEffect } from 'react';
-import { RecoilRoot, useRecoilState } from 'recoil';
+import { RecoilRoot } from 'recoil';
 import { BrowserRouter as Router, Route, Switch, Redirect } from 'react-router-dom';
 import { fr } from 'date-fns/esm/locale';
 import { registerLocale } from 'react-datepicker';
@@ -32,7 +32,7 @@ import Reception from './scenes/reception';
 import Charte from './scenes/auth/charte';
 import { useAuth } from './recoil/auth';
 import useApi from './services/api-interface-with-dashboard';
-import { tokenState } from './services/api';
+import { tokenCached } from './services/api';
 
 const store = createStore(combineReducers({ toastr }));
 
@@ -40,10 +40,9 @@ registerLocale('fr', fr);
 
 const App = () => {
   const API = useApi();
-  const token = useRecoilState(tokenState);
 
   const onWindowFocus = (e) => {
-    if (token && e.newState === 'active') API.get({ path: '/check-auth' }); // will force logout if session is expired
+    if (tokenCached && e.newState === 'active') API.get({ path: '/check-auth' }); // will force logout if session is expired
   };
 
   useEffect(() => {

--- a/dashboard/src/app.js
+++ b/dashboard/src/app.js
@@ -42,8 +42,8 @@ const App = () => {
   const API = useApi();
   const token = useRecoilState(tokenState);
 
-  const onWindowFocus = () => {
-    if (token) API.get({ path: '/check-auth' }); // will force logout if session is expired
+  const onWindowFocus = (e) => {
+    if (token && e.newState === 'active') API.get({ path: '/check-auth' }); // will force logout if session is expired
   };
 
   useEffect(() => {
@@ -52,6 +52,7 @@ const App = () => {
       lifecycle.removeEventListener('statechange', onWindowFocus);
     };
   }, []);
+
   return (
     <div className="main-container">
       <div className="main">

--- a/dashboard/src/scenes/auth/signin.js
+++ b/dashboard/src/scenes/auth/signin.js
@@ -15,6 +15,7 @@ import useApi from '../../services/api-interface-with-dashboard';
 import { useRefresh } from '../../recoil/refresh';
 import { encryptVerificationKey } from '../../services/encryption';
 import { useRecoilState, useSetRecoilState } from 'recoil';
+import { hashedOrgEncryptionKey } from '../../services/api';
 
 /*
 TODO:
@@ -48,7 +49,7 @@ const SignIn = () => {
   const setEncryptionVerificationKey = async (organisation, user) => {
     if (!organisation.encryptionEnabled) return;
     if (!organisation.encryptedVerificationKey && ['admin'].includes(user.role)) {
-      const encryptedVerificationKey = await encryptVerificationKey(API.hashedOrgEncryptionKey);
+      const encryptedVerificationKey = await encryptVerificationKey(hashedOrgEncryptionKey);
       const orgRes = await API.put({ path: `/organisation/${organisation._id}`, body: { encryptedVerificationKey } });
       if (orgRes.ok) setOrganisation(orgRes.data);
     }


### PR DESCRIPTION
Bon, je sais pas si c'est une "bonne pratique" ce que je viens de faire, mais ça a le mérite de marcher. Chez moi...

Contexte : j'ai un problème avec les hooks dans ma vie !
Je t'ai montré que de temps en temps, le state recoil se met à jour mais certaines fonctions utilisent toujours l'ANCIEN state recoil. Je n'arrive pas à comprendre pourquoi...

![Screen Shot 2021-11-19 at 12 39 30](https://user-images.githubusercontent.com/31724752/142616882-edec0a13-0bf1-4d99-bf50-472864485ec0.png)


Certains ont cette [erreur sentry]( https://sentry.io/organizations/betagouv-f7/issues/2798886616/events/16be16eacf4c4e7294714e27cb8a4dd9/?project=5833236&query=is%3Aunresolved+%21bookmarks%3Ame): 4 users, mais 1400 fois.

Cause: `hashedOrgEncryptionKey === null` ce qui ne devrait pas être le cas.
![Screen Shot 2021-11-19 at 12 38 42](https://user-images.githubusercontent.com/31724752/142616800-55d6e982-2eb1-4154-807f-6b5e91023efe.png)

j'ai donc pris une autre tactique pour ces cas particuliers, et ça marche.

J'aimerais bien ton avis !

