### PR TITLE
feat: custom fields consultation

### DIFF
--- a/api/src/controllers/consultation.js
+++ b/api/src/controllers/consultation.js
@@ -1,0 +1,64 @@
+const express = require("express");
+const router = express.Router();
+const passport = require("passport");
+const { z } = require("zod");
+const sequelize = require("../db/sequelize");
+const { catchErrors } = require("../errors");
+const Organisation = require("../models/organisation");
+const validateEncryptionAndMigrations = require("../middleware/validateEncryptionAndMigrations");
+const { capture } = require("../sentry");
+const validateUser = require("../middleware/validateUser");
+const { looseUuidRegex, customFieldSchema } = require("../utils");
+const Person = require("../models/person");
+
+router.put(
+  "/",
+  passport.authenticate("user", { session: false }),
+  validateUser("admin"),
+  validateEncryptionAndMigrations,
+  catchErrors(async (req, res, next) => {
+    try {
+      z.array(
+        z.object({
+          _id: z.string().regex(looseUuidRegex),
+          encrypted: z.string(),
+          encryptedEntityKey: z.string(),
+        })
+      ).parse(req.body.persons);
+      z.optional(
+        z.array(
+          z.object({
+            name: z.string().min(1),
+            fields: z.array(customFieldSchema),
+          })
+        )
+      ).parse(req.body.consultations);
+    } catch (e) {
+      const error = new Error(`Invalid request in consultation update: ${e}`);
+      error.status = 400;
+      return next(error);
+    }
+
+    const organisation = await Organisation.findOne({ where: { _id: req.user.organisation } });
+    if (!organisation) return res.status(404).send({ ok: false, error: "Not Found" });
+
+    const { persons = [], consulations = [] } = req.body;
+
+    try {
+      await sequelize.transaction(async (tx) => {
+        for (let { encrypted, encryptedEntityKey, _id } of persons) {
+          await Person.update({ encrypted, encryptedEntityKey }, { where: { _id }, transaction: tx });
+        }
+
+        organisation.set({ consulations });
+        await organisation.save({ transaction: tx });
+      });
+    } catch (e) {
+      capture("error updating category", e);
+      throw e;
+    }
+    return res.status(200).send({ ok: true });
+  })
+);
+
+module.exports = router;

