### PR TITLE
feat(dashboard): allow super admin to re-encrypt

### DIFF
--- a/api/src/utils/encryptedTransaction.js
+++ b/api/src/utils/encryptedTransaction.js
@@ -1,12 +1,12 @@
 const sequelize = require("../db/sequelize");
 const Organisation = require("../models/organisation");
 
-const encryptedTransaction = (req) => (dbOperation) =>
+const encryptedTransaction = (req) => (dbOperation, organisationId) =>
   sequelize.transaction(async (tx) => {
     const { encryptionEnabled, encryptionLastUpdateAt, changeMasterKey } = req.query;
 
     const checkIfCanChangeData = async () => {
-      const organisation = await Organisation.findOne({ where: { _id: req.user.organisation } });
+      const organisation = await Organisation.findOne({ where: { _id: organisationId } });
       if (encryptionEnabled !== "true" && organisation.encryptionEnabled) {
         return {
           ok: false,

--- a/api/src/utils/encryptedTransaction.js
+++ b/api/src/utils/encryptedTransaction.js
@@ -6,6 +6,7 @@ const encryptedTransaction = (req) => (dbOperation, organisationId) =>
     const { encryptionEnabled, encryptionLastUpdateAt, changeMasterKey } = req.query;
 
     const checkIfCanChangeData = async () => {
+      if (!organisationId) organisationId = req.user.organisation;
       const organisation = await Organisation.findOne({ where: { _id: organisationId } });
       if (encryptionEnabled !== "true" && organisation.encryptionEnabled) {
         return {

--- a/dashboard/src/recoil/persons.js
+++ b/dashboard/src/recoil/persons.js
@@ -427,7 +427,7 @@ export const personFields = [
     name: 'outOfActiveList',
     type: 'yes-no',
     label: 'Sortie de file active',
-    encrypted: false,
+    encrypted: true,
     importable: false,
     options: yesNoOptions,
     filterable: true,

--- a/dashboard/src/recoil/relPersonPlace.js
+++ b/dashboard/src/recoil/relPersonPlace.js
@@ -81,7 +81,7 @@ export const useRelsPerson = () => {
   };
 };
 
-const encryptedFields = ['place', 'person'];
+const encryptedFields = ['place', 'person', 'user'];
 
 export const prepareRelPersonPlaceForEncryption = (relPersonPlace) => {
   const decrypted = {};

--- a/dashboard/src/scenes/organisation/list.js
+++ b/dashboard/src/scenes/organisation/list.js
@@ -12,6 +12,7 @@ import CreateWrapper from '../../components/createWrapper';
 import useApi from '../../services/api';
 import DeleteOrganisation from '../../components/DeleteOrganisation';
 import { formatDateWithFullMonth } from '../../services/date';
+import EncryptionKey from '../../components/EncryptionKey';
 
 const List = () => {
   const [organisations, setOrganisations] = useState(null);
@@ -100,18 +101,27 @@ const List = () => {
             render: (o) => formatDateWithFullMonth(o.encryptionLastUpdateAt || ''),
           },
           {
-            title: 'Action',
-            dataKey: 'delete',
+            title: 'Actions',
+            dataKey: 'actions',
             render: (o) => {
               return (
-                <DeleteOrganisation
-                  buttonTitle="Supprimer"
-                  onSuccess={() => {
-                    setRefresh(true);
-                  }}
-                  buttonStyle={{ margin: 'auto' }}
-                  organisation={o}
-                />
+                <>
+                  <DeleteOrganisation
+                    buttonTitle="Supprimer"
+                    onSuccess={() => {
+                      setRefresh(true);
+                    }}
+                    buttonStyle={{ margin: 'auto' }}
+                    organisation={o}
+                  />
+                  <EncryptionKey
+                    organisation={o}
+                    setOrganisation={() => {
+                      setRefresh(true);
+                    }}
+                    reloadOnly={true}
+                  />
+                </>
               );
             },
           },

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -65,7 +65,7 @@ const View = () => {
                 <hr />
                 <Title>Encryption</Title>
                 <div style={{ display: 'flex', justifyContent: 'space-around', marginBottom: 40 }}>
-                  <EncryptionKey isMain />
+                  <EncryptionKey isMain organisation={organisation} setOrganisation={setOrganisation} />
                 </div>
                 <hr />
                 <Title>Réglage des Actions</Title>
@@ -163,7 +163,7 @@ const View = () => {
                         </Col>
                       </Row>
                       <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: 40 }}>
-                        <EncryptionKey />
+                        <EncryptionKey organisation={organisation} setOrganisation={setOrganisation} />
                       </div>
                     </>
                   )}


### PR DESCRIPTION
Avant de livrer ça https://github.com/SocialGouv/mano/pull/326 on va d'abord permettre de ré-encrypter.

Pour diverses raisons (entre autre la complexité de faire un script qui appelle à la fois des fonctions de l'API et du front, ou tout simplement le fait qu'on ne peut pas utiliser notre implémentation de libsodium dans un script), j'ai intégré ça dans l'interface. L'idée est qu'avec un bouton "recharger l'encryption" pour le super admin, on peut relancer le processus après avoir renseigné la clé. 

Comme ça ce sera plus rapide à faire et ça permettra de le refaire si besoin. Une fois que c'est merge il faudra rebase  https://github.com/SocialGouv/mano/pull/326 et resteter

EDIT: alors c'est assez rare pour être signalé : les tests m'ont permis de détecter un bug.