### PR TITLE
fix(dashboard): drawer disabled when teams request fails

### DIFF
--- a/dashboard/src/services/api.js
+++ b/dashboard/src/services/api.js
@@ -111,8 +111,8 @@ const useApiService = ({
         };
       }
 
-      options.retries = 3;
-      options.retryDelay = 1000;
+      options.retries = 10;
+      options.retryDelay = 2000;
 
       const url = getUrl(path, query);
       const response = await fetch(url, options);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/31724752/142628980-55bc76bd-a211-447e-8452-5b5fffe1d3f7.png)

le drawer est disabled quand un admin se connecte pour la première fois et qu'aucune équipe n'est créée.

Je pense donc, sans avoir réussi à reproduire, que c'est parce que la requête `/teams` n'a pas fonctionné chez Nathan - il a réussi à reproduire plusieurs fois, mais toujours de manière aléatoire - je ne vois pas d'autre explication...

Donc voilà ma proposition : plus de retries, plus espacés !

J'ai vu que SWR essayait 10 fois, ça n'a pas l'air de faire de mal...