### PR TITLE
fix(api): password disclosure in sentry

### DIFF
--- a/api/src/sentry.js
+++ b/api/src/sentry.js
@@ -30,11 +30,14 @@ function capture(err, context = {}) {
   if (!!context.extra && typeof context.extra !== "string") {
     try {
       const newExtra = {};
-      for (let extraKey of Object.keys(context.extra)) {
-        if (typeof context.extra[extraKey] === "string") {
-          newExtra[extraKey] = context.extra[extraKey];
+      for (const [extraKey, extraValue] of Object.entries(context.extra)) {
+        if (typeof extraValue === "string") {
+          newExtra[extraKey] = extraValue;
         } else {
-          newExtra[extraKey] = JSON.stringify(context.extra[extraKey]);
+          if (extraValue?.password) {
+            extraValue.password = "******";
+          }
+          newExtra[extraKey] = JSON.stringify(extraValue);
         }
       }
       context.extra = newExtra;


### PR DESCRIPTION
En fait on ne peut pas utiliser le système dédié de sentry (https://docs.sentry.io/platforms/javascript/data-management/sensitive-data/) parce que c'est stringifié avant.