### PR TITLE
fix(dashboard): passages

### DIFF
--- a/api/src/db/migration.js
+++ b/api/src/db/migration.js
@@ -55,4 +55,5 @@ const getIsDayWithinHoursOffsetOfDay = (dayToTest, referenceDay, offsetHours) =>
       await report.save();
     }
   }
+  capture("DONE PASSAGES MIGRATION");
 })();

--- a/api/src/db/migration.js
+++ b/api/src/db/migration.js
@@ -14,3 +14,75 @@ const TerritoryObservation = require("../models/territoryObservation");
 const RelPersonTeam = require("../models/relPersonTeam");
 const Report = require("../models/report");
 const { capture } = require("../sentry");
+
+// this function is copy/pasted from dashboard
+const getIsDayWithinHoursOffsetOfDay = (dayToTest, referenceDay, offsetHours) => {
+  if (!dayToTest) return false;
+  referenceDay = new Date(referenceDay);
+  referenceDay.setHours(0, 0, 0, 0);
+  const startDate = new Date(referenceDay);
+  startDate.setHours(referenceDay.getHours() + offsetHours);
+  const endDate = new Date(startDate);
+  endDate.setHours(startDate.getHours() + 24);
+
+  dayToTest = new Date(dayToTest).toISOString();
+
+  return dayToTest > startDate.toISOString() && dayToTest <= endDate.toISOString();
+};
+
+// const currentTeam = get(currentTeamState);
+// const comments = get(commentsState);
+// const persons = get(personsState);
+// return comments
+//   .filter((c) => c.team === currentTeam._id)
+//   .filter((c) => getIsDayWithinHoursOffsetOfDay(c.createdAt, date, currentTeam?.nightSession ? 12 : 0))
+//   .filter((c) => !!c.comment.includes('Passage enregistré'))
+//   .map((passage) => {
+//     const commentPopulated = { ...passage };
+//     if (passage.person) {
+//       commentPopulated.person = persons.find((p) => p._id === passage?.person);
+//       commentPopulated.type = 'person';
+//     }
+//     return commentPopulated;
+//   });
+
+// here you can write any data migration, not schema migrations
+(async () => {
+  const organisations = await Organisation.findAll({ where: { receptionEnabled: true } });
+  const commentedPassages = await Comment.findAll({ where: { comment: "Passage enregistré" } });
+  const teams = await Team.findAll();
+  const reports = await Report.findAll();
+  console.log(commentedPassages.length, organisations.length, teams.length, reports.length);
+  // for (const comment of commentedPassages) {
+  // if (!comment.team) {
+  //   console.log("NO COMMENT TEAM", comment._id);
+  //   continue;
+  // }
+  // const team = teams.find((t) => t._id === comment.team);
+  // if (!team) {
+  //   console.log("NO TEAM", comment._id, comment.team);
+  //   continue;
+  // }
+  // const report = reports
+  //   .filter((r) => r.team === comment.team)
+  //   .find((r) => getIsDayWithinHoursOffsetOfDay(comment.createdAt, r.date, team?.nightSession ? 12 : 0));
+  // if (!report) {
+  //   console.log("NO REPORT", comment._id, team.nightSession);
+  // }
+  // grab the report
+  // }
+
+  // check double reports
+  let doubles = 0;
+  reports.reduce((dates, report) => {
+    if (!dates[report.date]) dates[report.date] = {};
+    if (!dates[report.date][report.team]) {
+      dates[report.date][report.team] = report._id;
+    } else {
+      console.log("DOUBLE", report._id, dates[report.date][report.team], report.team, report.date);
+      doubles++;
+    }
+    return dates;
+  }, {});
+  console.log({ doubles });
+})();

--- a/api/src/db/migration.js
+++ b/api/src/db/migration.js
@@ -14,6 +14,7 @@ const TerritoryObservation = require("../models/territoryObservation");
 const RelPersonTeam = require("../models/relPersonTeam");
 const Report = require("../models/report");
 const { capture } = require("../sentry");
+// here you can write any data migration, not schema migrations
 
 // this function is copy/pasted from dashboard
 const getIsDayWithinHoursOffsetOfDay = (dayToTest, referenceDay, offsetHours) => {
@@ -30,59 +31,28 @@ const getIsDayWithinHoursOffsetOfDay = (dayToTest, referenceDay, offsetHours) =>
   return dayToTest > startDate.toISOString() && dayToTest <= endDate.toISOString();
 };
 
