### PR TITLE
fix(app): loose bottom navigation bar

### DIFF
--- a/app/src/Navigators.js
+++ b/app/src/Navigators.js
@@ -49,6 +49,9 @@ const ActionsNavigator = () => {
       <ActionsStack.Screen name="Action" component={Action} />
       <ActionsStack.Screen name="NewActionForm" component={NewActionForm} />
       <ActionsStack.Screen name="ActionComment" component={Comment} />
+
+      <PersonsStack.Screen name="Person" component={Person} />
+      <PersonsStack.Screen name="PersonsSearch" component={PersonsSearch} />
     </ActionsStack.Navigator>
   );
 };
@@ -66,6 +69,9 @@ const PersonsNavigator = () => {
       <PersonsStack.Screen name="PersonPlace" component={Place} />
       <PersonsStack.Screen name="NewPersonPlaceForm" component={NewPlaceForm} />
       <PersonsStack.Screen name="PersonComment" component={Comment} />
+
+      <ActionsStack.Screen name="Action" component={Action} />
+      <ActionsStack.Screen name="NewActionForm" component={NewActionForm} />
     </PersonsStack.Navigator>
   );
 };
@@ -210,8 +216,6 @@ const App = () => {
           <AppStack.Navigator headerMode="none" initialRouteName="LoginStack" screenOptions={{ gestureEnabled: false }}>
             <AppStack.Screen name="LoginStack" component={LoginNavigator} />
             <AppStack.Screen name="Home" component={TabNavigator} />
-            <AppStack.Screen name="Persons" component={PersonsNavigator} />
-            <AppStack.Screen name="Actions" component={ActionsNavigator} />
           </AppStack.Navigator>
           <Loader />
           <EnvironmentIndicator />

--- a/app/src/Navigators.js
+++ b/app/src/Navigators.js
@@ -50,8 +50,12 @@ const ActionsNavigator = () => {
       <ActionsStack.Screen name="NewActionForm" component={NewActionForm} />
       <ActionsStack.Screen name="ActionComment" component={Comment} />
 
-      <PersonsStack.Screen name="Person" component={Person} />
-      <PersonsStack.Screen name="PersonsSearch" component={PersonsSearch} />
+      <ActionsStack.Screen name="Person" component={Person} />
+      <ActionsStack.Screen name="PersonsSearch" component={PersonsSearch} />
+      <ActionsStack.Screen name="PersonsOutOfActiveListReason" component={PersonsOutOfActiveListReason} />
+      <ActionsStack.Screen name="PersonPlace" component={Place} />
+      <ActionsStack.Screen name="NewPersonPlaceForm" component={NewPlaceForm} />
+      <ActionsStack.Screen name="PersonComment" component={Comment} />
     </ActionsStack.Navigator>
   );
 };
@@ -70,8 +74,9 @@ const PersonsNavigator = () => {
       <PersonsStack.Screen name="NewPersonPlaceForm" component={NewPlaceForm} />
       <PersonsStack.Screen name="PersonComment" component={Comment} />
 
-      <ActionsStack.Screen name="Action" component={Action} />
-      <ActionsStack.Screen name="NewActionForm" component={NewActionForm} />
+      <PersonsStack.Screen name="Action" component={Action} />
+      <PersonsStack.Screen name="NewActionForm" component={NewActionForm} />
+      <PersonsStack.Screen name="ActionComment" component={Comment} />
     </PersonsStack.Navigator>
   );
 };

--- a/app/src/scenes/Actions/Action.js
+++ b/app/src/scenes/Actions/Action.js
@@ -146,11 +146,7 @@ const Action = ({ navigation, route }) => {
     ]);
   };
 
