### PR TITLE
fix(dashboard): dates with dayjs

### DIFF
--- a/dashboard/src/components/ActionsCalendar.js
+++ b/dashboard/src/components/ActionsCalendar.js
@@ -4,6 +4,7 @@ import { Nav, NavItem, NavLink, TabContent, TabPane } from 'reactstrap';
 import { useHistory, useLocation } from 'react-router-dom';
 import {
   addOneDay,
+  dayjsInstance,
   formatCalendarDate,
   formatDateTimeWithNameOfDay,
   formatDateWithFullMonth,
@@ -40,7 +41,7 @@ const ActionsCalendar = ({ actions, columns = ['Heure', 'Nom', 'Personne suivie'
 
   useEffect(() => {
     const searchParams = new URLSearchParams(location.search);
-    searchParams.set('calendarDate', currentDate.toISOString().split('T')[0]);
+    searchParams.set('calendarDate', dayjsInstance(currentDate).format('YYYY-MM-DD'));
     history.replace({ pathname: location.pathname, search: searchParams.toString() });
   }, [currentDate]);
 

--- a/dashboard/src/components/Comments.js
+++ b/dashboard/src/components/Comments.js
@@ -18,6 +18,7 @@ import { userState } from '../recoil/auth';
 import { useComments } from '../recoil/comments';
 import { useRecoilValue } from 'recoil';
 import { commentsFilteredSelector } from '../recoil/selectors';
+import { dateForDatePicker } from '../services/date';
 
 const Comments = ({ personId = '', actionId = '', forPassages = false, onUpdateResults }) => {
   const [editingId, setEditing] = useState(null);
@@ -167,7 +168,7 @@ const EditingComment = ({ value = {}, commentId, onSubmit, onCancel, newComment,
                             <DatePicker
                               locale="fr"
                               className="form-control"
-                              selected={values.createdAt ? new Date(values.createdAt) : new Date()}
+                              selected={dateForDatePicker(values.createdAt ?? new Date())}
                               onChange={(date) => handleChange({ target: { value: date, name: 'createdAt' } })}
                               timeInputLabel="Heure :"
                               dateFormat="dd/MM/yyyy HH:mm"

--- a/dashboard/src/components/CreateObservation.js
+++ b/dashboard/src/components/CreateObservation.js
@@ -14,6 +14,7 @@ import CustomFieldInput from './CustomFieldInput';
 import { userState } from '../recoil/auth';
 import { territoriesState } from '../recoil/territory';
 import { useRecoilValue } from 'recoil';
+import { dateForDatePicker } from '../services/date';
 export const policeSelect = ['Oui', 'Non'];
 export const atmosphereSelect = ['Violences', 'Tensions', 'RAS'];
 
@@ -71,7 +72,7 @@ const CreateObservation = ({ observation = {}, forceOpen = 0 }) => {
                         <DatePicker
                           locale="fr"
                           className="form-control"
-                          selected={values.createdAt ? new Date(values.createdAt) : new Date()}
+                          selected={dateForDatePicker(values.createdAt ?? new Date())}
                           onChange={(date) => handleChange({ target: { value: date, name: 'createdAt' } })}
                           timeInputLabel="Heure :"
                           dateFormat="dd/MM/yyyy hh:mm"

--- a/dashboard/src/components/CustomFieldDisplay.js
+++ b/dashboard/src/components/CustomFieldDisplay.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import 'react-datepicker/dist/react-datepicker.css';
+import { formatDateTimeWithNameOfDay, formatDateWithNameOfDay } from '../services/date';
 
 const showBoolean = (value) => {
   if (value === null) return '';
@@ -22,19 +23,8 @@ const CustomFieldDisplay = ({ field, value }) => {
           ))}
         </p>
       )}
-      {!!['date-with-time'].includes(field.type) &&
-        !!value &&
-        new Date(value).toLocaleDateString('fr', {
-          day: 'numeric',
-          weekday: 'long',
-          month: 'long',
-          year: 'numeric',
-          hour: '2-digit',
-          minute: '2-digit',
-        })}
-      {!!['date'].includes(field.type) &&
-        !!value &&
-        new Date(value).toLocaleDateString('fr', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' })}
+      {!!['date-with-time'].includes(field.type) && !!value && formatDateTimeWithNameOfDay(value)}
+      {!!['date'].includes(field.type) && !!value && formatDateWithNameOfDay(value)}
       {!!['boolean'].includes(field.type) && showBoolean(value)}
       {!!['yes-no'].includes(field.type) && value}
       {!!['enum'].includes(field.type) && value}

--- a/dashboard/src/components/CustomFieldInput.js
+++ b/dashboard/src/components/CustomFieldInput.js
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import SelectAsInput from './SelectAsInput';
 import SelectCustom from './SelectCustom';
 import DatePicker from 'react-datepicker';
+import { dateForDatePicker } from '../services/date';
 
 const CustomFieldInput = ({ field, values, handleChange }) => (
   <Col md={6} key={field.name}>
@@ -21,7 +22,7 @@ const CustomFieldInput = ({ field, values, handleChange }) => (
           <DatePicker
             locale="fr"
             className="form-control"
-            selected={values[field.name] ? new Date(values[field.name]) : field.required ? new Date() : null}
+            selected={dateForDatePicker(values[field.name] ? values[field.name] : field.required ? new Date() : null)}
             onChange={(date) => handleChange({ target: { value: date, name: field.name } })}
             timeInputLabel="Heure :"
             dateFormat={`dd/MM/yyyy${field.type === 'date-with-time' ? ' HH:mm' : ''}`}

--- a/dashboard/src/components/DateRangePickerWithPresets.js
+++ b/dashboard/src/components/DateRangePickerWithPresets.js
@@ -3,12 +3,10 @@ import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
 import OutsideClickHandler from 'react-outside-click-handler';
 import { DateRangePicker } from 'react-dates';
-import moment from 'moment';
-
-moment.locale('fr');
+import { dayjsInstance } from '../services/date';
 
 const getOffsetFromToday = (value, unit, end) => {
-  const a = moment();
+  const a = dayjsInstance();
   const b = a.subtract(value, unit);
   return end ? b.endOf('day') : b.startOf('day');
 };
@@ -21,7 +19,7 @@ const DateRangePickerWithPresets = ({ period, setPeriod }) => {
     },
     {
       label: "Aujourd'hui",
-      period: { startDate: moment().startOf('day'), endDate: moment().endOf('day') },
+      period: { startDate: dayjsInstance().startOf('day'), endDate: dayjsInstance().endOf('day') },
     },
     {
       label: 'Hier',
@@ -29,49 +27,53 @@ const DateRangePickerWithPresets = ({ period, setPeriod }) => {
     },
     {
       label: 'Cette semaine',
-      period: { startDate: moment().startOf('week'), endDate: moment().endOf('week') },
+      period: { startDate: dayjsInstance().startOf('week'), endDate: dayjsInstance().endOf('week') },
     },
     {
       label: 'Le semaine dernière',
-      period: { startDate: moment().startOf('week').subtract(1, 'week'), endDate: moment().endOf('week').subtract(1, 'week') },
+      period: { startDate: dayjsInstance().startOf('week').subtract(1, 'week'), endDate: dayjsInstance().endOf('week').subtract(1, 'week') },
     },
     {
       label: 'Ce mois-ci',
-      period: { startDate: moment().startOf('month'), endDate: moment().endOf('month') },
+      period: { startDate: dayjsInstance().startOf('month'), endDate: dayjsInstance().endOf('month') },
     },
     {
       label: 'Le mois dernier',
-      period: { startDate: moment().subtract(1, 'month').startOf('month'), endDate: moment().subtract(1, 'month').endOf('month') },
+      period: { startDate: dayjsInstance().subtract(1, 'month').startOf('month'), endDate: dayjsInstance().subtract(1, 'month').endOf('month') },
     },
     {
       label: 'Les trois derniers mois',
-      period: { startDate: moment().subtract(3, 'month').startOf('month'), endDate: moment().subtract(1, 'month').endOf('month') },
+      period: { startDate: dayjsInstance().subtract(3, 'month').startOf('month'), endDate: dayjsInstance().subtract(1, 'month').endOf('month') },
     },
     {
       label: 'Les six derniers mois',
-      period: { startDate: moment().subtract(6, 'month').startOf('month'), endDate: moment().subtract(1, 'month').endOf('month') },
+      period: { startDate: dayjsInstance().subtract(6, 'month').startOf('month'), endDate: dayjsInstance().subtract(1, 'month').endOf('month') },
     },
     {
       label: 'Ce semestre',
       period: {
-        startDate: moment().get('month') < 6 ? moment().startOf('year') : moment().startOf('year').add(6, 'month'),
-        endDate: moment().get('month') < 6 ? moment().startOf('year').add(5, 'month').endOf('month') : moment().endOf('year'),
+        startDate: dayjsInstance().get('month') < 6 ? dayjsInstance().startOf('year') : dayjsInstance().startOf('year').add(6, 'month'),
+        endDate: dayjsInstance().get('month') < 6 ? dayjsInstance().startOf('year').add(5, 'month').endOf('month') : dayjsInstance().endOf('year'),
       },
     },
     {
       label: 'Le dernier semestre',
       period: {
-        startDate: moment().get('month') < 6 ? moment().subtract(1, 'year').startOf('year').add(6, 'month') : moment().startOf('year'),
-        endDate: moment().get('month') < 6 ? moment().subtract(1, 'year').endOf('year') : moment().startOf('year').add(5, 'month').endOf('month'),
+        startDate:
+          dayjsInstance().get('month') < 6 ? dayjsInstance().subtract(1, 'year').startOf('year').add(6, 'month') : dayjsInstance().startOf('year'),
+        endDate:
+          dayjsInstance().get('month') < 6
+            ? dayjsInstance().subtract(1, 'year').endOf('year')
+            : dayjsInstance().startOf('year').add(5, 'month').endOf('month'),
       },
     },
     {
       label: 'Cette année',
-      period: { startDate: moment().startOf('year'), endDate: moment().endOf('year') },
+      period: { startDate: dayjsInstance().startOf('year'), endDate: dayjsInstance().endOf('year') },
     },
     {
       label: "L'année dernière",
-      period: { startDate: moment().subtract(1, 'year').startOf('year'), endDate: moment().subtract(1, 'year').endOf('year') },
+      period: { startDate: dayjsInstance().subtract(1, 'year').startOf('year'), endDate: dayjsInstance().subtract(1, 'year').endOf('year') },
     },
   ];
 
@@ -109,7 +111,8 @@ const DateRangePickerWithPresets = ({ period, setPeriod }) => {
 
   const renderLabel = () => {
     if (!!preset) return preset;
-    if (!!period.startDate && !!period.endDate) return `${moment(period.startDate).format('DD/MM/YYYY')} -> ${period.endDate.format('DD/MM/YYYY')}`;
+    if (!!period.startDate && !!period.endDate)
+      return `${dayjsInstance(period.startDate).format('DD/MM/YYYY')} -> ${period.endDate.format('DD/MM/YYYY')}`;
     return `Entre... et le...`;
   };
 

--- a/dashboard/src/components/Documents.js
+++ b/dashboard/src/components/Documents.js
@@ -7,10 +7,11 @@ import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import Table from './table';
 import UserName from './UserName';
-import { toFrenchDate, download } from '../utils';
+import { download } from '../utils';
 import { usePersons } from '../recoil/persons';
 import { userState } from '../recoil/auth';
 import ButtonCustom from './ButtonCustom';
+import { formatDateWithFullMonth } from '../services/date';
 
 const Documents = ({ person, onUpdateResults }) => {
   const { updatePerson, uploadDocument, downloadDocument, deleteDocument } = usePersons();
@@ -65,7 +66,7 @@ const Documents = ({ person, onUpdateResults }) => {
         onRowClick={() => {}}
         columns={[
           { title: 'Nom', dataKey: 'name', render: (document) => <b>{document.name}</b> },
-          { title: 'Ajouté le', dataKey: 'createdAt', render: (document) => toFrenchDate(document.createdAt) },
+          { title: 'Ajouté le', dataKey: 'createdAt', render: (document) => formatDateWithFullMonth(document.createdAt) },
           { title: 'Ajouté par', dataKey: 'createdBy', render: (document) => <UserName id={document.createdBy} /> },
           {
             title: 'Action',

--- a/dashboard/src/components/Places.js
+++ b/dashboard/src/components/Places.js
@@ -11,10 +11,10 @@ import Box from './Box';
 import ButtonCustom from './ButtonCustom';
 import { usePlaces } from '../recoil/places';
 import Table from './table';
-import { toFrenchDate } from '../utils';
 import SelectCustom from './SelectCustom';
 import { currentTeamState } from '../recoil/auth';
 import { useRelsPerson } from '../recoil/relPersonPlace';
+import { formatDateWithFullMonth } from '../services/date';
 
 const Places = ({ personId = '', onUpdateResults }) => {
   const history = useHistory();
@@ -46,7 +46,7 @@ const Places = ({ personId = '', onUpdateResults }) => {
           onRowClick={(relation) => history.push(`/place/${relation?.place?._id}`)}
           columns={[
             { title: 'Nom', render: (relation) => relation?.place?.name },
-            { title: 'Ajouté le', dataKey: 'createdAt', render: (relation) => toFrenchDate(relation.createdAt) },
+            { title: 'Ajouté le', dataKey: 'createdAt', render: (relation) => formatDateWithFullMonth(relation.createdAt) },
           ]}
         />
         <AddPlace personId={personId} />

--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -12,6 +12,7 @@ import SelectCustom from './SelectCustom';
 import Table from './table';
 
 const newField = () => ({
+  // Todo: I guess could use crypto here.
   name: `custom-${new Date().toISOString().split('.').join('-').split(':').join('-')}`,
   label: '',
   type: 'text',

--- a/dashboard/src/index.js
+++ b/dashboard/src/index.js
@@ -6,7 +6,6 @@ import 'react-dates/lib/css/_datepicker.css';
 import 'bootstrap/dist/css/bootstrap.min.css';
 import './datepicker.css';
 import './index.scss';
-import 'moment/min/locales.min';
 import App from './app';
 import './services/sentry';
 import './services/api';

--- a/dashboard/src/recoil/actions.js
+++ b/dashboard/src/recoil/actions.js
@@ -2,6 +2,7 @@ import { atom, useRecoilState, useRecoilValue } from 'recoil';
 import { userState } from '../recoil/auth';
 import useApi from '../services/api';
 import { getData, useStorage } from '../services/dataManagement';
+import { now } from '../services/date';
 import { capture } from '../services/sentry';
 import { useComments } from './comments';
 
@@ -83,7 +84,7 @@ export const useActions = () => {
     try {
       if (statusChanged) {
         if ([DONE, CANCEL].includes(action.status)) {
-          action.completedAt = new Date().toISOString();
+          action.completedAt = now();
         } else {
           action.completedAt = null;
         }

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -7,7 +7,7 @@ import { placesState } from './places';
 import { relsPersonPlaceState } from './relPersonPlace';
 import { reportsState } from './reports';
 import { territoriesState } from './territory';
-import { getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, isToday, today } from '../services/date';
+import { getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, isToday } from '../services/date';
 import { customFieldsObsSelector, territoryObservationsState } from './territoryObservations';
 import { selector, selectorFamily } from 'recoil';
 import { filterData } from '../components/Filters';

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -7,7 +7,7 @@ import { placesState } from './places';
 import { relsPersonPlaceState } from './relPersonPlace';
 import { reportsState } from './reports';
 import { territoriesState } from './territory';
-import { getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, today } from '../services/date';
+import { getIsDayWithinHoursOffsetOfPeriod, isOnSameDay, isToday, today } from '../services/date';
 import { customFieldsObsSelector, territoryObservationsState } from './territoryObservations';
 import { selector, selectorFamily } from 'recoil';
 import { filterData } from '../components/Filters';
@@ -26,7 +26,7 @@ export const todaysReportSelector = selector({
   key: 'todaysReportSelector',
   get: ({ get }) => {
     const teamsReports = get(currentTeamReportsSelector);
-    return teamsReports.find((rep) => isOnSameDay(new Date(rep.date), today()));
+    return teamsReports.find((rep) => isToday(rep.date));
   },
 });
 
@@ -45,7 +45,7 @@ export const reportPerDateSelector = selectorFamily({
     ({ date }) =>
     ({ get }) => {
       const teamsReports = get(currentTeamReportsSelector);
-      return teamsReports.find((rep) => isOnSameDay(new Date(rep.date), new Date(date)));
+      return teamsReports.find((rep) => isOnSameDay(rep.date, date));
     },
 });
 

--- a/dashboard/src/scenes/action/CreateAction.js
+++ b/dashboard/src/scenes/action/CreateAction.js
@@ -12,12 +12,12 @@ import agendaIcon from '../../assets/icons/agenda-icon.svg';
 import SelectTeam from '../../components/SelectTeam';
 import SelectPerson from '../../components/SelectPerson';
 import ButtonCustom from '../../components/ButtonCustom';
-import { toFrenchDate } from '../../utils';
 import { DONE, TODO, useActions } from '../../recoil/actions';
 import SelectStatus from '../../components/SelectStatus';
 import { organisationState, teamsState, userState } from '../../recoil/auth';
 import { useRefresh } from '../../recoil/refresh';
 import SelectCustom from '../../components/SelectCustom';
+import { dateForDatePicker, formatDateWithFullMonth } from '../../services/date';
 
 const CreateAction = ({ disabled, title, person = null, persons = null, isMulti = false, completedAt, refreshable, buttonOnly = false, noIcon }) => {
   const [open, setOpen] = useState(false);
@@ -30,7 +30,7 @@ const CreateAction = ({ disabled, title, person = null, persons = null, isMulti 
   const { loading, actionsRefresher } = useRefresh();
   const history = useHistory();
 
-  title = title || 'Créer une nouvelle action' + (Boolean(completedAt) ? ` faite le ${toFrenchDate(completedAt)}` : '');
+  title = title || 'Créer une nouvelle action' + (Boolean(completedAt) ? ` faite le ${formatDateWithFullMonth(completedAt)}` : '');
 
   const onAddAction = async (body) => {
     if (body.status !== TODO) body.completedAt = completedAt || Date.now();
@@ -152,7 +152,7 @@ const CreateAction = ({ disabled, title, person = null, persons = null, isMulti 
                         <DatePicker
                           locale="fr"
                           className="form-control"
-                          selected={new Date(values.dueAt)}
+                          selected={dateForDatePicker(values.dueAt)}
                           onChange={(date) => handleChange({ target: { value: date, name: 'dueAt' } })}
                           timeInputLabel="Heure :"
                           dateFormat={values.withTime ? 'dd/MM/yyyy HH:mm' : 'dd/MM/yyyy'}

--- a/dashboard/src/scenes/action/list.js
+++ b/dashboard/src/scenes/action/list.js
@@ -13,7 +13,6 @@ import ActionStatus from '../../components/ActionStatus';
 
 import DateBloc from '../../components/DateBloc';
 
-import { toFrenchDate } from '../../utils';
 import PaginationContext from '../../contexts/pagination';
 import Search from '../../components/search';
 import { actionsFullSearchSelector } from '../../recoil/selectors';
@@ -23,6 +22,7 @@ import ActionName from '../../components/ActionName';
 import { currentTeamState } from '../../recoil/auth';
 import { useRecoilState, useRecoilValue } from 'recoil';
 import ActionPersonName from '../../components/ActionPersonName';
+import { formatDateWithFullMonth, formatTime } from '../../services/date';
 
 const showAsOptions = ['Calendrier', 'Liste'];
 
@@ -92,6 +92,7 @@ const List = () => {
       </Row>
       {showAs === showAsOptions[0] && (
         <div style={{ minHeight: '100vh' }}>
+          {' '}
           <ActionsCalendar actions={actionsFiltered} />
         </div>
       )}
@@ -114,10 +115,7 @@ const List = () => {
                 dataKey: '_id',
                 render: (action) => {
                   if (!action.dueAt || !action.withTime) return null;
-                  return new Date(action.dueAt).toLocaleString('fr', {
-                    hour: '2-digit',
-                    minute: '2-digit',
-                  });
+                  return formatTime(action.dueAt);
                 },
               },
               {
@@ -130,7 +128,7 @@ const List = () => {
                 dataKey: 'person',
                 render: (action) => <ActionPersonName action={action} />,
               },
-              { title: 'Créée le', dataKey: 'createdAt', render: (action) => toFrenchDate(action.createdAt || '') },
+              { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt || '') },
               { title: 'Status', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
             ]}
           />

--- a/dashboard/src/scenes/action/view.js
+++ b/dashboard/src/scenes/action/view.js
@@ -25,6 +25,7 @@ import SelectTeam from '../../components/SelectTeam';
 import { organisationState, teamsState, userState } from '../../recoil/auth';
 import { useActions, CANCEL, DONE } from '../../recoil/actions';
 import { useRecoilValue } from 'recoil';
+import { dateForDatePicker } from '../../services/date';
 
 const View = () => {
   const { id } = useParams();
@@ -99,7 +100,7 @@ const View = () => {
                         <DatePicker
                           locale="fr"
                           className="form-control"
-                          selected={values.dueAt ? new Date(values.dueAt) : new Date()}
+                          selected={dateForDatePicker(values.dueAt ?? new Date())}
                           onChange={(date) => handleChange({ target: { value: date, name: 'dueAt' } })}
                           dateFormat={values.withTime ? 'dd/MM/yyyy HH:mm' : 'dd/MM/yyyy'}
                           showTimeInput={values.withTime}
@@ -132,7 +133,7 @@ const View = () => {
                           <DatePicker
                             locale="fr"
                             className="form-control"
-                            selected={values.completedAt ? new Date(values.completedAt) : new Date()}
+                            selected={dateForDatePicker(values.completedAt ?? new Date())}
                             onChange={(date) => handleChange({ target: { value: date, name: 'completedAt' } })}
                             timeInputLabel="Heure :"
                             dateFormat="dd/MM/yyyy HH:mm"

--- a/dashboard/src/scenes/data-import-export/ImportData.js
+++ b/dashboard/src/scenes/data-import-export/ImportData.js
@@ -14,8 +14,9 @@ import {
   usePersons,
 } from '../../recoil/persons';
 import { teamsState, userState } from '../../recoil/auth';
-import { isNullOrUndefined, toFrenchDate, typeOptions } from '../../utils';
+import { isNullOrUndefined, typeOptions } from '../../utils';
 import useApi, { encryptItem, hashedOrgEncryptionKey } from '../../services/api';
+import { formatDateWithFullMonth, now } from '../../services/date';
 
 const ImportData = () => {
   const user = useRecoilValue(userState);
@@ -100,7 +101,7 @@ const ImportData = () => {
           }
         }
         if (Object.keys(person).length) {
-          person.description = `Données importées le ${toFrenchDate(new Date())}\n${person.description || ''}`;
+          person.description = `Données importées le ${formatDateWithFullMonth(now())}\n${person.description || ''}`;
           persons.push(person);
         }
       }

--- a/dashboard/src/scenes/organisation/list.js
+++ b/dashboard/src/scenes/organisation/list.js
@@ -9,9 +9,9 @@ import ButtonCustom from '../../components/ButtonCustom';
 
 import Loading from '../../components/loading';
 import CreateWrapper from '../../components/createWrapper';
-import { toFrenchDate } from '../../utils';
 import useApi from '../../services/api';
 import DeleteOrganisation from '../../components/DeleteOrganisation';
+import { formatDateWithFullMonth } from '../../services/date';
 
 const List = () => {
   const [organisations, setOrganisations] = useState(null);
@@ -52,7 +52,7 @@ const List = () => {
           {
             title: 'Créée le',
             dataKey: 'createdAt',
-            render: (o) => toFrenchDate(o.createdAt || ''),
+            render: (o) => formatDateWithFullMonth(o.createdAt || ''),
             onSortOrder: setSortOrder,
             onSortBy: setSortBy,
             sortOrder,
@@ -97,7 +97,7 @@ const List = () => {
             sortOrder,
             onSortOrder: setSortOrder,
             onSortBy: setSortBy,
-            render: (o) => toFrenchDate(o.encryptionLastUpdateAt || ''),
+            render: (o) => formatDateWithFullMonth(o.encryptionLastUpdateAt || ''),
           },
           {
             title: 'Action',

--- a/dashboard/src/scenes/person/list.js
+++ b/dashboard/src/scenes/person/list.js
@@ -4,9 +4,6 @@ import { Col, Container, Row } from 'reactstrap';
 import { useHistory } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
 import styled from 'styled-components';
-
-import { toFrenchDate } from '../../utils';
-
 import Header from '../../components/header';
 import Page from '../../components/pagination';
 import Search from '../../components/search';
@@ -17,7 +14,7 @@ import { customFieldsPersonsMedicalSelector, customFieldsPersonsSocialSelector, 
 import TagTeam from '../../components/TagTeam';
 import PaginationContext from '../../contexts/pagination';
 import Filters from '../../components/Filters';
-import { displayBirthDate } from '../../services/date';
+import { formatBirthDate, formatDateWithFullMonth } from '../../services/date';
 import { personsFullSearchSelector } from '../../recoil/selectors';
 import { theme } from '../../config';
 import { currentTeamState, organisationState, teamsState } from '../../recoil/auth';
@@ -136,10 +133,10 @@ const List = () => {
             dataKey: '_id',
             render: (p) => {
               if (!p.birthdate) return '';
-              else if (p.outOfActiveList) return <i style={{ color: theme.black50 }}>{displayBirthDate(p.birthdate)}</i>;
+              else if (p.outOfActiveList) return <i style={{ color: theme.black50 }}>{formatBirthDate(p.birthdate)}</i>;
               return (
                 <span>
-                  <i>{displayBirthDate(p.birthdate)}</i>
+                  <i>{formatBirthDate(p.birthdate)}</i>
                 </span>
               );
             },
@@ -154,8 +151,8 @@ const List = () => {
             title: 'Suivi(e) depuis le',
             dataKey: 'createdAt',
             render: (p) => {
-              if (p.outOfActiveList) return <div style={{ color: theme.black50 }}>{toFrenchDate(p.createdAt || '')}</div>;
-              return toFrenchDate(p.createdAt || '');
+              if (p.outOfActiveList) return <div style={{ color: theme.black50 }}>{formatDateWithFullMonth(p.createdAt || '')}</div>;
+              return formatDateWithFullMonth(p.createdAt || '');
             },
           },
         ]}

--- a/dashboard/src/scenes/person/view.js
+++ b/dashboard/src/scenes/person/view.js
@@ -36,11 +36,11 @@ import UserName from '../../components/UserName';
 import SelectCustom from '../../components/SelectCustom';
 import SelectAsInput from '../../components/SelectAsInput';
 import Places from '../../components/Places';
-import { toFrenchDate } from '../../utils';
 import ActionName from '../../components/ActionName';
 import OutOfActiveList from './OutOfActiveList';
 import { organisationState } from '../../recoil/auth';
 import Documents from '../../components/Documents';
+import { dateForDatePicker, formatDateWithFullMonth, formatTime } from '../../services/date';
 
 const initTabs = ['Résumé', 'Actions', 'Commentaires', 'Passages', 'Lieux', 'Documents'];
 
@@ -174,7 +174,7 @@ const Summary = ({ person }) => {
                       <DatePicker
                         locale="fr"
                         className="form-control"
-                        selected={values.birthdate ? new Date(values.birthdate) : null}
+                        selected={dateForDatePicker(values.birthdate)}
                         onChange={(date) => handleChange({ target: { value: date, name: 'birthdate' } })}
                         dateFormat="dd/MM/yyyy"
                       />
@@ -188,7 +188,7 @@ const Summary = ({ person }) => {
                       <DatePicker
                         locale="fr"
                         className="form-control"
-                        selected={values.wanderingAt ? new Date(values.wanderingAt) : null}
+                        selected={dateForDatePicker(values.wanderingAt)}
                         onChange={(date) => handleChange({ target: { value: date, name: 'wanderingAt' } })}
                         dateFormat="dd/MM/yyyy"
                       />
@@ -202,7 +202,7 @@ const Summary = ({ person }) => {
                       <DatePicker
                         locale="fr"
                         className="form-control"
-                        selected={values.createdAt ? new Date(values.createdAt) : null}
+                        selected={dateForDatePicker(values.createdAt)}
                         onChange={(date) => handleChange({ target: { value: date, name: 'createdAt' } })}
                         dateFormat="dd/MM/yyyy"
                       />
@@ -374,16 +374,13 @@ const Actions = ({ person, onUpdateResults }) => {
         onRowClick={(action) => history.push(`/action/${action._id}`)}
         columns={[
           { title: 'Nom', dataKey: 'name', render: (action) => <ActionName action={action} /> },
-          { title: 'À faire le', dataKey: 'dueAt', render: (action) => toFrenchDate(action.dueAt) },
+          { title: 'À faire le', dataKey: 'dueAt', render: (action) => formatDateWithFullMonth(action.dueAt) },
           {
             title: 'Heure',
             dataKey: '_id',
             render: (action) => {
               if (!action.dueAt || !action.withTime) return null;
-              return new Date(action.dueAt).toLocaleString('fr', {
-                hour: '2-digit',
-                minute: '2-digit',
-              });
+              return formatTime(action.dueAt);
             },
           },
           { title: 'Status', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },

--- a/dashboard/src/scenes/place/list.js
+++ b/dashboard/src/scenes/place/list.js
@@ -13,13 +13,13 @@ import Search from '../../components/search';
 import PaginationContext from '../../contexts/pagination';
 import Page from '../../components/pagination';
 import { filterBySearch } from '../search/utils';
-import { toFrenchDate } from '../../utils';
 import { currentTeamState, organisationState } from '../../recoil/auth';
 import { usePersons } from '../../recoil/persons';
 import { useRelsPerson } from '../../recoil/relPersonPlace';
 import { usePlaces } from '../../recoil/places';
 import { useRefresh } from '../../recoil/refresh';
 import { useRecoilValue } from 'recoil';
+import { formatDateWithFullMonth } from '../../services/date';
 
 const filterPlaces = (places, { page, limit, search }) => {
   if (search?.length) places = filterBySearch(search, places);
@@ -84,7 +84,7 @@ const List = () => {
               />
             ),
           },
-          { title: 'Créée le', dataKey: 'createdAt', render: (place) => toFrenchDate(place.createdAt) },
+          { title: 'Créée le', dataKey: 'createdAt', render: (place) => formatDateWithFullMonth(place.createdAt) },
         ]}
       />
       <Page page={page} limit={limit} total={total} onChange={({ page }) => setPage(page, true)} />

--- a/dashboard/src/scenes/reception/view.js
+++ b/dashboard/src/scenes/reception/view.js
@@ -3,10 +3,8 @@ import React, { useEffect, useState } from 'react';
 import { Col, Container, Row } from 'reactstrap';
 import styled from 'styled-components';
 import { useHistory, useLocation } from 'react-router-dom';
-
 import Header from '../../components/header';
-
-import { today } from '../../services/date';
+import { formatDateWithNameOfDay, now, startOfToday } from '../../services/date';
 import {
   actionsByStatusSelector,
   lastReportSelector,
@@ -40,8 +38,8 @@ const Reception = () => {
   const lastReport = useRecoilValue(lastReportSelector);
   const { addComment } = useComments();
 
-  const anonymousPassages = useRecoilValue(numberOfPassagesAnonymousPerDatePerTeamSelector({ date: today() }));
-  const nonAnonymousPassages = useRecoilValue(numberOfPassagesNonAnonymousPerDatePerTeamSelector({ date: today() }));
+  const anonymousPassages = useRecoilValue(numberOfPassagesAnonymousPerDatePerTeamSelector({ date: startOfToday() }));
+  const nonAnonymousPassages = useRecoilValue(numberOfPassagesNonAnonymousPerDatePerTeamSelector({ date: startOfToday() }));
 
   const { persons } = usePersons();
   const history = useHistory();
@@ -60,7 +58,7 @@ const Reception = () => {
     return params.map((id) => persons.find((p) => p._id === id));
   });
 
-  const createReport = () => addReport(today(), currentTeam._id);
+  const createReport = () => addReport(startOfToday(), currentTeam._id);
 
   useEffect(() => {
     if (!reportsLoading && !todaysReport && !!currentTeam?._id) createReport();
@@ -118,8 +116,7 @@ const Reception = () => {
         titleStyle={{ fontWeight: '400' }}
         title={
           <span>
-            Accueil du <b>{new Date().toLocaleDateString('fr', { day: 'numeric', weekday: 'long', month: 'long', year: 'numeric' })}</b> de l'équipe{' '}
-            {currentTeam?.nightSession ? 'de nuit ' : ''}
+            Accueil du <b>{formatDateWithNameOfDay(now())}</b> de l'équipe {currentTeam?.nightSession ? 'de nuit ' : ''}
             <b>{currentTeam?.name || ''}</b>
           </span>
         }

--- a/dashboard/src/scenes/report/list.js
+++ b/dashboard/src/scenes/report/list.js
@@ -52,12 +52,7 @@ const HitMonth = ({ date, reports, team, debug }) => {
 
   return (
     <div style={{ width: '100%' }}>
-      <MonthButton
-        onClick={() => setIsOpen(!isOpen)}
-        title={`${date.toDate().toLocaleString('default', { month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' })} ${date
-          .toDate()
-          .getFullYear()}`}
-      />
+      <MonthButton onClick={() => setIsOpen(!isOpen)} title={`${date.format('MMMM YYYY')}`} />
       <Collapse
         isOpen={isOpen}
         style={{
@@ -98,6 +93,7 @@ const FullButton = styled(EmptyButton)`
 
 const MonthButton = styled(EmptyButton)`
   border: 1px solid ${theme.main75};
+  text-transform: capitalize;
   width: 100%;
   max-width: 100%;
   color: ${theme.main};

--- a/dashboard/src/scenes/report/list.js
+++ b/dashboard/src/scenes/report/list.js
@@ -1,14 +1,11 @@
 import React, { useState } from 'react';
 import { Container, Collapse } from 'reactstrap';
 import { useHistory } from 'react-router-dom';
-
 import Header from '../../components/header';
-
-import { toFrenchDate } from '../../utils';
 import ButtonCustom from '../../components/ButtonCustom';
 import { theme } from '../../config';
 import styled from 'styled-components';
-import { getMonths, isOnSameDay } from '../../services/date';
+import { formatDateWithFullMonth, getDaysOfMonth, getMonths, isAfterToday, isOnSameDay } from '../../services/date';
 import { currentTeamState } from '../../recoil/auth';
 import { reportsState, useReports } from '../../recoil/reports';
 import { useRefresh } from '../../recoil/refresh';
@@ -51,16 +48,16 @@ const HitMonth = ({ date, reports, team, debug }) => {
     history.push(`/report/${res.data._id}`);
   };
 
-  let newDate = new Date(date);
-  const days = [];
-  while (newDate.getMonth() === date.getMonth() && newDate < new Date()) {
-    days.push(new Date(newDate));
-    newDate.setDate(newDate.getDate() + 1);
-  }
+  const days = getDaysOfMonth(date).filter((day) => !isAfterToday(day));
 
   return (
     <div style={{ width: '100%' }}>
-      <MonthButton onClick={() => setIsOpen(!isOpen)} title={`${date.toLocaleString('default', { month: 'long' })} ${date.getFullYear()}`} />
+      <MonthButton
+        onClick={() => setIsOpen(!isOpen)}
+        title={`${date.toDate().toLocaleString('default', { month: 'long', day: 'numeric', hour: 'numeric', minute: 'numeric' })} ${date
+          .toDate()
+          .getFullYear()}`}
+      />
       <Collapse
         isOpen={isOpen}
         style={{
@@ -71,11 +68,11 @@ const HitMonth = ({ date, reports, team, debug }) => {
           width: '100%',
         }}>
         {days.map((day) => {
-          const report = reports.find((rep) => isOnSameDay(new Date(rep.date), day));
+          const report = reports.find((rep) => isOnSameDay(rep.date, day));
           if (report) {
-            return <FullButton onClick={() => history.push(`/report/${report._id}`)} key={day} title={`${toFrenchDate(day)} `} />;
+            return <FullButton onClick={() => history.push(`/report/${report._id}`)} key={day} title={`${formatDateWithFullMonth(day.toDate())} `} />;
           }
-          return <EmptyButton onClick={() => createReport(day)} key={day} title={`${toFrenchDate(day)} `} />;
+          return <EmptyButton onClick={() => createReport(day)} key={day} title={`${formatDateWithFullMonth(day.toDate())} `} />;
         })}
       </Collapse>
     </div>

--- a/dashboard/src/scenes/search/index.js
+++ b/dashboard/src/scenes/search/index.js
@@ -3,8 +3,6 @@ import React, { useContext, useState, useEffect } from 'react';
 import { Container, Row, Col, TabContent, TabPane, Nav, NavItem, NavLink } from 'reactstrap';
 import styled from 'styled-components';
 import { useHistory, useLocation } from 'react-router-dom';
-
-import { toFrenchDate } from '../../utils';
 import DateBloc from '../../components/DateBloc';
 import Header from '../../components/header';
 import Box from '../../components/Box';
@@ -33,6 +31,7 @@ import {
   territoriesSearchSelector,
 } from '../../recoil/selectors';
 import ActionPersonName from '../../components/ActionPersonName';
+import { formatDateWithFullMonth, formatTime } from '../../services/date';
 
 const initTabs = ['Actions', 'Personnes', 'Commentaires', 'Lieux', 'Territoires', 'Observations'];
 
@@ -140,15 +139,12 @@ const Actions = ({ search, onUpdateResults }) => {
               dataKey: '_id',
               render: (action) => {
                 if (!action.dueAt || !action.withTime) return null;
-                return new Date(action.dueAt).toLocaleString('fr', {
-                  hour: '2-digit',
-                  minute: '2-digit',
-                });
+                return formatTime(action.dueAt);
               },
             },
             { title: 'Nom', dataKey: 'name' },
             { title: 'Personne suivie', dataKey: 'person', render: (action) => <ActionPersonName action={action} /> },
-            { title: 'Créée le', dataKey: 'createdAt', render: (action) => toFrenchDate(action.createdAt || '') },
+            { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt || '') },
             { title: 'Status', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
           ]}
         />
@@ -204,7 +200,7 @@ const Persons = ({ search, onUpdateResults }) => {
               render: (p) => <Alertness>{p.alertness ? '!' : ''}</Alertness>,
             },
             { title: 'Équipe(s) en charge', dataKey: 'assignedTeams', render: (person) => <Teams teams={teams} person={person} /> },
-            { title: 'Suivi(e) depuis le', dataKey: 'createdAt', render: (p) => toFrenchDate(p.createdAt || '') },
+            { title: 'Suivi(e) depuis le', dataKey: 'createdAt', render: (p) => formatDateWithFullMonth(p.createdAt || '') },
           ]}
         />
       </StyledBox>
@@ -345,7 +341,7 @@ const Territories = ({ search, onUpdateResults }) => {
             { title: 'Nom', dataKey: 'name' },
             { title: 'Types', dataKey: 'types', render: ({ types }) => (types ? types.join(', ') : '') },
             { title: 'Périmètre', dataKey: 'perimeter' },
-            { title: 'Créé le', dataKey: 'createdAt', render: (territory) => toFrenchDate(territory.createdAt || '') },
+            { title: 'Créé le', dataKey: 'createdAt', render: (territory) => formatDateWithFullMonth(territory.createdAt || '') },
           ]}
         />
       </StyledBox>
@@ -394,7 +390,7 @@ const Places = ({ search, onUpdateResults }) => {
                 />
               ),
             },
-            { title: 'Créée le', dataKey: 'createdAt', render: (place) => toFrenchDate(place.createdAt) },
+            { title: 'Créée le', dataKey: 'createdAt', render: (place) => formatDateWithFullMonth(place.createdAt) },
           ]}
         />
       </StyledBox>

--- a/dashboard/src/scenes/stats/index.js
+++ b/dashboard/src/scenes/stats/index.js
@@ -2,7 +2,6 @@
 import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 import { Col, Container, Label, Nav, NavItem, NavLink, Row, TabContent, TabPane } from 'reactstrap';
-import moment from 'moment';
 import { useRecoilValue } from 'recoil';
 import Header from '../../components/header';
 import Loading from '../../components/loading';
@@ -31,14 +30,14 @@ import ExportData from '../data-import-export/ExportData';
 import SelectCustom from '../../components/SelectCustom';
 import { useTerritories } from '../../recoil/territory';
 import { passagesNonAnonymousPerDatePerTeamSelector } from '../../recoil/selectors';
-moment.locale('fr');
+import { dayjsInstance } from '../../services/date';
 
 const getDataForPeriod = (data, { startDate, endDate }, filters = []) => {
   if (!!filters?.filter((f) => Boolean(f?.value)).length) data = filterData(data, filters);
   if (!startDate || !endDate) {
     return data;
   }
-  return data.filter((item) => moment(item.createdAt).isBefore(endDate) && moment(item.createdAt).isAfter(startDate));
+  return data.filter((item) => dayjsInstance(item.createdAt).isBetween(startDate, endDate));
 };
 
 const tabs = ['Général', 'Accueil', 'Actions', 'Personnes suivies', 'Observations', 'Comptes-rendus'];

--- a/dashboard/src/scenes/structure/list.js
+++ b/dashboard/src/scenes/structure/list.js
@@ -3,7 +3,6 @@ import React, { useEffect, useState } from 'react';
 import { Col, Container, FormGroup, Input, Modal, ModalBody, ModalHeader, Row } from 'reactstrap';
 import { useHistory } from 'react-router-dom';
 import { useRecoilValue } from 'recoil';
-
 import Header from '../../components/header';
 import Page from '../../components/pagination';
 import Loading from '../../components/loading';
@@ -13,9 +12,9 @@ import { Formik } from 'formik';
 import { toastr } from 'react-redux-toastr';
 import ButtonCustom from '../../components/ButtonCustom';
 import Search from '../../components/search';
-import { toFrenchDate } from '../../utils';
 import { currentTeamState } from '../../recoil/auth';
 import useApi from '../../services/api';
+import { formatDateWithFullMonth } from '../../services/date';
 
 const List = () => {
   const [structures, setStructures] = useState(null);
@@ -59,7 +58,7 @@ const List = () => {
           onRowClick={(i) => history.push(`/structure/${i._id}`)}
           columns={[
             { title: 'Nom', dataKey: 'name' },
-            { title: 'Créée le', dataKey: 'createdAt', render: (i) => toFrenchDate(i.createdAt) },
+            { title: 'Créée le', dataKey: 'createdAt', render: (i) => formatDateWithFullMonth(i.createdAt) },
           ]}
         />
         <Page {...pagination} onChange={getStructure} />

--- a/dashboard/src/scenes/team/list.js
+++ b/dashboard/src/scenes/team/list.js
@@ -9,13 +9,12 @@ import Header from '../../components/header';
 import ButtonCustom from '../../components/ButtonCustom';
 import CreateWrapper from '../../components/createWrapper';
 import Table from '../../components/table';
-
-import { toFrenchDate } from '../../utils';
 import NightSessionModale from '../../components/NightSessionModale';
 import { currentTeamState, organisationState, teamsState, userState } from '../../recoil/auth';
 import useApi from '../../services/api';
 import { AppSentry } from '../../services/sentry';
 import OnboardingEndModal from '../../components/OnboardingEndModal';
+import { formatDateWithFullMonth } from '../../services/date';
 
 const List = () => {
   const teams = useRecoilValue(teamsState);
@@ -31,7 +30,7 @@ const List = () => {
         rowKey={'_id'}
         columns={[
           { title: 'Nom', dataKey: 'name' },
-          { title: 'Créée le', dataKey: 'createdAt', render: (i) => toFrenchDate(i.createdAt) },
+          { title: 'Créée le', dataKey: 'createdAt', render: (i) => formatDateWithFullMonth(i.createdAt) },
           {
             title: (
               <>

--- a/dashboard/src/scenes/territory/list.js
+++ b/dashboard/src/scenes/territory/list.js
@@ -6,10 +6,8 @@ import styled from 'styled-components';
 import { toastr } from 'react-redux-toastr';
 import { Formik } from 'formik';
 import { useRecoilValue } from 'recoil';
-
 import Header from '../../components/header';
 import Page from '../../components/pagination';
-import { toFrenchDate } from '../../utils';
 import Loading from '../../components/loading';
 import Table from '../../components/table';
 import ButtonCustom from '../../components/ButtonCustom';
@@ -20,6 +18,7 @@ import SelectCustom from '../../components/SelectCustom';
 import { territoriesFullSearchSelector } from '../../recoil/selectors';
 import { currentTeamState, organisationState } from '../../recoil/auth';
 import { useRefresh } from '../../recoil/refresh';
+import { formatDateWithFullMonth } from '../../services/date';
 
 const List = () => {
   const organisation = useRecoilValue(organisationState);
@@ -65,7 +64,7 @@ const List = () => {
           { title: 'Nom', dataKey: 'name' },
           { title: 'Types', dataKey: 'types', render: ({ types }) => (types ? types.join(', ') : '') },
           { title: 'Périmètre', dataKey: 'perimeter' },
-          { title: 'Créé le', dataKey: 'createdAt', render: (territory) => toFrenchDate(territory.createdAt || '') },
+          { title: 'Créé le', dataKey: 'createdAt', render: (territory) => formatDateWithFullMonth(territory.createdAt || '') },
         ]}
       />
       <Page page={page} limit={limit} total={total} onChange={({ page }) => setPage(page, true)} />

--- a/dashboard/src/scenes/user/list.js
+++ b/dashboard/src/scenes/user/list.js
@@ -6,8 +6,6 @@ import { Formik } from 'formik';
 import { toastr } from 'react-redux-toastr';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
-
-import { toFrenchDate } from '../../utils';
 import Header from '../../components/header';
 import SelectTeamMultiple from '../../components/SelectTeamMultiple';
 import Loading from '../../components/loading';
@@ -18,6 +16,7 @@ import SelectCustom from '../../components/SelectCustom';
 import TagTeam from '../../components/TagTeam';
 import { organisationState, userState } from '../../recoil/auth';
 import useApi from '../../services/api';
+import { formatDateWithFullMonth } from '../../services/date';
 
 const List = () => {
   const [users, setUsers] = useState(null);
@@ -58,8 +57,8 @@ const List = () => {
               );
             },
           },
-          { title: 'Créée le', dataKey: 'createdAt', render: (i) => toFrenchDate(i.createdAt) },
-          { title: 'Dernière connection le', dataKey: 'lastLoginAt', render: (i) => toFrenchDate(i.lastLoginAt) },
+          { title: 'Créée le', dataKey: 'createdAt', render: (i) => formatDateWithFullMonth(i.createdAt) },
+          { title: 'Dernière connection le', dataKey: 'lastLoginAt', render: (i) => formatDateWithFullMonth(i.lastLoginAt) },
         ]}
       />
     </Container>

--- a/dashboard/src/services/date.js
+++ b/dashboard/src/services/date.js
@@ -62,7 +62,7 @@ export function subtractOneDay(date) {
 }
 
 export function startOfToday() {
-  dayjs().startOf('day');
+  return dayjs().startOf('day');
 }
 
 export function now() {

--- a/dashboard/src/utils.js
+++ b/dashboard/src/utils.js
@@ -1,8 +1,6 @@
-const toFrenchDate = (d) => {
-  if (!d) return '';
-  return new Date(d).toLocaleDateString('fr', { day: 'numeric', month: 'long', year: 'numeric' });
-};
+import { dayjsInstance } from './services/date';
 
+// This function should be replaced with secure crypto.
 const generatePassword = () => {
   let length = 6;
   let charset = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
@@ -12,12 +10,6 @@ const generatePassword = () => {
   }
   return retVal;
 };
-/*
-
-CUSTOM FIELDS
-VALIDATION FIELDS
-
-*/
 
 const isNullOrUndefined = (value) => {
   if (typeof value === 'undefined') return true;
@@ -40,7 +32,7 @@ const validateNumber = ({ v: value }) => {
 
 const validateDate = ({ w: value }) => {
   // https://stackoverflow.com/a/643827/5225096
-  if (typeof value?.getMonth === 'function') return value;
+  if (typeof value?.getMonth === 'function' || value instanceof dayjsInstance) return value;
   if (!isNaN(new Date(value).getMonth())) return new Date(value);
   return null;
 };
@@ -113,7 +105,6 @@ function download(file, fileName) {
 
 export {
   download,
-  toFrenchDate,
   generatePassword,
   typeOptions,
   isNullOrUndefined,


### PR DESCRIPTION
OK je suis passé aux différents endroits pour tout uniformiser. Globalement maintenant on utilisera `dayjs` partout dans le dashboard et ensuite dans l'app. Je suis passé partout pour essayer de virer au max les cas particuliers. L'idée c'est donc : 
- On n'utilise plus les fonctions `Date` direct
- On utilise tout ce qui est dans le fichier `src/services/date.js`
- Tout passe par `dayjs`

`dayjs` ne fait aucun forçage de fuseau horaire. Donc potentiellement on peut encore avoir des problèmes si la personne a l'heure pétée sur son ordi, mais c'est comme pour la refonte de l'app c'est un premier pas. Le suivant pourra être de définir un fuseau horaire par organisation (en défaut à Paris/Europe)

Mes réflexions : https://www.notion.so/lestud/R-flexion-sur-les-dates-46c5313325664b3ea6edcf9a6af3548e

A bien tester si possible !