-// const currentTeam = get(currentTeamState);
-// const comments = get(commentsState);
-// const persons = get(personsState);
-// return comments
-//   .filter((c) => c.team === currentTeam._id)
-//   .filter((c) => getIsDayWithinHoursOffsetOfDay(c.createdAt, date, currentTeam?.nightSession ? 12 : 0))
-//   .filter((c) => !!c.comment.includes('Passage enregistré'))
-//   .map((passage) => {
-//     const commentPopulated = { ...passage };
-//     if (passage.person) {
-//       commentPopulated.person = persons.find((p) => p._id === passage?.person);
-//       commentPopulated.type = 'person';
-//     }
-//     return commentPopulated;
-//   });
+// this migration is to be called ONCE ONLY, otherwise there line 54 will be called many times
 
-// here you can write any data migration, not schema migrations
 (async () => {
-  const organisations = await Organisation.findAll({ where: { receptionEnabled: true } });
   const commentedPassages = await Comment.findAll({ where: { comment: "Passage enregistré" } });
   const teams = await Team.findAll();
   const reports = await Report.findAll();
-  console.log(commentedPassages.length, organisations.length, teams.length, reports.length);
-  // for (const comment of commentedPassages) {
-  // if (!comment.team) {
-  //   console.log("NO COMMENT TEAM", comment._id);
-  //   continue;
-  // }
-  // const team = teams.find((t) => t._id === comment.team);
-  // if (!team) {
-  //   console.log("NO TEAM", comment._id, comment.team);
-  //   continue;
-  // }
-  // const report = reports
-  //   .filter((r) => r.team === comment.team)
-  //   .find((r) => getIsDayWithinHoursOffsetOfDay(comment.createdAt, r.date, team?.nightSession ? 12 : 0));
-  // if (!report) {
-  //   console.log("NO REPORT", comment._id, team.nightSession);
-  // }
-  // grab the report
-  // }
-
-  // check double reports
-  let doubles = 0;
-  reports.reduce((dates, report) => {
-    if (!dates[report.date]) dates[report.date] = {};
-    if (!dates[report.date][report.team]) {
-      dates[report.date][report.team] = report._id;
-    } else {
-      console.log("DOUBLE", report._id, dates[report.date][report.team], report.team, report.date);
-      doubles++;
+  for (const comment of commentedPassages) {
+    if (!comment.team) {
+      console.log("NO COMMENT TEAM", comment._id);
+      continue;
     }
-    return dates;
-  }, {});
-  console.log({ doubles });
+    const team = teams.find((t) => t._id === comment.team);
+    if (!team) {
+      console.log("NO TEAM", comment._id, comment.team);
+      continue;
+    }
+    const report = reports
+      .filter((r) => r.team === comment.team)
+      .find((r) => getIsDayWithinHoursOffsetOfDay(comment.createdAt, r.date, team?.nightSession ? 12 : 0));
+    if (!!report && !!report.passages && report.passages > 1) {
+      report.set({ passages: report.passages - 1 });
+      await report.save();
+    }
+  }
 })();

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -7,7 +7,7 @@ import { placesState } from './places';
 import { relsPersonPlaceState } from './relPersonPlace';
 import { reportsState } from './reports';
 import { territoriesState } from './territory';
-import { isOnSameDay, today } from '../services/date';
+import { getIsDayWithinHoursOffsetOfDay, isOnSameDay, today } from '../services/date';
 import { customFieldsObsSelector, territoryObservationsState } from './territoryObservations';
 import { selector, selectorFamily } from 'recoil';
 import { filterData } from '../components/Filters';
@@ -37,6 +37,16 @@ export const lastReportSelector = selector({
     const todays = get(todaysReportSelector);
     return teamsReports.filter((rep) => rep._id !== todays?._id)[0];
   },
+});
+
+export const reportPerDateSelector = selectorFamily({
+  key: 'reportPerDateSelector',
+  get:
+    ({ date }) =>
+    ({ get }) => {
+      const teamsReports = get(currentTeamReportsSelector);
+      return teamsReports.find((rep) => isOnSameDay(new Date(rep.date), new Date(date)));
+    },
 });
 
 export const personsWithPlacesSelector = selector({
@@ -278,17 +288,45 @@ export const territoriesFullSearchSelector = selectorFamily({
     },
 });
 
-// export const passagesNonAnonymousPerDatePerTeamSelector = selectorFamily({
-//   key: 'passagesNonAnonymousPerDatePerTeamSelector',
-//   get: ({ date }) => {},
-// });
+export const passagesNonAnonymousPerDatePerTeamSelector = selectorFamily({
+  key: 'passagesNonAnonymousPerDatePerTeamSelector',
+  get:
+    ({ date }) =>
+    ({ get }) => {
+      const currentTeam = get(currentTeamState);
+      const comments = get(commentsState);
+      const persons = get(personsState);
+      return comments
+        .filter((c) => c.team === currentTeam._id)
+        .filter((c) => getIsDayWithinHoursOffsetOfDay(c.createdAt, date, currentTeam?.nightSession ? 12 : 0))
+        .filter((c) => !!c.comment.includes('Passage enregistré'))
+        .map((passage) => {
+          const commentPopulated = { ...passage };
+          if (passage.person) {
+            commentPopulated.person = persons.find((p) => p._id === passage?.person);
+            commentPopulated.type = 'person';
+          }
+          return commentPopulated;
+        });
+    },
+});
 
-// export const passagesAnonymousPerDatePerTeamSelector = selectorFamily({
-//   key: 'passagesAnonymousPerDatePerTeamSelector',
-//   get:
-//     ({ date }) =>
-//     ({ get }) => {
-//       const todaysReports = get(todaysReportSelector);
-//       return todaysReportSelector?.passages;
-//     },
-// });
+export const numberOfPassagesNonAnonymousPerDatePerTeamSelector = selectorFamily({
+  key: 'numberOfPassagesNonAnonymousPerDatePerTeamSelector',
+  get:
+    ({ date }) =>
+    ({ get }) => {
+      const nonAnonymousPassages = get(passagesNonAnonymousPerDatePerTeamSelector({ date }));
+      return nonAnonymousPassages?.length || 0;
+    },
+});
+
+export const numberOfPassagesAnonymousPerDatePerTeamSelector = selectorFamily({
+  key: 'numberOfPassagesAnonymousPerDatePerTeamSelector',
+  get:
+    ({ date }) =>
+    ({ get }) => {
+      const todaysReports = get(reportPerDateSelector({ date }));
+      return todaysReports?.passages || 0;
+    },
+});

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -277,3 +277,18 @@ export const territoriesFullSearchSelector = selectorFamily({
       return territories.filter((t) => territoriesIdsFilterBySearch.includes(t._id));
     },
 });
