### PR TITLE
fix(app):  app perfs

### DIFF
--- a/api/src/controllers/public.js
+++ b/api/src/controllers/public.js
@@ -11,6 +11,7 @@ const Territory = require("../models/territory");
 const TerritoryObservation = require("../models/territoryObservation");
 const Report = require("../models/report");
 const RelPersonPlace = require("../models/relPersonPlace");
+const { Op } = require("sequelize");
 
 router.get(
   "/stats",
@@ -19,7 +20,7 @@ router.get(
     if (req.query.organisation) query.where = { organisation: req.query.organisation };
     if (Number(req.query.lastRefresh)) {
       if (!query.where) query.where = {};
-      query.where.updatedAt = { $gte: req.query.lastRefresh };
+      query.where.updatedAt = { [Op.gte]: new Date(Number(req.query.lastRefresh)) };
     }
     const places = await Place.count(query);
     const relsPersonPlace = await RelPersonPlace.count(query);

--- a/app/src/components/Loader.js
+++ b/app/src/components/Loader.js
@@ -47,11 +47,11 @@ export const refreshTriggerState = atom({
   },
 });
 
-const mergeItems = (oldItems, newItems) =>
-  [...oldItems, ...newItems].reduce((items, item) => {
-    if (items.find((i) => i?.id === item._id)) return items.map((i) => (i._id === item._id ? item : i));
-    return [...items, item];
-  }, []);
+const mergeItems = (oldItems, newItems) => {
+  const newItemsIds = newItems.map((i) => i._id);
+  const oldItemsPurged = oldItems.filter((i) => !newItemsIds.includes(i._id));
+  return [...oldItemsPurged, ...newItems];
+};
 
 const Loader = () => {
   const [picture, setPicture] = useState([picture1, picture3, picture2][randomIntFromInterval(0, 2)]);
@@ -70,9 +70,6 @@ const Loader = () => {
   const [territoryObservations, setTerritoryObs] = useRecoilState(territoryObservationsState);
   const [comments, setComments] = useRecoilState(commentsState);
   const [refreshTrigger, setRefreshTrigger] = useRecoilState(refreshTriggerState);
-
-  console.log('actions.length', actions.length);
-  console.log('refreshTrigger', refreshTrigger);
 
   useEffect(() => {
     if (refreshTrigger.status === true) {
@@ -99,6 +96,9 @@ const Loader = () => {
       });
       return;
     }
+
+    console.log('response.data.actions', response.data.actions);
+
     let total =
       response.data.actions +
       response.data.persons +
@@ -112,6 +112,7 @@ const Loader = () => {
       const numberOfCollections = 8;
       total = total + numberOfCollections; // for the progress bar to be beautiful
     }
+    console.log('total', total);
     /*
     Get persons
     */

--- a/app/src/components/Loader.js
+++ b/app/src/components/Loader.js
@@ -97,8 +97,6 @@ const Loader = () => {
       return;
     }
 
-    console.log('response.data.actions', response.data.actions);
-
     let total =
       response.data.actions +
       response.data.persons +
@@ -112,7 +110,6 @@ const Loader = () => {
       const numberOfCollections = 8;
       total = total + numberOfCollections; // for the progress bar to be beautiful
     }
-    console.log('total', total);
     /*
     Get persons
     */

--- a/app/src/components/Loader.js
+++ b/app/src/components/Loader.js
@@ -69,8 +69,11 @@ const Loader = () => {
   const [relsPersonPlace, setRelsPersonPlace] = useRecoilState(relsPersonPlaceState);
   const [territoryObservations, setTerritoryObs] = useRecoilState(territoryObservationsState);
   const [comments, setComments] = useRecoilState(commentsState);
-
   const [refreshTrigger, setRefreshTrigger] = useRecoilState(refreshTriggerState);
+
+  console.log('actions.length', actions.length);
+  console.log('refreshTrigger', refreshTrigger);
+
   useEffect(() => {
     if (refreshTrigger.status === true) {
       refresh();
@@ -96,43 +99,53 @@ const Loader = () => {
       });
       return;
     }
-    const total =
-      (response.data.actions || 1) +
-      (response.data.persons || 1) +
-      (response.data.territories || 1) +
-      (response.data.territoryObservations || 1) +
-      (response.data.places || 1) +
-      (response.data.comments || 1) +
-      (response.data.reports || 1) +
-      (response.data.relsPersonPlace || 1);
+    let total =
+      response.data.actions +
+      response.data.persons +
+      response.data.territories +
+      response.data.territoryObservations +
+      response.data.places +
+      response.data.comments +
+      response.data.reports +
+      response.data.relsPersonPlace;
+    if (initialLoad) {
+      const numberOfCollections = 8;
+      total = total + numberOfCollections; // for the progress bar to be beautiful
+    }
     /*
     Get persons
     */
-    setLoading('Chargement des personnes');
-    const refreshedPersons = await getData({
-      collectionName: 'person',
-      data: persons,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newPersons) => setPersons((oldPersons) => (initialLoad ? [...oldPersons, ...newPersons] : mergeItems(oldPersons, newPersons))),
-      API,
-    });
-    if (refreshedPersons) setPersons(refreshedPersons.sort((p1, p2) => p1.name.localeCompare(p2.name)));
+    if (initialLoad || response.data.persons) {
+      setLoading('Chargement des personnes');
+      const refreshedPersons = await getData({
+        collectionName: 'person',
+        data: persons,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newPersons) => setPersons((oldPersons) => (initialLoad ? [...oldPersons, ...newPersons] : mergeItems(oldPersons, newPersons))),
+        API,
+      });
+      if (refreshedPersons) setPersons(refreshedPersons.sort((p1, p2) => p1.name.localeCompare(p2.name)));
+    }
     /*
     Get actions
     */
-    setLoading('Chargement des actions');
-    const refreshedActions = await getData({
-      collectionName: 'action',
-      data: actions,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newActions) => setActions((oldActions) => (initialLoad ? [...oldActions, ...newActions] : mergeItems(oldActions, newActions))),
-      API,
-    });
-    if (refreshedActions) setActions(refreshedActions);
+    if (initialLoad || response.data.actions) {
+      setLoading('Chargement des actions');
+      const refreshedActions = await getData({
+        collectionName: 'action',
+        data: actions,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newActions) => {
+          setActions((oldActions) => (initialLoad ? [...oldActions, ...newActions] : mergeItems(oldActions, newActions)));
+        },
+        API,
+      });
+      if (refreshedActions) setActions(refreshedActions);
+    }
     /*
     Switch to not full screen
     */
@@ -140,72 +153,82 @@ const Loader = () => {
     /*
     Get territories
     */
-    setLoading('Chargement des territoires');
-    const refreshedTerritories = await getData({
-      collectionName: 'territory',
-      data: territories,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newTerritories) =>
-        setTerritories((oldTerritories) => (initialLoad ? [...oldTerritories, ...newTerritories] : mergeItems(oldTerritories, newTerritories))),
-      API,
-    });
-    if (refreshedTerritories) setTerritories(refreshedTerritories);
+    if (initialLoad || response.data.territories) {
+      setLoading('Chargement des territoires');
+      const refreshedTerritories = await getData({
+        collectionName: 'territory',
+        data: territories,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newTerritories) =>
+          setTerritories((oldTerritories) => (initialLoad ? [...oldTerritories, ...newTerritories] : mergeItems(oldTerritories, newTerritories))),
+        API,
+      });
+      if (refreshedTerritories) setTerritories(refreshedTerritories);
+    }
     /*
     Get places
     */
-    setLoading('Chargement des lieux');
-    const refreshedPlaces = await getData({
-      collectionName: 'place',
-      data: places,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newPlaces) => setPlaces((oldPlaces) => (initialLoad ? [...oldPlaces, ...newPlaces] : mergeItems(oldPlaces, newPlaces))),
-      API,
-    });
-    if (refreshedPlaces) setPlaces(refreshedPlaces.sort((p1, p2) => p1.name.localeCompare(p2.name)));
-    const refreshedRelPersonPlaces = await getData({
-      collectionName: 'relPersonPlace',
-      data: relsPersonPlace,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newRelPerPlace) =>
-        setRelsPersonPlace((oldRelPerPlace) => (initialLoad ? [...oldRelPerPlace, ...newRelPerPlace] : mergeItems(oldRelPerPlace, newRelPerPlace))),
-      API,
-    });
-    if (refreshedRelPersonPlaces) setRelsPersonPlace(refreshedRelPersonPlaces);
+    if (initialLoad || response.data.places) {
+      setLoading('Chargement des lieux');
+      const refreshedPlaces = await getData({
+        collectionName: 'place',
+        data: places,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newPlaces) => setPlaces((oldPlaces) => (initialLoad ? [...oldPlaces, ...newPlaces] : mergeItems(oldPlaces, newPlaces))),
+        API,
+      });
+      if (refreshedPlaces) setPlaces(refreshedPlaces.sort((p1, p2) => p1.name.localeCompare(p2.name)));
+    }
+    if (initialLoad || response.data.relsPersonPlace) {
+      const refreshedRelPersonPlaces = await getData({
+        collectionName: 'relPersonPlace',
+        data: relsPersonPlace,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newRelPerPlace) =>
+          setRelsPersonPlace((oldRelPerPlace) => (initialLoad ? [...oldRelPerPlace, ...newRelPerPlace] : mergeItems(oldRelPerPlace, newRelPerPlace))),
+        API,
+      });
+      if (refreshedRelPersonPlaces) setRelsPersonPlace(refreshedRelPersonPlaces);
+    }
     /*
     Get observations territories
     */
