### PR TITLE
feat(api): optimize query action

### DIFF
--- a/api/src/controllers/action.js
+++ b/api/src/controllers/action.js
@@ -52,7 +52,7 @@ router.get(
       where: {
         organisation: req.user.organisation,
       },
-      order: [literal(`CASE status when 'ANNULEE' then 1 when 'A FAIRE' then 2 else 3 end`), ["dueAt", "ASC"], ["createdAt", "ASC"]],
+      order: [literal(`CASE status when 'A FAIRE' then 1 when 'FAIT' then 2 else 3 end`), ["dueAt", "ASC"], ["createdAt", "ASC"]],
     };
     const total = await Action.count(query);
     const limit = parseInt(req.query.limit, 10);


### PR DESCRIPTION
EN fait il y avait plusieurs problèmes : 
 - Les sort à la main c'est lourd
 - Comme on fait avec un limit 1000 potentiellement on ne met pas les bons au bon endroit.

J'ai vu ça en voulant régler https://trello.com/c/mCRMxOQo/546-bug-dactions-multiples mais je ne pense pas que ça le règle 😢 

PS : je suis pas sûr d'avoir compris le tri pour les annulé et fait s'il faut changer la règle c'est facile en SQL.