### PR TITLE
fix(dashboard): organisationEncryptionKey can also be setup by non-admin

### DIFF
--- a/dashboard/src/scenes/auth/signin.js
+++ b/dashboard/src/scenes/auth/signin.js
@@ -16,6 +16,7 @@ import { useRefresh } from '../../recoil/refresh';
 import { encryptVerificationKey } from '../../services/encryption';
 import { useRecoilState, useSetRecoilState } from 'recoil';
 import { hashedOrgEncryptionKey } from '../../services/api';
+import { capture } from '../../services/sentry';
 
 /*
 TODO:
@@ -48,7 +49,8 @@ const SignIn = () => {
   // temporary migration : until all organisations have an `encryptedVerificationKey`
   const setEncryptionVerificationKey = async (organisation, user) => {
     if (!organisation.encryptionEnabled) return;
-    if (!organisation.encryptedVerificationKey && ['admin'].includes(user.role)) {
+    if (!organisation.encryptedVerificationKey) {
+      capture('setting encryptedVerificationKey :', organisation.name);
       const encryptedVerificationKey = await encryptVerificationKey(hashedOrgEncryptionKey);
       const orgRes = await API.put({ path: `/organisation/${organisation._id}`, body: { encryptedVerificationKey } });
       if (orgRes.ok) setOrganisation(orgRes.data);


### PR DESCRIPTION
Objectif: finir cette "migration" consistant à créer le champ `encryptionVerificationKey`.
Objectif supérieur: en finir avec "déchiffrer quelques éléments pour voir si la clé est bonne", afin que l'erreur `ERROR DECRYPTING ITEM : Error: FAILURE` ait de nouveau du sens.

Problème: dans 3 orgas il semble que l'admin ne se connecte jamais, et donc n'active jamais `encryptionVerificationKey`.

Donc on va dire que pour ces 3 dernières, même un admin peut, si la clé qu'il a rentrée est bonne, créer ce champ.