### PR TITLE
chore: remove dataref and setup key to reset sortablejs state

### DIFF
--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -78,13 +78,12 @@ const TableCustomFields = ({ data, customFields }) => {
     setIsSubmitting(false);
   };
 
-  const handleSort = async (keys, currentDataRef) => {
-    // See ./Table.js for more information about currentDataRef.
+  const handleSort = async (keys) => {
     setIsSubmitting(true);
     try {
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
-        body: { [customFields]: keys.map((key) => currentDataRef.find((field) => field.name === key)) },
+        body: { [customFields]: keys.map((key) => mutableData.find((field) => field.name === key)) },
       });
       if (response.ok) {
         toastr.success('Mise à jour !');
@@ -102,6 +101,8 @@ const TableCustomFields = ({ data, customFields }) => {
     <>
       <Table
         data={mutableData}
+        // use this key prop to reset table and reset sortablejs on each element added/removed
+        key={mutableData.length}
         rowKey="name"
         isSortable
         onSort={handleSort}

--- a/dashboard/src/components/table.js
+++ b/dashboard/src/components/table.js
@@ -6,23 +6,13 @@ import { theme } from '../config';
 const Table = ({ columns = [], data = [], rowKey, onRowClick, nullDisplay = '', className, title, noData, isSortable, onSort }) => {
   const gridRef = useRef(null);
   const sortableJsRef = useRef(null);
-  // There was a bug where we can't add a field then re-order the list: `data` is not updated
-  // in `onListChange` callack so the list is partial and re-order fails (or loose fields).
-  // We have to use a Ref for data since data does not react inside `{ onEnd: onListChange }` and is in its old state.
-  // The bug is fixed, via using one more Ref 😱 (a.k.a "this"-ish) that is updated on each data change.
-  // In a near future we should either avoir using Refs or use https://github.com/SortableJS/react-sortablejs instead.
-  // To discuss with @Arnaud.
-  const dataRef = useRef(null);
-  useEffect(() => {
-    dataRef.current = data;
-  }, [data]);
 
   const onListChange = useCallback(() => {
     onSort(
       [...gridRef.current.children].map((i) => i.dataset.key),
-      dataRef.current
+      data
     );
-  }, [onSort]);
+  }, [onSort, data]);
 
   useEffect(() => {
     if (!!isSortable && !!data.length) {


### PR DESCRIPTION
 non. pas que je tenais absolument à modifier ce code, mais j'étais parti sur [Réglage des actions : Bug du tri des catégories d'actions](https://trello.com/c/UJmtrXdK/613-réglage-des-actions-bug-du-tri-des-catégories-dactions) et je me suis attaqué à ça au passage
finalement, le bug du tri n'existe pas !
donc c'est juste du nettoyage de code...