### PR TITLE
fix: data validation

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -32,7 +32,8 @@
     "password-validator": "^5.1.0",
     "pg": "^8.5.1",
     "pg-hstore": "^2.3.3",
-    "sequelize": "^6.3.5"
+    "sequelize": "^6.3.5",
+    "zod": "^3.13.4"
   },
   "devDependencies": {
     "@types/jsonwebtoken": "^8.5.6",

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -169,7 +169,6 @@ router.post(
       z.array(z.string().uuid()).optional().parse(req.body.team);
       z.enum(["admin", "normal"]).parse(req.body.role);
     } catch (e) {
-      console.log(e);
       return res.status(400).send({ ok: false, error: "Invalid request" });
     }
 

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -220,7 +220,18 @@ Guillaume Demirhan, porteur du projet: g.demirhan@aurore.asso.fr - +33 7 66 56 1
 `;
     await mailservice.sendEmail(data.email, subject, body);
 
-    return res.status(200).send({ ok: true, data });
+    return res.status(200).send({
+      ok: true,
+      data: {
+        _id: data._id,
+        name: data.name,
+        email: data.email,
+        role: data.role,
+        organisation: data.organisation,
+        createdAt: data.createdAt,
+        updatedAt: data.updatedAt,
+      },
+    });
   })
 );
 

--- a/api/yarn.lock
+++ b/api/yarn.lock
@@ -1871,3 +1871,8 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+zod@^3.13.4:
+  version "3.13.4"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.13.4.tgz#5d6fe03ef4824a637d7ef50b5441cf6ab3acede0"
+  integrity sha512-LZRucWt4j/ru5azOkJxCfpR87IyFDn8h2UODdqvXzZLb3K7bb9chUrUIGTy3BPsr8XnbQYfQ5Md5Hu2OYIo1mg==

--- a/dashboard/src/scenes/user/list.js
+++ b/dashboard/src/scenes/user/list.js
@@ -82,13 +82,14 @@ const Create = ({ onChange }) => {
         <ModalHeader toggle={() => setOpen(false)}>Créer un nouvel utilisateur</ModalHeader>
         <ModalBody>
           <Formik
-            initialValues={{ name: '', email: '', role: '' }}
+            initialValues={{ name: '', email: '', role: '', team: [] }}
             validate={(values) => {
               const errors = {};
               if (!values.name) errors.name = 'Le nom est obligatoire';
               if (!values.email) errors.email = "L'email est obligatoire";
               else if (!/^[A-Z0-9._%+-]+@[A-Z0-9.-]+\.[A-Z]{2,}$/i.test(values.email)) errors.email = "L'email est invalide";
               if (!values.role) errors.role = 'Le rôle est obligatoire';
+              if (!values.team?.length) errors.team = 'Veuillez sélectionner une équipe';
               return errors;
             }}
             onSubmit={async (body, actions) => {
@@ -141,6 +142,7 @@ const Create = ({ onChange }) => {
                           value={values.team || []}
                           colored
                         />
+                        {touched.team && errors.team && <Error>{errors.team}</Error>}
                       </div>
                     </FormGroup>
                   </Col>


### PR DESCRIPTION
Cette PR est une preuve de concept sur une seule route avant de commencer à appliquer partout. J'ai décidé d'utiliser Zod pour la validation suite à ces messages (https://twitter.com/rap2h/status/1499313840303099908). Bonus, ce serait encore mieux avec du Typescript mais bon.

L'idée générale (qui est faite sous forme de démo ici) c'est : 
 - On **valide côté back** sans tenir compte de ce qui a été fait côté front.
 - La validation est dans un try/catch au début et **ne donne pas d'information** sur comment faire correctement l'appel à l'API (ce n'est pas une API publique, mais interne)
 - On utilise dans **req.body** que ce qui a déjà été validé (par exemple en déstructurant)
 - On ne se base **pas sur le front** pour obtenir les informations qu'on peut avoir autrement : exemple, on récupérait l'organisation depuis le front alors qu'on ne peut normalement que créer un user dans sa propre orga. Ça ouvrait une faille qui permettait de choisir n'importe quelle organisation
 - On vérifie la cohérence de ce qu'on fait : les teams qu'on peut affecter sont uniquement celles de l'orga précédemment définie (sinon on peut créer des **incohérences**)
 - On ne renvoie que **ce dont on a besoin** dans la réponse (pas le mot de passe  😱  ni l'expiration de connexion)
 - Les validations côté front sont là uniquement pour aider le user à bien remplir son formulaire

A ta dispo pour en parler. Si tu es OK je peux mettre les vérifications partout.
Ensuite il y aura d'autres trucs.