### PR TITLE
fix(dashboard): error deleting person due to casade

### DIFF
--- a/api/src/controllers/action.js
+++ b/api/src/controllers/action.js
@@ -146,7 +146,7 @@ router.delete(
 
     if (req.user.role !== "admin") query.where.team = req.user.teams.map((e) => e._id);
     let action = await Action.findOne(query);
-    if (!action) return res.status(404).send({ ok: false, error: "Not Found" });
+    if (!action) return res.status(200).send({ ok: true });
 
     await action.destroy();
 


### PR DESCRIPTION
Remplace https://github.com/SocialGouv/mano/pull/346 de manière beaucoup plus simple.
Pour l'instant on renvoie 200 même si on ne trouve pas quand on delete. On verra après (suppression du relationnel pour l'encryption) comment on fait

Voir: https://trello.com/c/5OaWIjBA/549-bug-action-non-supprim%C3%A9e