-  const onSearchPerson = () =>
-    navigation.push('Persons', {
-      screen: 'PersonsSearch',
-      params: { fromRoute: 'Action' },
-    });
+  const onSearchPerson = () => navigation.push('PersonsSearch', { fromRoute: 'Action' });
 
   const handleBeforeRemove = (e) => {
     if (backRequestHandledRef.current === true) return;

--- a/app/src/scenes/Actions/ActionsList.js
+++ b/app/src/scenes/Actions/ActionsList.js
@@ -54,10 +54,7 @@ const ActionsList = () => {
   const onPseudoPress = useCallback(
     (person) => {
       Sentry.setContext('person', { _id: person._id });
-      navigation.push('Persons', {
-        screen: 'Person',
-        params: { ...person, fromRoute: 'ActionsList' },
-      });
+      navigation.push('Person', { ...person, fromRoute: 'ActionsList' });
     },
     [navigation]
   );

--- a/app/src/scenes/Actions/NewActionForm.js
+++ b/app/src/scenes/Actions/NewActionForm.js
@@ -57,10 +57,7 @@ const NewActionForm = ({ route, navigation }) => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigation, route?.params?.person]);
 
-  const onSearchPerson = () =>
-    navigation.push('PersonsSearch', {
-      fromRoute: 'NewActionForm',
-    });
+  const onSearchPerson = () => navigation.push('PersonsSearch', { fromRoute: 'NewActionForm' });
 
   const onCreateAction = async () => {
     setPosting(true);

--- a/app/src/scenes/Actions/NewActionForm.js
+++ b/app/src/scenes/Actions/NewActionForm.js
@@ -58,9 +58,8 @@ const NewActionForm = ({ route, navigation }) => {
   }, [navigation, route?.params?.person]);
 
   const onSearchPerson = () =>
-    navigation.push('Persons', {
-      screen: 'PersonsSearch',
-      params: { fromRoute: 'NewActionForm' },
+    navigation.push('PersonsSearch', {
+      fromRoute: 'NewActionForm',
     });
 
   const onCreateAction = async () => {

--- a/app/src/scenes/Persons/PersonSummary.js
+++ b/app/src/scenes/Persons/PersonSummary.js
@@ -88,10 +88,7 @@ const PersonSummary = ({
   };
 
   const onAddActionRequest = () => {
-    navigation.push('Actions', {
-      screen: 'NewActionForm',
-      params: { person: personDB?._id, fromRoute: 'Person' },
-    });
+    navigation.push('NewActionForm', { fromRoute: 'Person', person: personDB?._id });
   };
 
   const scrollViewRef = useRef(null);
@@ -141,9 +138,9 @@ const PersonSummary = ({
   const onActionPress = useCallback(
     (action) => {
       Sentry.setContext('action', { _id: action._id });
-      navigation.push('Actions', {
-        screen: 'Action',
-        params: { _id: action._id, fromRoute: 'Person' },
+      navigation.push('Action', {
+        _id: action._id,
+        fromRoute: 'Person',
       });
     },
     [navigation]

--- a/app/src/scenes/Persons/PersonSummary.js
+++ b/app/src/scenes/Persons/PersonSummary.js
@@ -138,10 +138,7 @@ const PersonSummary = ({
   const onActionPress = useCallback(
     (action) => {
       Sentry.setContext('action', { _id: action._id });
-      navigation.push('Action', {
-        _id: action._id,
-        fromRoute: 'Person',
-      });
+      navigation.push('Action', { _id: action._id, fromRoute: 'Person' });
     },
     [navigation]
   );


### PR DESCRIPTION
J'ai refait et j'ai privilégié le fait d'afficher la barre _tout le temps tant que le user n'a pas cliqué expressément_. **Tu peux tout à fait dire que tu n'es pas d'accord, je suis même chaud pour me ranger**. Mais finalement je suis convaincu par ton exemple de twitter, et par la proposition originale que tu avais faite : on reste là où on est.

J'ai l'impression que ça marche.

- Pour faire la correction, j'ai cherché partout où il y avait `screen` pour identifier les pages qui "restaient dans leur univers en partant ailleurs".
- Puis j'ai ajouté ces pages dans les stacks concernées
- J'ai viré les "person" et "action" globaux
- J'ai changé les navigations/push pour "rester au même endroit"

N'hésite pas à dire non ! Ton avis sur ces propositions est cool et tu as vachement plus d'expérience en mobile que moi (en fait c'est même toi qui m'a appris tout en mobile haha)

PS: ça corrige comme par magie https://trello.com/c/VAHgGV5a/609-bug-app-louche