+
+// export const passagesNonAnonymousPerDatePerTeamSelector = selectorFamily({
+//   key: 'passagesNonAnonymousPerDatePerTeamSelector',
+//   get: ({ date }) => {},
+// });
+
+// export const passagesAnonymousPerDatePerTeamSelector = selectorFamily({
+//   key: 'passagesAnonymousPerDatePerTeamSelector',
+//   get:
+//     ({ date }) =>
+//     ({ get }) => {
+//       const todaysReports = get(todaysReportSelector);
+//       return todaysReportSelector?.passages;
+//     },
+// });


### PR DESCRIPTION
La situation actuelle:
-> chaque compte rendu a un champ passages qui compte tous les passages, anonymes et non-anonymes
-> chaque passage non-anonyme est un commentaire avec marqué "Passage enregistré"
-> si on supprime un commentaire "Passage enregistré", ça ne retire pas un passage dans le compte-rendu

Ce qui amène à
-> des incohérences si on retire des passages
-> des possibilités de bugs, de passages négatifs et autres

La future situation qui arrive
-> chaque compte rendu a un champ passages qui compte SEULEMENT les passages anonymes
-> chaque passage non-anonyme est un commentaire avec marqué "Passage enregistré"
-> de sorte que dans les deux types de passages sont indépendants : quand on retire un passage, on retire un passage ANONYME seulement (cf photo), et quand on retire un commentaire "Passage enregistré", on ne touche pas aux passages anonymes

Problème: les passages déjà comptés précédemment.

Est-ce qu'il faut qu'on fasse une "migration", c'est à dire qu'on fasse une passe sur tous les passages précédents, et retirer les passages non-anonymes du comptage du nombre de passages ?

Question posée à Guillaume (https://trello.com/c/QMmd42bX/518-web-bug-des-passages)

Dispo pour en parler si c'est pas clair