### PR TITLE
chore: migration from frontend data

### DIFF
--- a/api/src/controllers/migration.js
+++ b/api/src/controllers/migration.js
@@ -1,0 +1,54 @@
+const express = require("express");
+const router = express.Router();
+const passport = require("passport");
+const { z } = require("zod");
+const sequelize = require("../db/sequelize");
+const { catchErrors } = require("../errors");
+const Organisation = require("../models/organisation");
+const validateOrganisationEncryption = require("../middleware/validateOrganisationEncryption");
+const { looseUuidRegex } = require("../utils");
+const { capture } = require("../sentry");
+
+router.put(
+  "/:migrationName",
+  passport.authenticate("user", { session: false }),
+  validateOrganisationEncryption,
+  catchErrors(async (req, res) => {
+    try {
+      z.literal("admin").parse(req.user.role);
+      z.string().regex(looseUuidRegex).parse(req.user.organisation);
+      z.string().min(1).parse(req.params.migrationName);
+    } catch (e) {
+      return res.status(400).send({ ok: false, error: "Invalid request" });
+    }
+
+    const organisation = await Organisation.findOne({ where: { _id: req.user.organisation } });
+    if (!organisation) return res.status(404).send({ ok: false, error: "Not Found" });
+
+    try {
+      await sequelize.transaction(async (tx) => {
+        // Each migration has its own "if". This is an example.
+        if (req.params.migrationName === "passages-from-comments-to-table") {
+          try {
+            z.array(z.string().regex(looseUuidRegex)).parse(req.body.commentIds);
+          } catch (e) {
+            return res.status(400).send({ ok: false, error: "Invalid request" });
+          }
+          for (const _id of actions) {
+            const comment = await Comment.findOne({ where: { _id, organisation: req.user.organisation }, transaction: tx });
+            if (comment) await comment.destroy();
+          }
+        }
+
+        organisation.set({ migrations: [...organisation.migrations, req.params.migrationName] });
+        await organisation.save({ transaction: tx });
+      });
+    } catch (e) {
+      capture("error migrating", e);
+      throw e;
+    }
+    return res.status(200).send({ ok: true });
+  })
+);
+
+module.exports = router;

--- a/api/src/db/migrations/2022-03-07_add_migrations_in_organisation.js
+++ b/api/src/db/migrations/2022-03-07_add_migrations_in_organisation.js
@@ -1,0 +1,6 @@
+const sequelize = require("../sequelize");
+
+sequelize.query(`
+  ALTER TABLE "mano"."Organisation"
+  ADD COLUMN IF NOT EXISTS "migrations" text[];
+`);

--- a/api/src/db/migrations/index.js
+++ b/api/src/db/migrations/index.js
@@ -11,3 +11,4 @@ require("./2021-11-16_observations-as-json");
 require("./2021-11-26-custom-fields-persons");
 require("./2022-02-14-drop-unencrypted-columns");
 require("./2022-02-22-encrypting");
+require("./2022-03-07_add_migrations_in_organisation.js");

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -62,6 +62,7 @@ app.use("/public", require("./controllers/public"));
 app.use("/encrypt", require("./controllers/encrypt"));
 app.use("/category", require("./controllers/category"));
 app.use("/service", require("./controllers/service"));
+app.use("/migration", require("./controllers/migration"));
 
 app.use(errors.sendError);
 

--- a/dashboard/src/components/Loader.js
+++ b/dashboard/src/components/Loader.js
@@ -261,6 +261,16 @@ const Loader = () => {
     setCollectionsToLoad((c) => c.filter((collectionName) => collectionName !== 'comment'));
 
     /*
+    Play organisation internal migrations (things that requires the database to be fully loaded locally).
+    */
+    // if (!organisation.migrations?.includes('passages-from-comments-to-table')) {
+    //   setLoading('Migration des passages');
+    //  // Do something and call API.
+    //  // Then update the organisation.
+    //  await API.put({ path: `/migration/passages-from-comments-to-table`, body: { comments } });
+    // }
+
+    /*
     Reset refresh trigger
     */
     await new Promise((res) => setTimeout(res, 150));


### PR DESCRIPTION
@arnaudambro Je voulais faire la migration des commentaires vers de véritable passage, mais je pense qu'une première étape est de se mettre d'accord sur la façon de faire les migrations maintenant qu'on n'a plus les données. 

D'où cette PR (que je peux jeter). 


 - Chaque organisation a une colonnes `migration` qui contient la liste des migrations faites
 - Côté front, après le chargement des données (donc à la toute fin), dans le loader, on rajoute des `if` pour chaque migration vu qu'elle est de toute façon unique.
   1. Vérification de si la migration est faite : 
   `if (!organisation.migrations?.includes('passages-from-comments-to-table'))`
   2. On met à jour le texte du loader (dont le progres est vers la fin, pas grave) : 
   `setLoading('Migration des passages');` 
   3. On fait les opérations dont on a besoin côté front et on appelle le back: 
   `PUT /migration/passages-from-comments-to-table`
 - Côté back on a une route migration avec des ifs aussi pour chaque migration qui se charge de mettre à jour l'organisation elle-même.
 - De temps en temps on vérifie si toutes les organisations "vivantes" ont bien été migrées et en fonction on supprime le code dont on n'a plus besoin.

Je vois plusieurs problèmes à cette approche : 
 - On est obligé de garder une rétrocompatibilité (un code en double) pour ceux qui ont migré et ceux qui pas. Je n'ai pas de contre proposition pour ça. Chez ForestAdmin c'était la même chose on avait un système de "feature".
 - Étant donné qu'on fait l'opération côté front à la toute fin, potentiellement c'est absurde car on doit tout recharger et refaire un rafracihissment (donc j'ai chargé tous les commentaires, mais en fait il faut que je les recharge). Ça peut-être géré correctement mais ça fait pas mal de code.
 - Le flow n'est pas simple à suivre (le backend donne l'état de l'orga, l'orga se charge, elle regarde s'il faut des migrations, fait ses modifs, appelle le backend avec les choses modifiées, récupère la réponse et se remet à jour si besoin).

Sinon une autre approche : on fait à peu près pareil, on peut faire un espèce de GROS chargement bloquant full screen dans ces cas là... (Configuration de votre organisation, veuillez patienter)