-    setLoading('Chargement des observations');
-    const refreshedObs = await getData({
-      collectionName: 'territory-observation',
-      data: territoryObservations,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newObs) => setTerritoryObs((oldObs) => (initialLoad ? [...oldObs, ...newObs] : mergeItems(oldObs, newObs))),
-      API,
-    });
-    if (refreshedObs) setTerritoryObs(refreshedObs);
+    if (initialLoad || response.data.territoryObservations) {
+      setLoading('Chargement des observations');
+      const refreshedObs = await getData({
+        collectionName: 'territory-observation',
+        data: territoryObservations,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newObs) => setTerritoryObs((oldObs) => (initialLoad ? [...oldObs, ...newObs] : mergeItems(oldObs, newObs))),
+        API,
+      });
+      if (refreshedObs) setTerritoryObs(refreshedObs);
+    }
     /*
     Get comments
     */
-    setLoading('Chargement des commentaires');
-    const refreshedComments = await getData({
-      collectionName: 'comment',
-      data: comments,
-      isInitialization: initialLoad,
-      setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
-      lastRefresh,
-      setBatchData: (newComments) =>
-        setComments((oldComments) => (initialLoad ? [...oldComments, ...newComments] : mergeItems(oldComments, newComments))),
-      API,
-    });
-    if (refreshedComments) setComments(refreshedComments);
+    if (initialLoad || response.data.comments) {
+      setLoading('Chargement des commentaires');
+      const refreshedComments = await getData({
+        collectionName: 'comment',
+        data: comments,
+        isInitialization: initialLoad,
+        setProgress: (batch) => setProgress((p) => (p * total + batch) / total),
+        lastRefresh,
+        setBatchData: (newComments) =>
+          setComments((oldComments) => (initialLoad ? [...oldComments, ...newComments] : mergeItems(oldComments, newComments))),
+        API,
+      });
+      if (refreshedComments) setComments(refreshedComments);
+    }
 
     /*
     Reset refresh trigger

--- a/app/src/components/ScreenTitle.js
+++ b/app/src/components/ScreenTitle.js
@@ -28,17 +28,18 @@ const ScreenTitle = ({
   children,
   parentScroll,
   testID = '',
+  forceTop = false,
 }) => {
   const showRightButton = Boolean(onAdd) || Boolean(onEdit) || Boolean(onSave);
   const showLeftButton = showRightButton || Boolean(onBack);
 
   return (
     <>
-      <AnimatedSafeAreaView style={[styles.color(backgroundColor), styles.wrapper(parentScroll)]}>
+      <AnimatedSafeAreaView style={[styles.color(backgroundColor), styles.wrapper(parentScroll, forceTop)]}>
         <StatusBar backgroundColor={backgroundColor} />
-        <Animated.View style={[styles.color(backgroundColor), styles.container]}>
-          <Animated.View style={styles.titleContainer(parentScroll)}>
-            <Animated.View style={[styles.buttonsContainer]} />
+        <Animated.View style={[styles.color(backgroundColor), styles.container(forceTop)]}>
+          <Animated.View style={styles.titleContainer(parentScroll, forceTop)}>
+            {!forceTop && <Animated.View style={[styles.buttonsContainer]} />}
             <Animated.View style={styles.titleCaptionContainer}>
               <Title heavy ellipsizeMode="tail" color={color}>
                 {title}
@@ -101,13 +102,15 @@ const ButtonText = styled(MyText)`
 `;
 
 const styles = StyleSheet.create({
-  wrapper: (parentScroll) => ({
+  wrapper: (parentScroll, forceTop) => ({
     overflow: 'visible',
     zIndex: 100,
-    marginTop: parentScroll?.interpolate ? -90 : 0,
+    marginTop: forceTop ? 0 : parentScroll?.interpolate ? -90 : 0,
     transform: [
       {
-        translateY: parentScroll?.interpolate
+        translateY: forceTop
+          ? 0
+          : parentScroll?.interpolate
           ? parentScroll.interpolate({
               inputRange: [0, 100],
               outputRange: [90, 0],
@@ -117,12 +120,14 @@ const styles = StyleSheet.create({
       },
     ],
   }),
-  titleContainer: (parentScroll) => ({
+  titleContainer: (parentScroll, forceTop) => ({
     justifyContent: 'flex-start',
     alignItems: 'flex-start',
     transform: [
       {
-        translateY: parentScroll?.interpolate
+        translateY: forceTop
+          ? 0
+          : parentScroll?.interpolate
           ? parentScroll.interpolate({
               inputRange: [0, 100],
               outputRange: [0, -90],
@@ -135,11 +140,11 @@ const styles = StyleSheet.create({
   color: (backgroundColor) => ({
     backgroundColor,
   }),
-  container: {
+  container: (forceTop) => ({
     paddingHorizontal: 15,
-    paddingTop: '5%',
-    paddingBottom: '5%',
-  },
+    paddingTop: forceTop ? 0 : '5%',
+    paddingBottom: forceTop ? 0 : '5%',
+  }),
   buttonsContainer: {
     flexDirection: 'row',
     justifyContent: 'space-between',

--- a/app/src/components/Search.js
+++ b/app/src/components/Search.js
@@ -17,7 +17,11 @@ const Search = ({ path, onSearchStart, onSearchClear, onChange, withOrg, onSearc
   const onSearch = async (search) => {
     if (onChange) {
       setSearch(search);
-      return onChange(search);
+      clearTimeout(searchTimeout.current);
+      searchTimeout.current = setTimeout(() => {
+        onChange(search);
+      }, 300);
+      return;
     }
     onSearchStart(search);
     setSearch(search);

--- a/app/src/components/Tabs.js
+++ b/app/src/components/Tabs.js
@@ -10,7 +10,7 @@ const tabsHorizontalMargin = 0.1;
 const tabsWidth = windowWidth * (1 - 2 * tabsHorizontalMargin);
 const tabMarginHorizontal = tabsWidth * 0.02;
 
-const Tabs = ({ state, descriptors, navigation, parentScroll, numberOfTabs, backgroundColor = colors.app.colorDark }) => {
+const Tabs = ({ state, descriptors, navigation, parentScroll, numberOfTabs, forceTop = false, backgroundColor = colors.app.colorDark }) => {
   const indicatorPosition = useRef(new Animated.Value(state.index)).current;
 
   useEffect(() => {
@@ -23,7 +23,7 @@ const Tabs = ({ state, descriptors, navigation, parentScroll, numberOfTabs, back
   }, [state.index]);
   const tabWidth = tabsWidth * ((1 / numberOfTabs) * 0.9);
   return (
-    <Animated.View style={styles.container(parentScroll, backgroundColor)}>
+    <Animated.View style={styles.container(parentScroll, forceTop, backgroundColor)}>
       <Animated.View style={[styles.indicatorStyle(tabWidth), styles.indicatorPosition(indicatorPosition, tabWidth, numberOfTabs)]} />
       {state.routes.map((route, index) => {
         const { options } = descriptors[route.key];
@@ -69,7 +69,7 @@ const Tabs = ({ state, descriptors, navigation, parentScroll, numberOfTabs, back
 };
 
 const styles = StyleSheet.create({
-  container: (parentScroll, backgroundColor) => ({
+  container: (parentScroll, forceTop, backgroundColor) => ({
     height: tabHeight,
     borderRadius: tabHeight,
     overflow: 'hidden',
@@ -81,13 +81,14 @@ const styles = StyleSheet.create({
     flexDirection: 'row',
     transform: [
       {
-        translateY: parentScroll?.interpolate
-          ? parentScroll.interpolate({
-              inputRange: [0, 100],
-              outputRange: [90, 0],
-              extrapolate: 'clamp',
-            })
-          : 0,
+        translateY:
+          parentScroll?.interpolate && !forceTop
+            ? parentScroll.interpolate({
+                inputRange: [0, 100],
+                outputRange: [90, 0],
+                extrapolate: 'clamp',
+              })
+            : 0,
       },
     ],
   }),

--- a/app/src/recoil/selectors.js
+++ b/app/src/recoil/selectors.js
@@ -115,7 +115,7 @@ export const personsSearchSelector = selectorFamily({
     ({ search = '' }) =>
     ({ get }) => {
       const persons = get(personsState);
-      if (!search?.length) return [];
+      if (!search?.length) return persons;
       return filterBySearch(search, persons);
     },
 });
@@ -240,6 +240,17 @@ export const actionsCanceledSelector = selector({
   },
 });
 
+export const actionsByStatusSelector = selectorFamily({
+  key: 'actionsByStatusSelector',
+  get:
+    ({ status }) =>
+    ({ get }) => {
+      if (status === DONE) return get(actionsDoneSelector);
+      if (status === TODO) return get(actionsTodoSelector);
+      if (status === CANCEL) return get(actionsCanceledSelector);
+    },
+});
+
 export const actionsSearchSelector = selectorFamily({
   key: 'actionsSearchSelector',
   get:
@@ -248,34 +259,6 @@ export const actionsSearchSelector = selectorFamily({
       const actions = get(actionsState);
       if (!search?.length) return [];
       return filterBySearch(search, actions);
-    },
-});
-
-export const actionsFullSearchSelector = selectorFamily({
-  key: 'actionsFullSearchSelector',
-  get:
-    ({ status, search = '' }) =>
-    ({ get }) => {
-      const actions = get(actionsForCurrentTeamSelector);
-      let actionsFiltered = actions;
-      if (status) actionsFiltered = actionsFiltered.filter((a) => a.status === status);
-      if (search?.length) {
-        const actionsFilteredIds = actionsFiltered.map((p) => p._id);
-        const comments = get(commentsState);
-        const persons = get(personsWithPlacesSelector);
-        const personsOfFilteredActions = persons.filter((a) => actionsFilteredIds.includes(a.person));
-        const commentsOfFilteredActions = comments.filter((c) => actionsFilteredIds.includes(c.action));
-        const actionsIdsFilteredByActionsSearch = filterBySearch(search, actionsFiltered).map((a) => a._id);
-        const actionsIdsFilteredByActionsCommentsSearch = filterBySearch(search, commentsOfFilteredActions).map((c) => c.action);
-        const personIdsFilteredByPersonsSearch = filterBySearch(search, personsOfFilteredActions).map((p) => p._id);
-        const actionIdsFilteredByPersonsSearch = actionsFiltered.filter((a) => personIdsFilteredByPersonsSearch.includes(a.person));
-
-        const actionsIdsFilterBySearch = [
-          ...new Set([...actionsIdsFilteredByActionsSearch, ...actionsIdsFilteredByActionsCommentsSearch, ...actionIdsFilteredByPersonsSearch]),
-        ];
-        actionsFiltered = actionsFiltered.filter((a) => actionsIdsFilterBySearch.includes(a._id));
-      }
-      return actionsFiltered;
     },
 });
 

--- a/app/src/scenes/Actions/ActionRow.js
+++ b/app/src/scenes/Actions/ActionRow.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useCallback, useMemo } from 'react';
 import styled from 'styled-components';
 import { useRecoilValue } from 'recoil';
 import ButtonRight from '../../components/ButtonRight';
@@ -15,11 +15,20 @@ const ActionRow = ({ onActionPress, onPseudoPress, showStatus, action, withTeamN
   const name = action?.name;
   const status = action?.status;
   const withTime = action?.withTime;
-  const pseudo = action?.personName || action?.person ? persons?.find((p) => p._id === action.person)?.name : null;
+  const person = useMemo(() => (action?.person ? persons?.find((p) => p._id === action.person)?.name : null), [persons, action.person]);
+  const pseudo = useMemo(() => action?.personName || person?.name, [action, person?.name]);
   const dueAt = action?.dueAt ? new Date(action?.dueAt) : null;
 
+  const onPseudoContainerPress = useCallback(() => {
+    onPseudoPress(person);
+  }, [person, onPseudoPress]);
+
+  const onRowPress = useCallback(() => {
+    onActionPress(action);
+  }, [action, onActionPress]);
+
   return (
-    <RowContainer onPress={onActionPress} testID={`${testID}-row-${name?.split(' ').join('-').toLowerCase()}-button`}>
+    <RowContainer onPress={onRowPress} testID={`${testID}-row-${name?.split(' ').join('-').toLowerCase()}-button`}>
       <DateContainer>
         {Boolean(dueAt) && (
           <>
@@ -39,7 +48,7 @@ const ActionRow = ({ onActionPress, onPseudoPress, showStatus, action, withTeamN
             <Status color={colors.app[status === DONE ? 'color' : 'secondary']}>{status}</Status>
           </StatusContainer>
         ) : pseudo ? (
-          <PseudoContainer onPress={onPseudoPress} testID={`${testID}-row-person-${pseudo?.split(' ').join('-').toLowerCase()}-button`}>
+          <PseudoContainer onPress={onPseudoContainerPress} testID={`${testID}-row-person-${pseudo?.split(' ').join('-').toLowerCase()}-button`}>
             <Pseudo>Pour {pseudo}</Pseudo>
           </PseudoContainer>
         ) : null}

--- a/app/src/scenes/Actions/ActionsList.js
+++ b/app/src/scenes/Actions/ActionsList.js
@@ -9,9 +9,9 @@ import { ListEmptyActions, ListNoMoreActions } from '../../components/ListEmptyC
 import FloatAddButton from '../../components/FloatAddButton';
 import { MyText } from '../../components/MyText';
 import FlatListStyled, { SectionListStyled } from '../../components/FlatListStyled';
-import { DONE, TODO, CANCEL } from '../../recoil/actions';
+import { TODO } from '../../recoil/actions';
 import API from '../../services/api';
-import { actionsDoneSelector, actionsTodoSelector, actionsCanceledSelector } from '../../recoil/selectors';
+import { actionsByStatusSelector } from '../../recoil/selectors';
 import { useNavigation, useRoute } from '@react-navigation/native';
 import { refreshTriggerState, loadingState } from '../../components/Loader';
 
@@ -24,15 +24,8 @@ const ActionsList = () => {
   const loading = useRecoilValue(loadingState);
   const status = useRoute().params.status;
   const [refreshTrigger, setRefreshTrigger] = useRecoilState(refreshTriggerState);
-  const actionsDone = useRecoilValue(actionsDoneSelector);
-  const actionsTodo = useRecoilValue(actionsTodoSelector);
-  const actionsCanceled = useRecoilValue(actionsCanceledSelector);
 
-  const actionsByStatus = useMemo(() => {
-    if (status === DONE) return actionsDone;
-    if (status === TODO) return actionsTodo;
-    if (status === CANCEL) return actionsCanceled;
-  }, [actionsCanceled, actionsDone, actionsTodo, status]);
+  const actionsByStatus = useRecoilValue(actionsByStatusSelector({ status }));
 
   useEffect(() => {
     API.navigation = navigation;

--- a/app/src/scenes/Actions/ActionsList.js
+++ b/app/src/scenes/Actions/ActionsList.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo } from 'react';
+import React, { useCallback, useEffect, useMemo } from 'react';
 import styled from 'styled-components';
 import * as Sentry from '@sentry/react-native';
 import { useRecoilState, useRecoilValue } from 'recoil';
@@ -12,108 +12,104 @@ import FlatListStyled, { SectionListStyled } from '../../components/FlatListStyl
 import { DONE, TODO, CANCEL } from '../../recoil/actions';
 import API from '../../services/api';
 import { actionsDoneSelector, actionsTodoSelector, actionsCanceledSelector } from '../../recoil/selectors';
-import { personsState } from '../../recoil/persons';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useRoute } from '@react-navigation/native';
 import { refreshTriggerState, loadingState } from '../../components/Loader';
 
-const ActionsList = ({ status, onScroll, parentScroll }) => {
-  const navigation = useNavigation();
+const emptyArray = [];
+const keyExtractor = (action) => action._id;
+const SectionHeader = ({ section: { title } }) => <SectionHeaderStyled heavy>{title}</SectionHeaderStyled>;
 
+const ActionsList = () => {
+  const navigation = useNavigation();
   const loading = useRecoilValue(loadingState);
+  const status = useRoute().params.status;
   const [refreshTrigger, setRefreshTrigger] = useRecoilState(refreshTriggerState);
   const actionsDone = useRecoilValue(actionsDoneSelector);
   const actionsTodo = useRecoilValue(actionsTodoSelector);
   const actionsCanceled = useRecoilValue(actionsCanceledSelector);
-  const persons = useRecoilValue(personsState);
 
   const actionsByStatus = useMemo(() => {
     if (status === DONE) return actionsDone;
     if (status === TODO) return actionsTodo;
     if (status === CANCEL) return actionsCanceled;
-    return [];
   }, [actionsCanceled, actionsDone, actionsTodo, status]);
 
   useEffect(() => {
     API.navigation = navigation;
   }, [navigation]);
 
-  const onRefresh = async () => {
+  const onRefresh = useCallback(async () => {
     setRefreshTrigger({ status: true, options: { showFullScreen: false, initialLoad: false } });
-  };
+  }, [setRefreshTrigger]);
 
-  const onCreateAction = () => navigation.navigate('NewActionForm', { fromRoute: 'ActionsList' });
+  const onCreateAction = useCallback(() => navigation.navigate('NewActionForm', { fromRoute: 'ActionsList' }), [navigation]);
 
-  const renderSectionHeader = ({ section: { title } }) => <SectionHeader heavy>{title}</SectionHeader>;
+  const ListFooterComponent = useMemo(() => (!actionsByStatus.length ? null : ListNoMoreActions), [actionsByStatus.length]);
+  const ListEmptyComponent = useMemo(() => (loading ? Spinner : ListEmptyActions), [loading]);
 
-  const keyExtractor = (action) => action._id;
-  const ListFooterComponent = () => {
-    if (!actionsByStatus.length) return null;
-    return <ListNoMoreActions />;
-  };
-  const onActionPress = (action) => {
-    Sentry.setContext('action', { _id: action._id });
-    navigation.push('Action', {
-      ...action,
-      fromRoute: 'ActionsList',
-    });
-  };
-  const renderActionRow = ({ item: action }) => (
-    <ActionRow
-      action={action}
-      onPseudoPress={() => {
-        const person = persons.find((p) => action.person === p._id);
-        Sentry.setContext('person', { _id: person._id });
-        navigation.push('Persons', {
-          screen: 'Person',
-          params: { ...person, fromRoute: 'ActionsList' },
-        });
-      }}
-      onActionPress={() => onActionPress(action)}
-    />
+  const onPseudoPress = useCallback(
+    (person) => {
+      Sentry.setContext('person', { _id: person._id });
+      navigation.push('Persons', {
+        screen: 'Person',
+        params: { ...person, fromRoute: 'ActionsList' },
+      });
+    },
+    [navigation]
   );
 
-  const renderSectionsList = () => (
-    <SectionListStyled
-      onScroll={onScroll}
-      refreshing={refreshTrigger.status}
-      onRefresh={onRefresh}
-      sections={actionsByStatus || []}
-      initialNumToRender={5}
-      renderItem={renderActionRow}
-      renderSectionHeader={renderSectionHeader}
-      keyExtractor={keyExtractor}
-      ListEmptyComponent={loading ? Spinner : ListEmptyActions}
-      ListFooterComponent={ListFooterComponent}
-      parentScroll={parentScroll}
-    />
+  const onActionPress = useCallback(
+    (action) => {
+      Sentry.setContext('action', { _id: action._id });
+      navigation.push('Action', {
+        ...action,
+        fromRoute: 'ActionsList',
+      });
+    },
+    [navigation]
   );
 
-  const renderFlatList = () => (
-    <FlatListStyled
-      refreshing={refreshTrigger.status}
-      onScroll={onScroll}
-      onRefresh={onRefresh}
-      data={actionsByStatus}
-      initialNumToRender={5}
-      renderItem={renderActionRow}
-      keyExtractor={keyExtractor}
-      ListEmptyComponent={loading ? Spinner : ListEmptyActions}
-      onEndReachedThreshold={0.3}
-      ListFooterComponent={ListFooterComponent}
-      parentScroll={parentScroll}
-    />
-  );
+  const renderItem = (item) => {
+    return <ActionRow action={item.item} onPseudoPress={onPseudoPress} onActionPress={onActionPress} />;
+  };
 
   return (
     <SceneContainer testID="actions-list">
-      {[TODO].includes(status) && renderSectionsList()}
-      {[DONE, CANCEL].includes(status) && renderFlatList()}
+      {[TODO].includes(status) ? (
+        <SectionListStyled
+          // onScroll={onScroll}
+          refreshing={refreshTrigger.status}
+          onRefresh={onRefresh}
+          sections={actionsByStatus || emptyArray}
+          initialNumToRender={5}
+          renderItem={renderItem}
+          renderSectionHeader={SectionHeader}
+          keyExtractor={keyExtractor}
+          ListEmptyComponent={ListEmptyComponent}
+          ListFooterComponent={ListFooterComponent}
+          // parentScroll={parentScroll}
+        />
+      ) : (
+        <FlatListStyled
+          refreshing={refreshTrigger.status}
+          // onScroll={onScroll}
+          onRefresh={onRefresh}
+          data={actionsByStatus}
+          initialNumToRender={5}
+          renderItem={renderItem}
+          keyExtractor={keyExtractor}
+          ListEmptyComponent={ListEmptyComponent}
+          onEndReachedThreshold={0.3}
+          ListFooterComponent={ListFooterComponent}
+          // parentScroll={parentScroll}
+        />
+      )}
       <FloatAddButton onPress={onCreateAction} />
     </SceneContainer>
   );
 };
 
-const SectionHeader = styled(MyText)`
+const SectionHeaderStyled = styled(MyText)`
   height: 40px;
   line-height: 40px;
   font-size: 25px;

--- a/app/src/scenes/Actions/ActionsTabNavigator.js
+++ b/app/src/scenes/Actions/ActionsTabNavigator.js
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useCallback, useRef } from 'react';
 import { Animated, Platform } from 'react-native';
 import { createMaterialTopTabNavigator } from '@react-navigation/material-top-tabs';
 import SceneContainer from '../../components/SceneContainer';
@@ -10,36 +10,21 @@ import { CANCEL, DONE, TODO } from '../../recoil/actions';
 const TabNavigator = createMaterialTopTabNavigator();
 
 const ActionsTabNavigator = () => {
-  const scrollY = useRef(new Animated.Value(0)).current;
-  const onScroll = Animated.event(
-    [
-      {
-        nativeEvent: {
-          contentOffset: {
-            y: scrollY,
-          },
-        },
-      },
-    ],
-    { useNativeDriver: true }
-  );
   return (
     <SceneContainer>
-      <ScreenTitle title="Agenda" parentScroll={scrollY} />
       <TabNavigator.Navigator
-        tabBar={(props) => <Tabs numberOfTabs={3} parentScroll={scrollY} {...props} />}
+        tabBar={(props) => (
+          <>
+            <ScreenTitle title="Agenda" forceTop />
+            <Tabs numberOfTabs={3} forceTop {...props} />
+          </>
+        )}
         lazy
         removeClippedSubviews={Platform.OS === 'android'}
         swipeEnabled>
-        <TabNavigator.Screen name={TODO} options={{ tabBarLabel: 'À Faire' }}>
-          {(props) => <ActionsList onScroll={onScroll} parentScroll={scrollY} status={TODO} />}
-        </TabNavigator.Screen>
-        <TabNavigator.Screen name={DONE} options={{ tabBarLabel: 'Faites' }}>
-          {(props) => <ActionsList onScroll={onScroll} parentScroll={scrollY} status={DONE} />}
-        </TabNavigator.Screen>
-        <TabNavigator.Screen name={CANCEL} options={{ tabBarLabel: 'Annulées' }}>
-          {(props) => <ActionsList onScroll={onScroll} parentScroll={scrollY} status={CANCEL} />}
-        </TabNavigator.Screen>
+        <TabNavigator.Screen name={TODO} options={{ tabBarLabel: 'À Faire' }} component={ActionsList} initialParams={{ status: TODO }} />
+        <TabNavigator.Screen name={DONE} options={{ tabBarLabel: 'Faites' }} component={ActionsList} initialParams={{ status: DONE }} />
+        <TabNavigator.Screen name={CANCEL} options={{ tabBarLabel: 'Annulées' }} component={ActionsList} initialParams={{ status: CANCEL }} />
       </TabNavigator.Navigator>
     </SceneContainer>
   );

--- a/app/src/scenes/Persons/PersonSummary.js
+++ b/app/src/scenes/Persons/PersonSummary.js
@@ -1,4 +1,4 @@
-import React, { useMemo, useRef } from 'react';
+import React, { useCallback, useMemo, useRef } from 'react';
 import { Alert, findNodeHandle, Linking, Text } from 'react-native';
 import styled from 'styled-components';
 import { connectActionSheet } from '@expo/react-native-action-sheet';
@@ -136,6 +136,17 @@ const PersonSummary = ({
   const comments = useMemo(() => allComments.filter((c) => c.person === personDB?._id), [allComments, personDB?._id]);
 
   const teams = useRecoilValue(teamsState);
+
+  const onActionPress = useCallback(
+    (action) => {
+      Sentry.setContext('action', { _id: action._id });
+      navigation.push('Actions', {
+        screen: 'Action',
+        params: { _id: action._id, fromRoute: 'Person' },
+      });
+    },
+    [navigation]
+  );
 
   return (
     <ScrollContainer ref={scrollViewRef} backgroundColor={backgroundColor || colors.app.color} testID="person-summary">
@@ -280,20 +291,7 @@ const PersonSummary = ({
         testID="person-actions-list"
         data={actions}
         renderItem={(action, index) => (
-          <ActionRow
-            key={index}
-            action={action}
-            showStatus
-            withTeamName
-            testID="person-action"
-            onActionPress={() => {
-              Sentry.setContext('action', { _id: action._id });
-              navigation.push('Actions', {
-                screen: 'Action',
-                params: { _id: action._id, fromRoute: 'Person' },
-              });
-            }}
-          />
+          <ActionRow key={index} action={action} showStatus withTeamName testID="person-action" onActionPress={onActionPress} />
         )}
         ifEmpty="Pas encore d'action"
       />

--- a/app/src/scenes/Persons/PersonsSearch.js
+++ b/app/src/scenes/Persons/PersonsSearch.js
@@ -7,7 +7,7 @@ import { ListEmptyPersons, ListNoMorePersons } from '../../components/ListEmptyC
 import Search from '../../components/Search';
 import FlatListStyled from '../../components/FlatListStyled';
 import { useRecoilState, useRecoilValue } from 'recoil';
-import { personsFullSearchSelector } from '../../recoil/selectors';
+import { personsSearchSelector } from '../../recoil/selectors';
 import { loadingState, refreshTriggerState } from '../../components/Loader';
 
 const PersonsSearch = ({ navigation, route }) => {
@@ -15,7 +15,7 @@ const PersonsSearch = ({ navigation, route }) => {
   const [refreshTrigger, setRefreshTrigger] = useRecoilState(refreshTriggerState);
   const loading = useRecoilState(loadingState);
 
-  const filteredPersons = useRecoilValue(personsFullSearchSelector({ search }));
+  const filteredPersons = useRecoilValue(personsSearchSelector({ search }));
 
   const onRefresh = async () => {
     setRefreshTrigger({ status: true, options: { showFullScreen: false, initialLoad: false } });

--- a/app/src/services/api-interface-with-app.js
+++ b/app/src/services/api-interface-with-app.js
@@ -1,7 +1,6 @@
 import { Alert, Linking, Platform } from 'react-native';
 import { MANO_DOWNLOAD_URL } from '../config';
 import API from './api';
-import { MMKV } from './dataManagement';
 import fetchRetry from 'fetch-retry';
 
 API.fetch = fetchRetry(fetch);
@@ -55,8 +54,6 @@ API.handleWrongKey = () => {
     API.navigation = null;
     API.token = null;
   }
-  MMKV?.clearStore();
-  MMKV?.clearMemoryCache();
 };
 
 API.handleNewVersion = (message) =>


### PR DESCRIPTION
- [ ] fix du refresher coté api
- [ ] loader plus efficace, avec aucune action quand rien à rafraichir, et un merge plus efficace
- [ ] on retire les animations côté Actions pour éviter des rerenders lourds et inutiles
- [ ] timeout sur la recherche de persons pour éviter à recoil des calculs inutiles qui font lagger
- [ ] on garde un sélecteur vénère pour la recherche de personnes sur la tab Personnes (incluant les filtres, les mentions dans les actions, les commentaires, etc.) mais on ne prend qu'un sélecteur sur les personnes lorsqu'il s'agit d'attribuer une action à une personne, puisqu'on peut imaginer que lorsqu'on crée une action pour une personne, on sait pour quelle personne - contrairement à la recherche globale où on peut vouloir rechercher par rapport à un souvenir de je ne sais quoi
- [ ] on utilise `useSelector` de recoil au lieu de `useMemo` pour avoir les listes d'actions par status, parce que leur memoization est bien mieux faite
- [ ] amélioration du component `ActionList` avec moins de inline functions, peut-être inutile mais ça participe probablement à une meilleur performance
- [ ] on arrête le vide du cache quand on se trompe de clé de chiffrement - aucun rapport, mais inutile et frustrant