### PR TITLE
feat(dashboard): stats orga and team

### DIFF
--- a/dashboard/src/app.js
+++ b/dashboard/src/app.js
@@ -90,7 +90,7 @@ const RestrictedRoute = ({ component: Component, isLoggedIn, ...rest }) => {
   return (
     <>
       {user && <Drawer />}
-      <div className="main-content" style={{ marginLeft: user ? 230 : 0, marginTop: user ? 35 : 0 }}>
+      <div className="main-content" style={{ marginLeft: user ? 230 : 0, marginTop: user ? 65 : 0 }}>
         <Route {...rest} render={(props) => (user ? <Component {...props} /> : <Redirect to={{ pathname: '/auth' }} />)} />
       </div>
     </>

--- a/dashboard/src/components/SelectTeam.js
+++ b/dashboard/src/components/SelectTeam.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import SelectCustom from './SelectCustom';
 
-const SelectTeam = ({ onChange = () => null, teamId = null, teams = null }) => {
+const SelectTeam = ({ onChange = () => null, teamId = null, teams = null, style = null }) => {
   if (!teams) return <div />;
 
   return (
@@ -12,6 +12,7 @@ const SelectTeam = ({ onChange = () => null, teamId = null, teams = null }) => {
         flexDirection: 'column',
         width: '100%',
         borderRadius: '5px',
+        ...style,
       }}>
       <SelectCustom
         options={teams.map(({ _id }) => _id)}

--- a/dashboard/src/components/charts.js
+++ b/dashboard/src/components/charts.js
@@ -50,7 +50,7 @@ export const CustomResponsivePie = ({ data, title, onAddFilter, field }) => {
             innerRadius={0.5}
             padAngle={0.7}
             cornerRadius={3}
-            colors={{ scheme: 'nivo' }}
+            colors={{ scheme: 'set2' }}
             borderWidth={1}
             borderColor={{ from: 'color', modifiers: [['darker', 0.2]] }}
             arcLinkLabelsSkipAngle={8}
@@ -102,7 +102,7 @@ export const CustomResponsiveBar = ({ title, data, categories, axisTitleX, axisT
             padding={0.3}
             valueScale={{ type: 'linear' }}
             indexScale={{ type: 'band', round: true }}
-            colors={{ scheme: 'nivo' }}
+            colors={{ scheme: 'set2' }}
             borderColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
             axisTop={null}
             axisRight={null}
@@ -169,10 +169,10 @@ const Data = styled.table`
   flex-basis: 25%;
   flex-shrink: 0;
   flex-grow: 0;
-  border: 1px solid #000;
+  border: 1px solid #aaa;
   /* font-size: 0.7em; */
   td {
-    border: 1px solid #000;
+    border: 1px solid #aaa;
     padding: 5px;
   }
 

--- a/dashboard/src/components/drawer.js
+++ b/dashboard/src/components/drawer.js
@@ -29,12 +29,6 @@ const Drawer = () => {
     <>
       <Sidebar className="noprint" onboardingForTeams={onboardingForTeams}>
         <Nav>
-          <div style={{ marginBottom: 30, display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
-            <Logo size={100} hide />
-            {!['superadmin'].includes(user.role) && (
-              <SelectTeam onChange={setCurrentTeam} teamId={currentTeam?._id} teams={user.role === 'admin' ? teams : user.teams} />
-            )}
-          </div>
           {!['superadmin'].includes(user.role) && (
             <>
               {!!organisation.receptionEnabled && (
@@ -57,13 +51,6 @@ const Drawer = () => {
             </>
           )}
           <hr />
-          {/* ["superadmin"].includes(user.role) && (
-          <li>
-            <NavLink to="/organisation" activeClassName="active">
-              Organisations
-            </NavLink>
-          </li>
-        ) */}
           {['admin'].includes(user.role) && (
             <li>
               <NavLink to={`/organisation/${organisation._id}`} activeClassName="active">
@@ -127,9 +114,21 @@ const Drawer = () => {
         </Nav>
       </Sidebar>
       <TopBar className="topBar">
-        <Organisation>{['superadmin'].includes(user.role) ? 'Support' : organisation?.name}</Organisation>
-        <Logo size={60} noMargin />
-        <div>
+        <TopBarOrganistionTeamBox>
+          <Organisation>{['superadmin'].includes(user.role) ? 'Support' : organisation?.name}</Organisation>
+          {!['superadmin'].includes(user.role) && (
+            <SelectTeam
+              style={{ maxWidth: '250px', fontSize: '13px' }}
+              onChange={setCurrentTeam}
+              teamId={currentTeam?._id}
+              teams={user.role === 'admin' ? teams : user.teams}
+            />
+          )}
+        </TopBarOrganistionTeamBox>
+        <TopBarLogo>
+          <Logo size={60} />
+        </TopBarLogo>
+        <TopBarAccount>
           <ButtonDropdown direction="left" isOpen={dropdownOpen} toggle={() => setDropdownOpen(!dropdownOpen)}>
             <DropdownToggleStyled>
               {user?.name}
@@ -175,21 +174,38 @@ const Drawer = () => {
               </DropdownItem>
             </DropdownMenu>
           </ButtonDropdown>
-        </div>
+        </TopBarAccount>
       </TopBar>
     </>
   );
 };
+
+const TopBarLogo = styled.div`
+  @media (max-width: 1024px) {
+    display: none;
+  }
+`;
+
+const TopBarAccount = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`;
+
+const TopBarOrganistionTeamBox = styled.div`
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+`;
 
 const Sidebar = styled.div`
   background-color: ${theme.white};
   height: 100%;
   max-width: 230px;
   width: 100%;
-  z-index: 10;
+  z-index: 9;
   position: fixed;
   left: 0;
-  top: 0;
+  top: 60px;
   padding: 18px;
   display: flex;
   flex-direction: column;
@@ -209,16 +225,17 @@ const Sidebar = styled.div`
 
 const TopBar = styled.div`
   background-color: ${theme.white};
-  z-index: 9;
+  z-index: 10;
   position: fixed;
-  left: 230px;
-  right: 0;
-  top: 0;
-  padding: 5px 18px;
+  width: 100%;
+  padding: 12px 18px;
   display: flex;
   justify-content: space-between;
   align-items: center;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
+  > div {
+    flex: 1;
+  }
   @media print {
     left: 0;
     position: relative;
@@ -228,20 +245,20 @@ const TopBar = styled.div`
 const Logo = styled.div`
   width: ${(props) => props.size}px;
   height: ${(props) => (props.size * 2) / 3}px;
-  ${(props) => props.hide && 'display: none;'}
-  margin-bottom: 20px;
-  ${(props) => props.noMargin && 'margin: 0;'}
+  margin: 0 auto;
   background-image: url(${logo});
   background-position: center;
   background-repeat: no-repeat;
   background-size: cover;
 `;
 
-const Organisation = styled.span`
+const Organisation = styled.div`
   font-weight: 600;
+  width: max-content;
   font-size: 14px;
   line-height: 22px;
-  text-align: center;
+  margin-right: 1rem;
+  text-align: left;
   letter-spacing: -0.01em;
 `;
 

--- a/dashboard/src/scenes/action/list.js
+++ b/dashboard/src/scenes/action/list.js
@@ -16,12 +16,11 @@ import DateBloc from '../../components/DateBloc';
 import { toFrenchDate } from '../../utils';
 import PaginationContext from '../../contexts/pagination';
 import Search from '../../components/search';
-import SelectTeam from '../../components/SelectTeam';
 import { actionsFullSearchSelector } from '../../recoil/selectors';
 import ActionsCalendar from '../../components/ActionsCalendar';
 import SelectCustom from '../../components/SelectCustom';
 import ActionName from '../../components/ActionName';
-import { currentTeamState, teamsState, userState } from '../../recoil/auth';
+import { currentTeamState } from '../../recoil/auth';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import ActionPersonName from '../../components/ActionPersonName';
 

--- a/dashboard/src/scenes/action/list.js
+++ b/dashboard/src/scenes/action/list.js
@@ -28,9 +28,7 @@ import ActionPersonName from '../../components/ActionPersonName';
 const showAsOptions = ['Calendrier', 'Liste'];
 
 const List = () => {
-  const teams = useRecoilValue(teamsState);
-  const user = useRecoilValue(userState);
-  const [currentTeam, setCurrentTeam] = useRecoilState(currentTeamState);
+  const [currentTeam] = useRecoilState(currentTeamState);
 
   const { search, setSearch, status, setStatus, page, setPage } = useContext(PaginationContext);
   const history = useHistory();
@@ -53,8 +51,15 @@ const List = () => {
   const total = actionsFiltered.length;
 
   return (
-    <Container style={{ padding: '40px 0' }}>
-      <Header title={`Actions de l'équipe ${currentTeam?.name || ''}`} />
+    <Container>
+      <Header
+        titleStyle={{ fontWeight: '400' }}
+        title={
+          <span>
+            Actions de l'équipe <b>{currentTeam?.name || ''}</b>
+          </span>
+        }
+      />
       <Row style={{ marginBottom: 40, justifyContent: 'center' }}>
         <Col>
           <CreateAction disabled={!currentTeam} isMulti refreshable />
@@ -64,12 +69,6 @@ const List = () => {
         <Col md={12} style={{ display: 'flex', alignItems: 'center', marginBottom: 20 }}>
           <span style={{ marginRight: 20, width: 250, flexShrink: 0 }}>Recherche : </span>
           <Search placeholder="Par mot clé, présent dans le nom, la catégorie, un commentaire, ..." value={search} onChange={setSearch} />
-        </Col>
-        <Col md={12} style={{ display: 'flex', alignItems: 'center', marginBottom: 20 }}>
-          <span style={{ marginRight: 20, width: 250, flexShrink: 0 }}>Filtrer par équipe en charge :</span>
-          <div style={{ width: 300 }}>
-            <SelectTeam onChange={setCurrentTeam} teamId={currentTeam?._id} teams={user.role === 'admin' ? teams : user.teams} />
-          </div>
         </Col>
         <Col md={12} style={{ display: 'flex', alignItems: 'center', marginBottom: 20 }}>
           <span style={{ marginRight: 20, width: 250, flexShrink: 0 }}>Filtrer par status : </span>

--- a/dashboard/src/scenes/place/list.js
+++ b/dashboard/src/scenes/place/list.js
@@ -44,8 +44,15 @@ const List = () => {
   const { data, total } = filterPlaces(places, { page, limit, search });
 
   return (
-    <Container style={{ padding: '40px 0' }}>
-      <Header title={`Lieux fréquentés de l'organisation ${organisation.name}`} />
+    <Container>
+      <Header
+        titleStyle={{ fontWeight: 400 }}
+        title={
+          <>
+            Lieux fréquentés de l'organisation <b>{organisation.name}</b>
+          </>
+        }
+      />
       <Row style={{ marginBottom: 40 }}>
         <Col>
           <Create />

--- a/dashboard/src/scenes/reception/view.js
+++ b/dashboard/src/scenes/reception/view.js
@@ -115,9 +115,14 @@ const Reception = () => {
   return (
     <Container style={{ padding: 0 }}>
       <Header
-        title={`Accueil du ${new Date().toLocaleDateString('fr', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' })} de l'équipe ${
-          currentTeam?.nightSession ? 'de nuit ' : ''
-        }${currentTeam?.name || ''}`}
+        titleStyle={{ fontWeight: '400' }}
+        title={
+          <span>
+            Accueil du <b>{new Date().toLocaleDateString('fr', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' })}</b> de l'équipe{' '}
+            {currentTeam?.nightSession ? 'de nuit ' : ''}
+            <b>{currentTeam?.name || ''}</b>
+          </span>
+        }
       />
       <Row style={{ paddingBottom: 20, marginBottom: 20, borderBottom: '1px solid #ddd' }}>
         <Col

--- a/dashboard/src/scenes/search/index.js
+++ b/dashboard/src/scenes/search/index.js
@@ -98,8 +98,8 @@ const View = () => {
   };
 
   return (
-    <Container style={{ padding: '40px 0' }}>
-      <Header title="Rechercher" onRefresh={() => refresh()} />
+    <Container>
+      <Header titleStyle={{ fontWeight: '400' }} title="Rechercher" onRefresh={() => refresh()} />
       <Row style={{ marginBottom: 40, borderBottom: '1px solid #ddd' }}>
         <Col md={12} style={{ display: 'flex', alignItems: 'center', marginBottom: 20 }}>
           <Search placeholder="Par mot clé" value={search} onChange={setSearch} />

--- a/dashboard/src/scenes/structure/list.js
+++ b/dashboard/src/scenes/structure/list.js
@@ -40,8 +40,8 @@ const List = () => {
 
   return (
     <div>
-      <Container style={{ padding: '40px 0' }}>
-        <Header title="Structures" />
+      <Container>
+        <Header titleStyle={{ fontWeight: 400 }} title="Structures" />
         <Row style={{ marginBottom: 20 }}>
           <Col>
             <Create onChange={() => setRefresh(true)} />

--- a/dashboard/src/scenes/team/list.js
+++ b/dashboard/src/scenes/team/list.js
@@ -21,8 +21,8 @@ const List = () => {
   const history = useHistory();
 
   return (
-    <Container style={{ padding: '40px 0' }}>
-      <Header title="Équipes" />
+    <Container>
+      <Header titleStyle={{ fontWeight: 400 }} title="Équipes" />
       <Create />
       <Table
         data={teams}

--- a/dashboard/src/scenes/territory/list.js
+++ b/dashboard/src/scenes/territory/list.js
@@ -37,8 +37,15 @@ const List = () => {
   const total = territories.length;
 
   return (
-    <Container style={{ padding: '40px 0' }}>
-      <Header title={`Territoires de l'organisation ${organisation.name}`} />
+    <Container>
+      <Header
+        titleStyle={{ fontWeight: 400 }}
+        title={
+          <>
+            Territoires de l'organisation <b>{organisation.name}</b>
+          </>
+        }
+      />
       <Row style={{ marginBottom: 40 }}>
         <Col>
           <CreateTerritory organisation={organisation} />

--- a/dashboard/src/scenes/user/list.js
+++ b/dashboard/src/scenes/user/list.js
@@ -35,8 +35,8 @@ const List = () => {
 
   if (!users) return <Loading />;
   return (
-    <Container style={{ padding: '40px 0' }}>
-      <Header title="Utilisateurs" />
+    <Container>
+      <Header titleStyle={{ fontWeight: 400 }} title="Utilisateurs" />
       {['superadmin', 'admin'].includes(user.role) && <Create onChange={() => setRefresh(true)} />}
       <Table
         data={users}


### PR DESCRIPTION
PR un peu mélangée (désolé 🐱), mais le principal but est de permettre de faire des stats par team / globales.
 - [x] Nouvelle barre en haut, pour clarifier la hiérarchie "orga" -> "équipe" et le rapport entre les menus
 - [x] Les titres mettent plus en avant les infos sur l'équipe ou l'orga
 - [x] Ajout d'une nouvelle case à cocher "stats de toute l'orga"
 - [x] **Dans les stats, chaque onglet est soit pour toute l'orga, soit pour seulement l'équipe sélectionnée**
 - [x] Suppression du sélecteur d'équipe dans les actions
 - [x] Suppression du sélecteur d'équipe dans les personnes et ajout de la case "afficher tout" sélectionnée par défaut (pour ne pas changer le fonctionnement actuel)
 - [x] Nouveau set de couleurs pour les charts, juste parce que (non mais vraiment le marronnasse par défaut du set par défaut est pourri : https://nivo.rocks/guides/colors, le set2 est presque pareil mais mieux organisé).

<img width="1424" alt="Capture d’écran 2021-12-13 à 16 33 54" src="https://user-images.githubusercontent.com/1575946/145841233-e6d21363-a76e-4778-bd4a-c6269ebdf669.png">
