### PR TITLE
fix: fix table sort

### DIFF
--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -78,12 +78,13 @@ const TableCustomFields = ({ data, customFields }) => {
     setIsSubmitting(false);
   };
 
-  const handleSort = async (keys) => {
+  const handleSort = async (keys, currentDataRef) => {
+    // See ./Table.js for more information about currentDataRef.
     setIsSubmitting(true);
     try {
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
-        body: { [customFields]: keys.map((key) => mutableData.find((field) => field.name === key)) },
+        body: { [customFields]: keys.map((key) => currentDataRef.find((field) => field.name === key)) },
       });
       if (response.ok) {
         toastr.success('Mise à jour !');

--- a/dashboard/src/components/table.js
+++ b/dashboard/src/components/table.js
@@ -6,9 +6,22 @@ import { theme } from '../config';
 const Table = ({ columns = [], data = [], rowKey, onRowClick, nullDisplay = '', className, title, noData, isSortable, onSort }) => {
   const gridRef = useRef(null);
   const sortableJsRef = useRef(null);
+  // There was a bug where we can't add a field then re-order the list: `data` is not updated
+  // in `onListChange` callack so the list is partial and re-order fails (or loose fields).
+  // We have to use a Ref for data since data does not react inside `{ onEnd: onListChange }` and is in its old state.
+  // The bug is fixed, via using one more Ref 😱 (a.k.a "this"-ish) that is updated on each data change.
+  // In a near future we should either avoir using Refs or use https://github.com/SortableJS/react-sortablejs instead.
+  // To discuss with @Arnaud.
+  const dataRef = useRef(null);
+  useEffect(() => {
+    dataRef.current = data;
+  }, [data]);
 
   const onListChange = useCallback(() => {
-    onSort([...gridRef.current.children].map((i) => i.dataset.key));
+    onSort(
+      [...gridRef.current.children].map((i) => i.dataset.key),
+      dataRef.current
+    );
   }, [onSort]);
 
   useEffect(() => {


### PR DESCRIPTION
Quand on crée un nouveau champ et qu'on le réorganise dans la foulée, ça fait buguer. j'ai un workaround mais il est vraiment merdique.

Workaround (via whatsapp):
1. Vous créez les champs. Vous ne les réorganisez surtout pas en même temps
2. Quand tous les champs sont créés vous rafraichissez la page(ça devrait vous redemander la clé)
3. Là vous pouvez réorganiser les champs