--- a/api/src/controllers/consultation.js
+++ b/api/src/controllers/consultation.js
@@ -46,7 +46,7 @@ router.put(
 
     try {
       await sequelize.transaction(async (tx) => {
-        for (let { encrypted, encryptedEntityKey, _id } of persons) {
+        for (const { encrypted, encryptedEntityKey, _id } of persons) {
           await Person.update({ encrypted, encryptedEntityKey }, { where: { _id }, transaction: tx });
         }
 
@@ -54,7 +54,7 @@ router.put(
         await organisation.save({ transaction: tx });
       });
     } catch (e) {
-      capture("error updating category", e);
+      capture("error updating consultation", e);
       throw e;
     }
     return res.status(200).send({ ok: true });

--- a/api/src/controllers/migration.js
+++ b/api/src/controllers/migration.js
@@ -100,6 +100,7 @@ router.put(
         encryptionLastUpdateAt: organisation.encryptionLastUpdateAt,
         receptionEnabled: organisation.receptionEnabled,
         services: organisation.services,
+        consultations: organisation.consultations,
         collaborations: organisation.collaborations,
         customFieldsObs: organisation.customFieldsObs,
         encryptedVerificationKey: organisation.encryptedVerificationKey,

--- a/api/src/controllers/organisation.js
+++ b/api/src/controllers/organisation.js
@@ -15,7 +15,7 @@ const Comment = require("../models/comment");
 const Passage = require("../models/passage");
 const mailservice = require("../utils/mailservice");
 const validateUser = require("../middleware/validateUser");
-const { looseUuidRegex } = require("../utils");
+const { looseUuidRegex, customFieldSchema } = require("../utils");
 const { capture } = require("../sentry");
 
 const JWT_MAX_AGE = 60 * 60 * 3; // 3 hours in s
@@ -140,18 +140,6 @@ router.put(
         z.optional(z.string().min(1)).parse(req.body.name);
         z.optional(z.array(z.string().min(1))).parse(req.body.categories);
         z.optional(z.array(z.string().min(1))).parse(req.body.collaborations);
-        const customFieldSchema = z
-          .object({
-            name: z.string().min(1),
-            type: z.string().min(1),
-            label: z.optional(z.string().min(1)),
-            enabled: z.optional(z.boolean()),
-            required: z.optional(z.boolean()),
-            showInStats: z.optional(z.boolean()),
-            onlyHealthcareProfessional: z.optional(z.boolean()),
-            options: z.optional(z.array(z.string())),
-          })
-          .strict();
         z.optional(z.array(customFieldSchema)).parse(req.body.customFieldsObs);
         z.optional(z.array(customFieldSchema)).parse(req.body.customFieldsPersonsSocial);
         z.optional(z.array(customFieldSchema)).parse(req.body.customFieldsPersonsMedical);

--- a/api/src/controllers/organisation.js
+++ b/api/src/controllers/organisation.js
@@ -155,6 +155,15 @@ router.put(
         z.optional(z.array(customFieldSchema)).parse(req.body.customFieldsObs);
         z.optional(z.array(customFieldSchema)).parse(req.body.customFieldsPersonsSocial);
         z.optional(z.array(customFieldSchema)).parse(req.body.customFieldsPersonsMedical);
+        z.optional(
+          z.array(
+            z.object({
+              name: z.string().min(1),
+              fields: z.array(customFieldSchema),
+            })
+          )
+        ).parse(req.body.consultations);
+
         z.optional(z.string().min(1)).parse(req.body.encryptedVerificationKey);
         z.optional(z.boolean()).parse(req.body.encryptionEnabled);
         if (req.body.encryptionLastUpdateAt) z.preprocess((input) => new Date(input), z.date()).parse(req.body.encryptionLastUpdateAt);
@@ -193,6 +202,8 @@ router.put(
         typeof req.body.customFieldsPersonsMedical === "string"
           ? JSON.parse(req.body.customFieldsPersonsMedical)
           : req.body.customFieldsPersonsMedical;
+    if (req.body.hasOwnProperty("consultations"))
+      updateOrg.consultations = typeof req.body.consultations === "string" ? JSON.parse(req.body.consultations) : req.body.consultations;
     if (req.body.hasOwnProperty("encryptedVerificationKey")) updateOrg.encryptedVerificationKey = req.body.encryptedVerificationKey;
     if (req.body.hasOwnProperty("encryptionEnabled")) updateOrg.encryptionEnabled = req.body.encryptionEnabled;
     if (req.body.hasOwnProperty("encryptionLastUpdateAt")) updateOrg.encryptionLastUpdateAt = req.body.encryptionLastUpdateAt;

--- a/api/src/controllers/user.js
+++ b/api/src/controllers/user.js
@@ -137,6 +137,7 @@ function serializeUserWithTeamsAndOrganisation(user, teams, organisation) {
       createdAt: organisation.createdAt,
       updatedAt: organisation.updatedAt,
       categories: organisation.categories,
+      consultations: organisation.consultations,
       encryptionEnabled: organisation.encryptionEnabled,
       encryptionLastUpdateAt: organisation.encryptionLastUpdateAt,
       receptionEnabled: organisation.receptionEnabled,

--- a/api/src/db/migrations/2022-03-29_add_consultations_columns.js
+++ b/api/src/db/migrations/2022-03-29_add_consultations_columns.js
@@ -1,0 +1,13 @@
+const sequelize = require("../sequelize");
+
+const json = JSON.stringify([
+  { name: "Psychologique", fields: [{ name: "description", type: "textarea", label: "Description", enabled: true, showInStats: false }] },
+  { name: "Infirmier", fields: [{ name: "description", type: "textarea", label: "Description", enabled: true, showInStats: false }] },
+  { name: "Médicale", fields: [{ name: "description", type: "textarea", label: "Description", enabled: true, showInStats: false }] },
+]);
+
+// No injection here, no need to escape.
+sequelize.query(`
+  ALTER TABLE "mano"."Organisation"
+  ADD COLUMN IF NOT EXISTS "consultations" JSONB DEFAULT '${json}'::JSONB;
+`);

--- a/api/src/db/migrations/index.js
+++ b/api/src/db/migrations/index.js
@@ -16,3 +16,4 @@ require("./2022-03-14_add_passage_table");
 require("./2022-03-16-migrating");
 require("./2022-03-17_user_healthcare_professional.js");
 require("./2022-03-21-debug-app-dashboard-user.js");
+require("./2022-03-29_add_consultations_columns.js");

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -72,6 +72,7 @@ app.use("/encrypt", require("./controllers/encrypt"));
 app.use("/category", require("./controllers/category"));
 app.use("/service", require("./controllers/service"));
 app.use("/migration", require("./controllers/migration"));
+app.use("/consultation", require("./controllers/consultation"));
 
 app.use(errors.sendError);
 

--- a/api/src/models/organisation.js
+++ b/api/src/models/organisation.js
@@ -9,6 +9,7 @@ Organisation.init(
     name: DataTypes.TEXT,
     categories: DataTypes.ARRAY(DataTypes.TEXT),
     collaborations: { type: [DataTypes.ARRAY(DataTypes.TEXT)], defaultValue: [] },
+    consultations: DataTypes.JSONB,
     encryptionEnabled: { type: DataTypes.BOOLEAN },
     encryptionLastUpdateAt: DataTypes.DATE,
     encryptedVerificationKey: DataTypes.TEXT,

--- a/api/src/utils.js
+++ b/api/src/utils.js
@@ -1,5 +1,6 @@
 const passwordValidator = require("password-validator");
 const bcrypt = require("bcryptjs");
+const { z } = require("zod");
 
 function validatePassword(password) {
   const schema = new passwordValidator();
@@ -31,6 +32,19 @@ const cryptoHexRegex = /^[A-Fa-f0-9]{16,128}$/;
 const positiveIntegerRegex = /^\d+$/;
 const jwtRegex = /^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$/;
 
+const customFieldSchema = z
+  .object({
+    name: z.string().min(1),
+    type: z.string().min(1),
+    label: z.optional(z.string().min(1)),
+    enabled: z.optional(z.boolean()),
+    required: z.optional(z.boolean()),
+    showInStats: z.optional(z.boolean()),
+    onlyHealthcareProfessional: z.optional(z.boolean()),
+    options: z.optional(z.array(z.string())),
+  })
+  .strict();
+
 module.exports = {
   validatePassword,
   comparePassword,
@@ -39,4 +53,5 @@ module.exports = {
   positiveIntegerRegex,
   cryptoHexRegex,
   jwtRegex,
+  customFieldSchema,
 };

--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -90,8 +90,8 @@ const TableCustomFields = ({
       });
       if (response.ok) {
         toastr.success('Mise à jour !');
-        setOrganisation(response.data);
         setMutableData(extractData ? extractData(response.data[customFields]) : response.data[customFields]);
+        setOrganisation(response.data);
       }
     } catch (orgUpdateError) {
       console.log('error in updating organisation', orgUpdateError);
@@ -104,15 +104,14 @@ const TableCustomFields = ({
     setIsSubmitting(true);
     try {
       const dataForApi = keys.map((key) => mutableData.find((field) => field.name === key));
-      debugger;
       const response = await API.put({
         path: `/organisation/${organisation._id}`,
         body: { [customFields]: mergeData ? mergeData(dataForApi) : dataForApi },
       });
       if (response.ok) {
         toastr.success('Mise à jour !');
-        setOrganisation(response.data);
         setMutableData(extractData ? extractData(response.data[customFields]) : response.data[customFields]);
+        setOrganisation(response.data);
       }
     } catch (orgUpdateError) {
       console.log('error in updating organisation', orgUpdateError);

--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -31,6 +31,7 @@ const TableCustomFields = ({
   mergeData = null,
   extractData = null,
   keyPrefix = null,
+  hideStats = false,
 }) => {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [mutableData, setMutableData] = useState(data);
@@ -177,17 +178,19 @@ const TableCustomFields = ({
                 dataKey: 'onlyHealthcareProfessional',
                 render: (f) => <input type="checkbox" checked={f.onlyHealthcareProfessional} onChange={onOnlyHealthcareProfessionalChange(f)} />,
               },
-          {
-            title: (
-              <>
-                Voir dans les
-                <br />
-                statistiques
-              </>
-            ),
-            dataKey: 'showInStats',
-            render: (f) => <input type="checkbox" checked={f.showInStats} onChange={onShowStatsChange(f)} />,
-          },
+          hideStats
+            ? null
+            : {
+                title: (
+                  <>
+                    Voir dans les
+                    <br />
+                    statistiques
+                  </>
+                ),
+                dataKey: 'showInStats',
+                render: (f) => <input type="checkbox" checked={f.showInStats} onChange={onShowStatsChange(f)} />,
+              },
           {
             title: '',
             dataKey: 'name',

--- a/dashboard/src/recoil/persons.js
+++ b/dashboard/src/recoil/persons.js
@@ -155,6 +155,8 @@ export const outOfActiveListReasonOptions = [
   'Autre',
 ];
 
+export const consultationTypes = ['Psychologique', 'Infirmier', 'Médicale'];
+
 export const defaultMedicalCustomFields = [
   {
     name: 'consumptions',

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -57,6 +57,9 @@ const View = () => {
           <DrawerButton className={tab === 'persons' ? 'active' : ''} onClick={() => setTab('persons')} disabled={!organisation.encryptionEnabled}>
             Personnes suivies
           </DrawerButton>
+          <DrawerButton className={tab === 'consultations' ? 'active' : ''} onClick={() => setTab('consultations')}>
+            Consultations
+          </DrawerButton>
           <DrawerButton className={tab === 'actions' ? 'active' : ''} onClick={() => setTab('actions')}>
             Actions
           </DrawerButton>
@@ -65,9 +68,6 @@ const View = () => {
             onClick={() => setTab('territories')}
             disabled={!organisation.encryptionEnabled}>
             Territoires
-          </DrawerButton>
-          <DrawerButton className={tab === 'consultations' ? 'active' : ''} onClick={() => setTab('consultations')}>
-            Consultations
           </DrawerButton>
           <hr />
           <DrawerButton className={tab === 'export' ? 'active' : ''} onClick={() => setTab('export')}>
@@ -486,7 +486,7 @@ const View = () => {
 };
 
 function Consultations({ handleChange, isSubmitting, handleSubmit }) {
-  const [organisation, setOrganisation] = useRecoilState(organisationState);
+  const organisation = useRecoilValue(organisationState);
   const [consultations, setConsultations] = useState([]);
   const consultationsSortable = useMemo(() => consultations.map((e) => e.name), [consultations]);
   useEffect(() => {
@@ -564,22 +564,9 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
                 customFields="consultations"
                 keyPrefix={consultation.name}
                 mergeData={(newData) => {
-                  console.log(
-                    'mergeData',
-                    newData,
-                    organisation.consultations,
-                    consultations,
-                    organisation.consultations.map((e) => (e.name === consultation.name ? { ...e, fields: newData } : e))
-                  );
                   return organisation.consultations.map((e) => (e.name === consultation.name ? { ...e, fields: newData } : e));
                 }}
                 extractData={(data) => {
-                  console.log(
-                    'extractData',
-                    data,
-                    consultation.name,
-                    data.find((e) => e.name === consultation.name)
-                  );
                   return data.find((e) => e.name === consultation.name).fields || [];
                 }}
                 data={(() => {

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -28,7 +28,7 @@ import useApi, { encryptItem, hashedOrgEncryptionKey } from '../../services/api'
 import ExportData from '../data-import-export/ExportData';
 import ImportData from '../data-import-export/ImportData';
 import DownloadExample from '../data-import-export/DownloadExample';
-import { theme } from '../../config';
+import { ENV, theme } from '../../config';
 import SortableGrid from '../../components/SortableGrid';
 import { prepareReportForEncryption, reportsState } from '../../recoil/reports';
 import { refreshTriggerState } from '../../components/Loader';
@@ -65,9 +65,13 @@ const View = () => {
           <DrawerButton className={tab === 'persons' ? 'active' : ''} onClick={() => setTab('persons')} disabled={!organisation.encryptionEnabled}>
             Personnes suivies
           </DrawerButton>
-          <DrawerButton className={tab === 'consultations' ? 'active' : ''} onClick={() => setTab('consultations')}>
-            Consultations
-          </DrawerButton>
+          {ENV === 'development' ? (
+            <DrawerButton className={tab === 'consultations' ? 'active' : ''} onClick={() => setTab('consultations')}>
+              {' '}
+              Consultations
+            </DrawerButton>
+          ) : null}
+
           <DrawerButton className={tab === 'actions' ? 'active' : ''} onClick={() => setTab('actions')}>
             Actions
           </DrawerButton>

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -492,7 +492,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
   useEffect(() => {
     setConsultations(organisation.consultations);
   }, [organisation, setConsultations]);
-  console.log('anciennes ? ', organisation.consultations);
+  console.log('anciennes ? ', organisation.consultations, consultations);
   return (
     <>
       <SubTitle>Consultations</SubTitle>
@@ -501,6 +501,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
 
         <SortableGrid
           list={consultationsSortable}
+          key={JSON.stringify(consultations)}
           editItemTitle="Changer le nom du type de consultation"
           onUpdateList={(list) => {
             const newConsultations = [];
@@ -545,6 +546,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
           title="Mettre à jour"
           loading={isSubmitting}
           onClick={() => {
+            debugger;
             handleChange({ target: { value: consultations, name: 'consultations' } });
             handleSubmit();
           }}
@@ -562,6 +564,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
             <Row>
               <TableCustomFields
                 customFields="consultations"
+                hideStats
                 keyPrefix={consultation.name}
                 mergeData={(newData) => {
                   return organisation.consultations.map((e) => (e.name === consultation.name ? { ...e, fields: newData } : e));

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -505,7 +505,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
   useEffect(() => {
     setConsultations(organisation.consultations);
   }, [organisation, setConsultations]);
-  console.log('anciennes ? ', organisation.consultations, consultations);
+
   return (
     <>
       <SubTitle>Consultations</SubTitle>
@@ -565,7 +565,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
               });
               handleChange({ target: { value: consultations, name: 'consultations' } });
               setOrganisation({ ...organisation, consultations: newConsultations });
-              toastr.success('Catégorie mise à jour', "Veuillez notifier vos équipes pour qu'elles rechargent leur app ou leur dashboard");
+              toastr.success('Consultation mise à jour', "Veuillez notifier vos équipes pour qu'elles rechargent leur app ou leur dashboard");
             } else {
               toastr.error('Erreur!', "Une erreur inattendue est survenue, l'équipe technique a été prévenue. Désolé !");
             }
@@ -597,6 +597,7 @@ function Consultations({ handleChange, isSubmitting, handleSubmit }) {
         <ButtonCustom
           title="Mettre à jour"
           loading={isSubmitting}
+          disabled={JSON.stringify(organisation.consultations) === JSON.stringify(consultations)}
           onClick={() => {
             handleChange({ target: { value: consultations, name: 'consultations' } });
             handleSubmit();

--- a/dashboard/src/scenes/organisation/view.js
+++ b/dashboard/src/scenes/organisation/view.js
@@ -485,12 +485,14 @@ const View = () => {
   );
 };
 
-function Consultations({ organisation, handleChange, isSubmitting, handleSubmit }) {
+function Consultations({ handleChange, isSubmitting, handleSubmit }) {
+  const [organisation, setOrganisation] = useRecoilState(organisationState);
   const [consultations, setConsultations] = useState([]);
   const consultationsSortable = useMemo(() => consultations.map((e) => e.name), [consultations]);
   useEffect(() => {
     setConsultations(organisation.consultations);
   }, [organisation, setConsultations]);
+  console.log('anciennes ? ', organisation.consultations);
   return (
     <>
       <SubTitle>Consultations</SubTitle>
@@ -566,12 +568,18 @@ function Consultations({ organisation, handleChange, isSubmitting, handleSubmit 
                     'mergeData',
                     newData,
                     organisation.consultations,
+                    consultations,
                     organisation.consultations.map((e) => (e.name === consultation.name ? { ...e, fields: newData } : e))
                   );
                   return organisation.consultations.map((e) => (e.name === consultation.name ? { ...e, fields: newData } : e));
                 }}
                 extractData={(data) => {
-                  console.log(data, consultation.name);
+                  console.log(
+                    'extractData',
+                    data,
+                    consultation.name,
+                    data.find((e) => e.name === consultation.name)
+                  );
                   return data.find((e) => e.name === consultation.name).fields || [];
                 }}
                 data={(() => {

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -288,7 +288,18 @@ export function MedicalFile({ person }) {
             dataKey: 'date',
             render: (e) => (e.date ? formatDateTimeWithNameOfDay(e.date) : ''),
           },
-          { title: 'Description', dataKey: 'name' },
+          {
+            title: 'Description',
+            dataKey: 'name',
+            render: (e) => {
+              return (
+                <>
+                  <div>{e.name}</div>
+                  <small className="text-muted">{e.type}</small>
+                </>
+              );
+            },
+          },
           {
             title: 'Créé par',
             dataKey: 'user',

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -253,10 +253,10 @@ export function MedicalFile({ person }) {
                 _id: uuidv4(),
                 date: new Date(),
                 name: '',
+                type: '',
                 status: 'A FAIRE',
                 user: user._id,
                 onlyVisibleByCreator: false,
-                type: '',
               });
             }}
             color="primary"
@@ -360,16 +360,17 @@ export function MedicalFile({ person }) {
                     <FormGroup>
                       <Label>Type</Label>
                       <SelectCustom
+                        value={{ label: values.type, value: values.type }}
                         onChange={(t) => {
-                          handleChange({ currentTarget: { value: t.value, name: 'consultationType' } });
+                          handleChange({ currentTarget: { value: t.value, name: 'type' } });
                         }}
                         options={organisation.consultations.map((e) => ({ label: e.name, value: e.name }))}
                       />
-                      {touched.consultationType && errors.consultationType && <Error>{errors.consultationType}</Error>}
+                      {touched.type && errors.type && <Error>{errors.type}</Error>}
                     </FormGroup>
                   </Col>
                   {organisation.consultations
-                    .find((e) => e.name === values.consultationType)
+                    .find((e) => e.name === values.type)
                     ?.fields.filter((f) => f.enabled)
                     .map((field) => {
                       return (

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -348,7 +348,6 @@ export function MedicalFile({ person }) {
             }}>
             {({ values, handleChange, handleSubmit, isSubmitting, touched, errors }) => (
               <React.Fragment>
-                {JSON.stringify(values)}
                 <Row>
                   <Col md={6}>
                     <FormGroup>

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -15,7 +15,7 @@ import {
   genderOptions,
   healthInsuranceOptions,
 } from '../../recoil/persons';
-import { usersState, userState } from '../../recoil/auth';
+import { organisationState, usersState, userState } from '../../recoil/auth';
 import { dateForDatePicker, formatDateTimeWithNameOfDay, formatDateWithFullMonth } from '../../services/date';
 import useApi from '../../services/api';
 import SelectAsInput from '../../components/SelectAsInput';
@@ -23,9 +23,11 @@ import CustomFieldInput from '../../components/CustomFieldInput';
 import Table from '../../components/table';
 import SelectStatus from '../../components/SelectStatus';
 import ActionStatus from '../../components/ActionStatus';
+import SelectCustom from '../../components/SelectCustom';
 
 export function MedicalFile({ person }) {
   const setPersons = useSetRecoilState(personsState);
+  const organisation = useRecoilValue(organisationState);
   const [showAddConsultation, setShowAddConsultation] = useState(false);
   const [showAddTreatment, setShowAddTreatment] = useState(false);
   const [currentConsultation, setCurrentConsultation] = useState(null);
@@ -254,6 +256,7 @@ export function MedicalFile({ person }) {
                 status: 'A FAIRE',
                 user: user._id,
                 onlyVisibleByCreator: false,
+                type: '',
               });
             }}
             color="primary"
@@ -344,6 +347,7 @@ export function MedicalFile({ person }) {
             }}>
             {({ values, handleChange, handleSubmit, isSubmitting, touched, errors }) => (
               <React.Fragment>
+                {JSON.stringify(values)}
                 <Row>
                   <Col md={6}>
                     <FormGroup>
@@ -352,6 +356,27 @@ export function MedicalFile({ person }) {
                       {touched.name && errors.name && <Error>{errors.name}</Error>}
                     </FormGroup>
                   </Col>
+                  <Col md={6}>
+                    <FormGroup>
+                      <Label>Type</Label>
+                      <SelectCustom
+                        onChange={(t) => {
+                          handleChange({ currentTarget: { value: t.value, name: 'consultationType' } });
+                        }}
+                        options={organisation.consultations.map((e) => ({ label: e.name, value: e.name }))}
+                      />
+                      {touched.consultationType && errors.consultationType && <Error>{errors.consultationType}</Error>}
+                    </FormGroup>
+                  </Col>
+                  {organisation.consultations
+                    .find((e) => e.name === values.consultationType)
+                    ?.fields.filter((f) => f.enabled)
+                    .map((field) => {
+                      return (
+                        <CustomFieldInput colWidth={6} model="person" values={values} handleChange={handleChange} field={field} key={field.name} />
+                      );
+                    })}
+
                   <Col md={6}>
                     <Label>Statut</Label>
                     <SelectStatus

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -330,6 +330,7 @@ export function MedicalFile({ person }) {
               if (!values.name) errors.name = 'Le nom est obligatoire';
               if (!values.status) errors.status = 'Le statut est obligatoire';
               if (!values.date) errors.date = 'La date est obligatoire';
+              if (!values.type) errors.type = 'Le type est obligatoire';
               return errors;
             }}
             onSubmit={async (values) => {

--- a/tests/src/scripts/db.sql
+++ b/tests/src/scripts/db.sql
@@ -33,6 +33,7 @@ create table if not exists "mano"."Organisation"
     "createdAt"                timestamp with time zone not null,
     "updatedAt"                timestamp with time zone not null,
     categories                 text[],
+    "consultations"            jsonb default '[{ name: "Médicale", fields: [{ name: "description", type: "textarea", label: "Description", enabled: true, showInStats: false }] }]'::jsonb,
     "encryptionEnabled"        boolean default false,
     "encryptionLastUpdateAt"   timestamp with time zone,
     encrypting                 boolean default false,

--- a/tests/src/utils.ts
+++ b/tests/src/utils.ts
@@ -4,7 +4,11 @@ import { v4 as uuidv4 } from "uuid";
 
 const postgresqlUrl = `${process.env.PGBASEURL}/${process.env.PGDATABASE}`;
 
-export async function connectWith(email: string, password: string, orgEncryptionKey: string = "") {
+export async function connectWith(
+  email: string,
+  password: string,
+  orgEncryptionKey: string = ""
+) {
   await page.goto("http://localhost:8090/auth");
   // Ensure not already connected
   try {
@@ -28,7 +32,9 @@ export async function connectWith(email: string, password: string, orgEncryption
 
 // React router seems broken for reason.
 export async function navigateWithReactRouter(path: string = "/search") {
-  return page.$eval("a[href='" + path + "']", (el) => (el as HTMLElement).click());
+  return page.$eval("a[href='" + path + "']", (el) =>
+    (el as HTMLElement).click()
+  );
 }
 
 export async function getInputValue(selector: string) {
@@ -65,7 +71,9 @@ export async function updateUserPassword(email: string, password: string) {
 export async function deleteOrganisation(orgaName: string) {
   const client = new pg.Client(postgresqlUrl);
   await client.connect();
-  await client.query(`DELETE FROM mano."Organisation" WHERE name = $1`, [orgaName]);
+  await client.query(`DELETE FROM mano."Organisation" WHERE name = $1`, [
+    orgaName,
+  ]);
   await client.end();
 }
 
@@ -78,7 +86,9 @@ export async function useSuperAdminAndOrga() {
 
   const date = "2021-01-01";
 
-  await client.query(`delete from mano."Organisation" where name='Default orga'`);
+  await client.query(
+    `delete from mano."Organisation" where name='Default orga'`
+  );
   await client.query(
     `INSERT INTO mano."Organisation" (
       _id,
@@ -145,7 +155,9 @@ export async function useEncryptedOrga() {
 
   const date = "2021-01-01";
 
-  await client.query(`delete from mano."Organisation" where name='Encrypted orga'`);
+  await client.query(
+    `delete from mano."Organisation" where name='Encrypted orga'`
+  );
   await client.query(
     `INSERT INTO mano."Organisation" (
       _id,
@@ -175,7 +187,9 @@ export async function useEncryptedOrga() {
     [orgId, date]
   );
 
-  await client.query(`delete from mano."User" where name='Encrypted Orga Admin'`);
+  await client.query(
+    `delete from mano."User" where name='Encrypted Orga Admin'`
+  );
   await client.query(
     `INSERT INTO mano."User" (
       _id,
@@ -209,7 +223,9 @@ export async function useEncryptedOrga() {
     [userId, bcrypt.hashSync("secret", 10), orgId, date, date]
   );
 
-  await client.query(`delete from mano."Team" where name='Encrypted Orga Team'`);
+  await client.query(
+    `delete from mano."Team" where name='Encrypted Orga Team'`
+  );
   await client.query(
     `INSERT INTO mano."Team" (
       _id,


### PR DESCRIPTION
J'ai ajouté la page de configuration des consultations dans l'onglet organisation. Et ça se répercute sur l'onglet "personnes suivies" -> "dossier médical"). C'est toujours uniquement visible en local. L'organisation a donc maintenant une propriété consultations sous la forme suivante : 

```js
[
  {
    "name": "Psychologique", // Il y a X types de consultations qui ont chacun un "name"
    "fields": [ // A l'intérieur il y a des fields (comme d'habitude)
      {
        "name": "description",
        "type": "textarea",
        "label": "Description",
        "enabled": true,
        "showInStats": false
      }
    ]
  },
  // ...
]
```
Et en fonction de ce qui est défini ça conditionne l'affichage du formulaire au moment où on remplit une consultations... Ça m'a forcé à adapter certains composants pour gérer le nested, j'espère ne pas avoir trop alourdi.

**TOUT est challengeable (défiable ?) dans cette PR (l'implémentation, l'UI, etc.).** C'est avec plaisir que je lirai tes retours !

_PS: Je postpone l'export PDF pour l'instant ça exporte juste la page telle quelle. Mais de toute façon la page est toujours cachée. Il y aura des procaines étapes._