### PR TITLE
fix: fix passages count in stat

### DIFF
--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -7,7 +7,7 @@ import { placesState } from './places';
 import { relsPersonPlaceState } from './relPersonPlace';
 import { reportsState } from './reports';
 import { territoriesState } from './territory';
-import { getIsDayWithinHoursOffsetOfDay, getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, today } from '../services/date';
+import { getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, today } from '../services/date';
 import { customFieldsObsSelector, territoryObservationsState } from './territoryObservations';
 import { selector, selectorFamily } from 'recoil';
 import { filterData } from '../components/Filters';

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -7,7 +7,7 @@ import { placesState } from './places';
 import { relsPersonPlaceState } from './relPersonPlace';
 import { reportsState } from './reports';
 import { territoriesState } from './territory';
-import { getIsDayWithinHoursOffsetOfDay, isOnSameDay, today } from '../services/date';
+import { getIsDayWithinHoursOffsetOfDay, getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, today } from '../services/date';
 import { customFieldsObsSelector, territoryObservationsState } from './territoryObservations';
 import { selector, selectorFamily } from 'recoil';
 import { filterData } from '../components/Filters';
@@ -291,14 +291,23 @@ export const territoriesFullSearchSelector = selectorFamily({
 export const passagesNonAnonymousPerDatePerTeamSelector = selectorFamily({
   key: 'passagesNonAnonymousPerDatePerTeamSelector',
   get:
-    ({ date }) =>
+    ({ date: { startDate, endDate }, filterCurrentTeam = true }) =>
     ({ get }) => {
       const currentTeam = get(currentTeamState);
       const comments = get(commentsState);
       const persons = get(personsState);
       return comments
-        .filter((c) => c.team === currentTeam._id)
-        .filter((c) => getIsDayWithinHoursOffsetOfDay(c.createdAt, date, currentTeam?.nightSession ? 12 : 0))
+        .filter((c) => (filterCurrentTeam ? c.team === currentTeam._id : true))
+        .filter((c) =>
+          getIsDayWithinHoursOffsetOfPeriod(
+            c.createdAt,
+            {
+              referenceStartDay: startDate,
+              referenceEndDay: endDate,
+            },
+            currentTeam?.nightSession ? 12 : 0
+          )
+        )
         .filter((c) => !!c.comment.includes('Passage enregistré'))
         .map((passage) => {
           const commentPopulated = { ...passage };

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -325,7 +325,11 @@ export const numberOfPassagesNonAnonymousPerDatePerTeamSelector = selectorFamily
   get:
     ({ date }) =>
     ({ get }) => {
-      const nonAnonymousPassages = get(passagesNonAnonymousPerDatePerTeamSelector({ date }));
+      const nonAnonymousPassages = get(
+        passagesNonAnonymousPerDatePerTeamSelector({
+          date: { startDate: date, endDate: date },
+        })
+      );
       return nonAnonymousPassages?.length || 0;
     },
 });

--- a/dashboard/src/scenes/report/view.js
+++ b/dashboard/src/scenes/report/view.js
@@ -481,7 +481,7 @@ const CommentCreatedAt = ({ date, onUpdateResults = () => null }) => {
 const PassagesCreatedAt = ({ date, onUpdateResults = () => null }) => {
   const history = useHistory();
 
-  const nonAnonymousPassages = useRecoilValue(passagesNonAnonymousPerDatePerTeamSelector({ date }));
+  const nonAnonymousPassages = useRecoilValue(passagesNonAnonymousPerDatePerTeamSelector({ date: { startDate: date, endDate: date } }));
   const numberOfNonAnonymousPassages = useRecoilValue(numberOfPassagesNonAnonymousPerDatePerTeamSelector({ date }));
   const numberOfAnonymousPassages = useRecoilValue(numberOfPassagesAnonymousPerDatePerTeamSelector({ date }));
 

--- a/dashboard/src/scenes/stats/index.js
+++ b/dashboard/src/scenes/stats/index.js
@@ -30,6 +30,7 @@ import { useRefresh } from '../../recoil/refresh';
 import ExportData from '../data-import-export/ExportData';
 import SelectCustom from '../../components/SelectCustom';
 import { useTerritories } from '../../recoil/territory';
+import { passagesNonAnonymousPerDatePerTeamSelector } from '../../recoil/selectors';
 moment.locale('fr');
 
 const getDataForPeriod = (data, { startDate, endDate }, filters = []) => {
@@ -63,12 +64,20 @@ const Stats = () => {
   const [activeTab, setActiveTab] = useState(0);
   const [filterPersons, setFilterPersons] = useState([]);
   const [viewAllOrganisationData, setViewAllOrganisationData] = useState(false);
+  const [period, setPeriod] = useState({ startDate: null, endDate: null });
+  const nonAnonymousPassages = useRecoilValue(
+    passagesNonAnonymousPerDatePerTeamSelector({
+      filterCurrentTeam: !viewAllOrganisationData,
+      date: {
+        startDate: period.startDate,
+        endDate: period.endDate,
+      },
+    })
+  );
 
   const addFilter = ({ field, value }) => {
     setFilterPersons((filters) => [...filters, { field, value }]);
   };
-
-  const [period, setPeriod] = useState({ startDate: null, endDate: null });
 
   useEffect(() => {
     if (loading) refresh();
@@ -171,7 +180,10 @@ const Stats = () => {
           <TabPane tabId={1}>
             <Title>Statistiques de l'accueil</Title>
             <Row>
-              <Block data={reports.reduce((passages, rep) => passages + (rep.passages || 0), 0)} title="Nombre de passages" />
+              <Block
+                data={reports.reduce((passages, rep) => passages + (rep.passages || 0), 0) + (nonAnonymousPassages?.length || 0)}
+                title="Nombre de passages"
+              />
               {organisation.services?.map((service) => (
                 <Block
                   key={service}

--- a/dashboard/src/services/date.js
+++ b/dashboard/src/services/date.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-extend-native */
+
+// todo: remove prototype pollution.
 Date.prototype.getBirthDate = function (locale) {
   return new Date(this).toLocaleDateString(locale, {
     month: 'numeric',
@@ -73,13 +75,21 @@ export const getMonths = () => {
 };
 
 export const getIsDayWithinHoursOffsetOfDay = (dayToTest, referenceDay, offsetHours = -12, debug = false) => {
+  return getIsDayWithinHoursOffsetOfPeriod(dayToTest, { referenceStartDay: referenceDay, referenceEndDay: referenceDay }, offsetHours, debug);
+};
+
+export const getIsDayWithinHoursOffsetOfPeriod = (dayToTest, { referenceStartDay, referenceEndDay }, offsetHours = -12, debug = false) => {
   if (!dayToTest) return false;
-  referenceDay = new Date(referenceDay);
-  referenceDay.setHours(0, 0, 0, 0);
-  const startDate = new Date(referenceDay);
-  startDate.setHours(referenceDay.getHours() + offsetHours);
-  const endDate = new Date(startDate);
-  endDate.setHours(startDate.getHours() + 24);
+
+  referenceStartDay = new Date(referenceStartDay);
+  referenceStartDay.setHours(0, 0, 0, 0);
+  const startDate = new Date(referenceStartDay);
+  startDate.setHours(referenceStartDay.getHours() + offsetHours);
+
+  referenceEndDay = new Date(referenceEndDay);
+  referenceEndDay.setHours(0, 0, 0, 0);
+  const endDate = new Date(referenceEndDay);
+  endDate.setHours(referenceEndDay.getHours() + offsetHours + 24);
 
   dayToTest = new Date(dayToTest).toISOString();
 

--- a/dashboard/src/services/date.js
+++ b/dashboard/src/services/date.js
@@ -78,7 +78,7 @@ export const getIsDayWithinHoursOffsetOfDay = (dayToTest, referenceDay, offsetHo
   return getIsDayWithinHoursOffsetOfPeriod(dayToTest, { referenceStartDay: referenceDay, referenceEndDay: referenceDay }, offsetHours, debug);
 };
 
-export const getIsDayWithinHoursOffsetOfPeriod = (dayToTest, { referenceStartDay, referenceEndDay }, offsetHours = -12, debug = false) => {
+export const getIsDayWithinHoursOffsetOfPeriod = (dayToTest, { referenceStartDay, referenceEndDay }, offsetHours = -12, debug = true) => {
   if (!dayToTest) return false;
 
   referenceStartDay = new Date(referenceStartDay);


### PR DESCRIPTION
See: https://trello.com/c/4Lo5I14F/553-module-stat-bug-de-laffichage-des-passages

Exemple de "je me demande si on a besoin des selecteurs" : là j'ai du faire évoluer un sélecteur pour mon besoin et il est utilisé seulement à deux endroits maintenant et différemment. Je me demande si on n'aurait pas été mieux avec une fonction : `getPassages({startDate, endDate, team})` qui est une fonction utilitaire et qu'on peut mettre en memo. Bon tout ça pour dire que je suis pas très fier de mon code 😬 