### PR TITLE
feat(dashboard): suggest team association when create person

### DIFF
--- a/dashboard/src/scenes/person/CreatePerson.js
+++ b/dashboard/src/scenes/person/CreatePerson.js
@@ -7,7 +7,7 @@ import { toastr } from 'react-redux-toastr';
 import personIcon from '../../assets/icons/person-icon.svg';
 
 import ButtonCustom from '../../components/ButtonCustom';
-import { currentTeamState, teamsState } from '../../recoil/auth';
+import { currentTeamState } from '../../recoil/auth';
 import {
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,

--- a/dashboard/src/scenes/person/CreatePerson.js
+++ b/dashboard/src/scenes/person/CreatePerson.js
@@ -1,13 +1,13 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React, { useState } from 'react';
-import { Col, Button as LinkButton, FormGroup, Row, Modal, ModalBody, ModalHeader, Input } from 'reactstrap';
+import { Col, Button as LinkButton, FormGroup, Row, Modal, ModalBody, ModalHeader, Input, Label } from 'reactstrap';
 import { useHistory } from 'react-router-dom';
 import { Formik } from 'formik';
 import { toastr } from 'react-redux-toastr';
 import personIcon from '../../assets/icons/person-icon.svg';
 
 import ButtonCustom from '../../components/ButtonCustom';
-import { currentTeamState } from '../../recoil/auth';
+import { currentTeamState, teamsState } from '../../recoil/auth';
 import {
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,
@@ -17,6 +17,7 @@ import {
 import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { refreshTriggerState, loadingState } from '../../components/Loader';
 import useApi from '../../services/api';
+import SelectTeamMultiple from '../../components/SelectTeamMultiple';
 
 const CreatePerson = ({ refreshable }) => {
   const [open, setOpen] = useState(false);
@@ -57,7 +58,7 @@ const CreatePerson = ({ refreshable }) => {
         <ModalHeader toggle={() => setOpen(false)}>Créer une nouvelle personne</ModalHeader>
         <ModalBody>
           <Formik
-            initialValues={{ name: '' }}
+            initialValues={{ name: '', assignedTeams: [currentTeam?._id] }}
             onSubmit={async (body, actions) => {
               const existingPerson = persons.find((p) => p.name === body.name);
               if (existingPerson) return toastr.error('Un utilisateur existe déjà à ce nom');
@@ -79,8 +80,20 @@ const CreatePerson = ({ refreshable }) => {
                 <Row>
                   <Col md={6}>
                     <FormGroup>
-                      <div>Nom</div>
+                      <Label>Nom</Label>
                       <Input name="name" value={values.name} onChange={handleChange} />
+                    </FormGroup>
+                  </Col>
+                  <Col md={6}>
+                    <FormGroup>
+                      <Label>Équipe(s) en charge</Label>
+                      <SelectTeamMultiple
+                        onChange={(teams) => handleChange({ target: { value: teams || [], name: 'assignedTeams' } })}
+                        value={values.assignedTeams}
+                        colored
+                        inputId="person-select-assigned-team"
+                        classNamePrefix="person-select-assigned-team"
+                      />
                     </FormGroup>
                   </Col>
                 </Row>

--- a/tests/src/__tests__/person.test.ts
+++ b/tests/src/__tests__/person.test.ts
@@ -100,7 +100,9 @@ describe("Organisation CRUD", () => {
     await expect(page).toClick("a", { text: "Résumé" });
     await expect(page).toFill('input[name="otherNames"]', "autre nom");
     await expect(page).toClick("input#person-select-gender");
-    await expect(page).toClick("div.person-select-gender__option:nth-of-type(2)");
+    await expect(page).toClick(
+      "div.person-select-gender__option:nth-of-type(2)"
+    );
     await expect(page).toFill("input#person-birthdate", "26/05/1981");
     await page.keyboard.press("Escape");
     await expect(page).toFill("input#person-wanderingAt", "26/04/2005");
@@ -108,22 +110,32 @@ describe("Organisation CRUD", () => {
     await expect(page).toFill("input#person-followedSince", "20/04/2019");
     await page.keyboard.press("Escape");
     await page.keyboard.press("Escape");
-    await expect(page).toClick("input#person-select-assigned-team");
-    await expect(page).toClick("div.person-select-assigned-team__option");
     await expect(page).toClick("input#person-alertness-checkbox");
     await expect(page).toFill('input[name="phone"]', "0123456789");
-    await expect(page).toFill('textarea[name="description"]', "Une chic personne");
+    await expect(page).toFill(
+      'textarea[name="description"]',
+      "Une chic personne"
+    );
     await expect(page).toClick("input#person-select-personalSituation");
-    await expect(page).toClick("div.person-select-personalSituation__option:nth-of-type(2)");
-    await expect(page).toFill('input[name="structureSocial"]', "Une structure sociale");
+    await expect(page).toClick(
+      "div.person-select-personalSituation__option:nth-of-type(2)"
+    );
+    await expect(page).toFill(
+      'input[name="structureSocial"]',
+      "Une structure sociale"
+    );
     await expect(page).toClick("input#person-select-animals");
     await expect(page).toClick("div.person-select-animals__option");
     await expect(page).toClick("input#person-select-address");
     await expect(page).toClick("div.person-select-address__option");
     await expect(page).toClick("input#person-select-addressDetail");
-    await expect(page).toClick("div.person-select-addressDetail__option:nth-of-type(4)");
+    await expect(page).toClick(
+      "div.person-select-addressDetail__option:nth-of-type(4)"
+    );
     await expect(page).toClick("input#person-select-nationalitySituation");
-    await expect(page).toClick("div.person-select-nationalitySituation__option");
+    await expect(page).toClick(
+      "div.person-select-nationalitySituation__option"
+    );
     await expect(page).toClick("input#person-select-employment");
     await expect(page).toClick("div.person-select-employment__option");
     await expect(page).toClick("input#person-select-resources");
@@ -134,8 +146,14 @@ describe("Organisation CRUD", () => {
     await expect(page).toClick("div.person-select-healthInsurance__option");
     await expect(page).toClick("input#person-custom-select-consumptions");
     await expect(page).toClick("div.person-custom-select-consumptions__option");
-    await expect(page).toFill('input[name="structureMedical"]', "Une structure médicale");
-    await expect(page).toFill('textarea[name="caseHistoryDescription"]', "Mon historique médical");
+    await expect(page).toFill(
+      'input[name="structureMedical"]',
+      "Une structure médicale"
+    );
+    await expect(page).toFill(
+      'textarea[name="caseHistoryDescription"]',
+      "Mon historique médical"
+    );
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await expect(page).toMatch("Mis à jour !");
     await expect(page).toClick("div.close-toastr");
@@ -150,15 +168,21 @@ describe("Organisation CRUD", () => {
   it("should see created person all fields", async () => {
     await navigateWithReactRouter("/person");
     await expect(page).toClick("td", { text: "Ma première personne" });
-    expect(await getInputValue('input[name="name"]')).toBe("Ma première personne");
+    expect(await getInputValue('input[name="name"]')).toBe(
+      "Ma première personne"
+    );
     expect(await getInputValue('input[name="otherNames"]')).toBe("autre nom");
-    expect(await getInnerText("div.person-select-gender__single-value")).toBe("Homme");
+    expect(await getInnerText("div.person-select-gender__single-value")).toBe(
+      "Homme"
+    );
     expect(await getInputValue("input#person-birthdate")).toBe("26/05/1981");
     expect(await getInputValue("input#person-wanderingAt")).toBe("26/04/2005");
-    expect(await getInputValue("input#person-followedSince")).toBe("20/04/2019");
-    expect(await getInnerText("div.person-select-assigned-team__multi-value__label")).toBe(
-      "Encrypted Orga Team"
+    expect(await getInputValue("input#person-followedSince")).toBe(
+      "20/04/2019"
     );
+    expect(
+      await getInnerText("div.person-select-assigned-team__multi-value__label")
+    ).toBe("Encrypted Orga Team");
     expect(
       await page
         .$('input[name="alertness"]')
@@ -166,29 +190,47 @@ describe("Organisation CRUD", () => {
         .then((value) => value?.jsonValue())
     ).toBe(true);
     expect(await getInputValue('input[name="phone"]')).toBe("0123456789");
-    expect(await getInputValue('textarea[name="description"]')).toBe("Une chic personne");
-    expect(await getInnerText("div.person-select-personalSituation__single-value")).toBe(
-      "Homme isolé"
+    expect(await getInputValue('textarea[name="description"]')).toBe(
+      "Une chic personne"
     );
-    expect(await getInputValue('input[name="structureSocial"]')).toBe("Une structure sociale");
-    expect(await getInnerText("div.person-select-animals__single-value")).toBe("Oui");
-    expect(await getInnerText("div.person-select-address__single-value")).toBe("Oui");
-    expect(await getInnerText("div.person-select-addressDetail__single-value")).toBe(
-      "Mise à l'abri"
+    expect(
+      await getInnerText("div.person-select-personalSituation__single-value")
+    ).toBe("Homme isolé");
+    expect(await getInputValue('input[name="structureSocial"]')).toBe(
+      "Une structure sociale"
     );
-    expect(await getInnerText("div.person-select-nationalitySituation__single-value")).toBe(
-      "Hors UE"
+    expect(await getInnerText("div.person-select-animals__single-value")).toBe(
+      "Oui"
     );
-    expect(await getInnerText("div.person-select-employment__single-value")).toBe("DPH");
-    expect(await getInnerText("div.person-select-resources__multi-value__label")).toBe("SANS");
-    expect(await getInnerText("div.person-select-reasons__multi-value__label")).toBe(
-      "Sortie d'hébergement"
+    expect(await getInnerText("div.person-select-address__single-value")).toBe(
+      "Oui"
     );
-    expect(await getInnerText("div.person-select-healthInsurance__single-value")).toBe("Aucune");
-    expect(await getInnerText("div.person-custom-select-consumptions__multi-value__label")).toBe(
-      "Alcool"
+    expect(
+      await getInnerText("div.person-select-addressDetail__single-value")
+    ).toBe("Mise à l'abri");
+    expect(
+      await getInnerText("div.person-select-nationalitySituation__single-value")
+    ).toBe("Hors UE");
+    expect(
+      await getInnerText("div.person-select-employment__single-value")
+    ).toBe("DPH");
+    expect(
+      await getInnerText("div.person-select-resources__multi-value__label")
+    ).toBe("SANS");
+    expect(
+      await getInnerText("div.person-select-reasons__multi-value__label")
+    ).toBe("Sortie d'hébergement");
+    expect(
+      await getInnerText("div.person-select-healthInsurance__single-value")
+    ).toBe("Aucune");
+    expect(
+      await getInnerText(
+        "div.person-custom-select-consumptions__multi-value__label"
+      )
+    ).toBe("Alcool");
+    expect(await getInputValue('input[name="structureMedical"]')).toBe(
+      "Une structure médicale"
     );
-    expect(await getInputValue('input[name="structureMedical"]')).toBe("Une structure médicale");
     expect(await getInputValue('textarea[name="caseHistoryDescription"]')).toBe(
       "Mon historique médical"
     );
@@ -231,7 +273,10 @@ describe("Organisation CRUD", () => {
     await expect(page).toClick("a", { text: "Commentaires (1)" });
     await expect(page).toClick("button", { text: "Ajouter un commentaire" });
     await expect(page).toMatch("Créer un commentaire", { timeout: 4000 });
-    await expect(page).toFill('textarea[name="comment"]', "Ceci est un commentaire");
+    await expect(page).toFill(
+      'textarea[name="comment"]',
+      "Ceci est un commentaire"
+    );
     await expect(page).toClick("button", { text: "Sauvegarder" });
     await expect(page).toClick("div.close-toastr");
     await expect(page).toMatch("Ceci est un commentaire");
@@ -243,7 +288,10 @@ describe("Organisation CRUD", () => {
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", { text: "Ajouter un commentaire" });
     await expect(page).toMatch("Créer un commentaire", { timeout: 4000 });
-    await expect(page).toFill('textarea[name="comment"]', "Ceci est un autre commentaire");
+    await expect(page).toFill(
+      'textarea[name="comment"]',
+      "Ceci est un autre commentaire"
+    );
     await expect(page).toClick("button", { text: "Sauvegarder" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("div.close-toastr");
@@ -258,7 +306,9 @@ describe("Organisation CRUD", () => {
   it("should add a place", async () => {
     await navigateWithReactRouter("/place");
     await page.waitForTimeout(1000);
-    await expect(page).toClick("button", { text: "Créer un nouveau lieu fréquenté" });
+    await expect(page).toClick("button", {
+      text: "Créer un nouveau lieu fréquenté",
+    });
     await page.waitForTimeout(1000);
     await expect(page).toFill("input#create-place-name", "Mon lieu fréquenté");
     await expect(page).toClick("button#create-place-button");
@@ -295,15 +345,21 @@ describe("Organisation CRUD", () => {
     await expect(page).toClick("td", { text: "Ma première personne" });
     // await scrollTop();
     /* Summary */
-    expect(await getInputValue('input[name="name"]')).toBe("Ma première personne");
+    expect(await getInputValue('input[name="name"]')).toBe(
+      "Ma première personne"
+    );
     expect(await getInputValue('input[name="otherNames"]')).toBe("autre nom");
-    expect(await getInnerText("div.person-select-gender__single-value")).toBe("Homme");
+    expect(await getInnerText("div.person-select-gender__single-value")).toBe(
+      "Homme"
+    );
     expect(await getInputValue("input#person-birthdate")).toBe("26/05/1981");
     expect(await getInputValue("input#person-wanderingAt")).toBe("26/04/2005");
-    expect(await getInputValue("input#person-followedSince")).toBe("20/04/2019");
-    expect(await getInnerText("div.person-select-assigned-team__multi-value__label")).toBe(
-      "Encrypted Orga Team"
+    expect(await getInputValue("input#person-followedSince")).toBe(
+      "20/04/2019"
     );
+    expect(
+      await getInnerText("div.person-select-assigned-team__multi-value__label")
+    ).toBe("Encrypted Orga Team");
     expect(
       await page
         .$('input[name="alertness"]')
@@ -311,29 +367,47 @@ describe("Organisation CRUD", () => {
         .then((value) => value?.jsonValue())
     ).toBe(true);
     expect(await getInputValue('input[name="phone"]')).toBe("0123456789");
-    expect(await getInputValue('textarea[name="description"]')).toBe("Une chic personne");
-    expect(await getInnerText("div.person-select-personalSituation__single-value")).toBe(
-      "Homme isolé"
+    expect(await getInputValue('textarea[name="description"]')).toBe(
+      "Une chic personne"
     );
-    expect(await getInputValue('input[name="structureSocial"]')).toBe("Une structure sociale");
-    expect(await getInnerText("div.person-select-animals__single-value")).toBe("Oui");
-    expect(await getInnerText("div.person-select-address__single-value")).toBe("Oui");
-    expect(await getInnerText("div.person-select-addressDetail__single-value")).toBe(
-      "Mise à l'abri"
+    expect(
+      await getInnerText("div.person-select-personalSituation__single-value")
+    ).toBe("Homme isolé");
+    expect(await getInputValue('input[name="structureSocial"]')).toBe(
+      "Une structure sociale"
     );
-    expect(await getInnerText("div.person-select-nationalitySituation__single-value")).toBe(
-      "Hors UE"
+    expect(await getInnerText("div.person-select-animals__single-value")).toBe(
+      "Oui"
     );
-    expect(await getInnerText("div.person-select-employment__single-value")).toBe("DPH");
-    expect(await getInnerText("div.person-select-resources__multi-value__label")).toBe("SANS");
-    expect(await getInnerText("div.person-select-reasons__multi-value__label")).toBe(
-      "Sortie d'hébergement"
+    expect(await getInnerText("div.person-select-address__single-value")).toBe(
+      "Oui"
     );
-    expect(await getInnerText("div.person-select-healthInsurance__single-value")).toBe("Aucune");
-    expect(await getInnerText("div.person-custom-select-consumptions__multi-value__label")).toBe(
-      "Alcool"
+    expect(
+      await getInnerText("div.person-select-addressDetail__single-value")
+    ).toBe("Mise à l'abri");
+    expect(
+      await getInnerText("div.person-select-nationalitySituation__single-value")
+    ).toBe("Hors UE");
+    expect(
+      await getInnerText("div.person-select-employment__single-value")
+    ).toBe("DPH");
+    expect(
+      await getInnerText("div.person-select-resources__multi-value__label")
+    ).toBe("SANS");
+    expect(
+      await getInnerText("div.person-select-reasons__multi-value__label")
+    ).toBe("Sortie d'hébergement");
+    expect(
+      await getInnerText("div.person-select-healthInsurance__single-value")
+    ).toBe("Aucune");
+    expect(
+      await getInnerText(
+        "div.person-custom-select-consumptions__multi-value__label"
+      )
+    ).toBe("Alcool");
+    expect(await getInputValue('input[name="structureMedical"]')).toBe(
+      "Une structure médicale"
     );
-    expect(await getInputValue('input[name="structureMedical"]')).toBe("Une structure médicale");
     expect(await getInputValue('textarea[name="caseHistoryDescription"]')).toBe(
       "Mon historique médical"
     );
@@ -361,7 +435,9 @@ describe("Organisation CRUD", () => {
     await expect(page).toClick("button", { text: "Sortie de file active" });
     await expect(page).toMatch("Veuillez préciser le motif de sortie");
     await expect(page).toClick("input#person-select-outOfActiveListReason");
-    await expect(page).toClick("div.person-select-outOfActiveListReason__option");
+    await expect(page).toClick(
+      "div.person-select-outOfActiveListReason__option"
+    );
     await expect(page).toClick("button", { text: "Sauvegarder" });
     await expect(page).toMatch("Mise à jour réussie");
     await expect(page).toClick("div.close-toastr");
@@ -372,7 +448,9 @@ describe("Organisation CRUD", () => {
     );
     await expect(page).toClick("a", { text: "Retour" });
     await expect(page).toMatch("Ma première personne");
-    await expect(page).toMatch("Sortie de file active : Relai vers autre structure");
+    await expect(page).toMatch(
+      "Sortie de file active : Relai vers autre structure"
+    );
   });
 
   it("should be able to put back in active list", async () => {
@@ -388,7 +466,9 @@ describe("Organisation CRUD", () => {
     await expect(page).toMatch(
       "Ma première personne est en dehors de la file active, pour le motif suivant : Relai vers autre structure"
     );
-    await expect(page).toClick("button", { text: "Réintégrer dans la file active" });
+    await expect(page).toClick("button", {
+      text: "Réintégrer dans la file active",
+    });
     await expect(page).toMatch("Mise à jour réussie");
     await expect(page).toClick("div.close-toastr");
   });
@@ -419,7 +499,9 @@ describe("Organisation CRUD", () => {
   it("should be able to see the action in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format(
+        "dddd D MMMM YYYY"
+      )} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toMatch("Mon action");
   });
@@ -427,13 +509,19 @@ describe("Organisation CRUD", () => {
   it("should be able to add a passage", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format(
+        "dddd D MMMM YYYY"
+      )} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toClick("input#person-select-and-create-reception");
-    await expect(page).toClick("div.person-select-and-create-reception__option");
-    expect(await getInnerText("div.person-select-and-create-reception__multi-value__label")).toBe(
-      "!Ma première personne"
+    await expect(page).toClick(
+      "div.person-select-and-create-reception__option"
     );
+    expect(
+      await getInnerText(
+        "div.person-select-and-create-reception__multi-value__label"
+      )
+    ).toBe("!Ma première personne");
     await expect(page).toClick("button", { text: "Ajouter un passage" });
     await page.waitForTimeout(1000);
     expect(await getInnerText("span#number-of-passages")).toBe("1");


### PR DESCRIPTION
<img width="877" alt="Capture d’écran 2022-04-01 à 08 55 06" src="https://user-images.githubusercontent.com/1575946/161211342-93c9b865-ff03-41c1-a47a-19bbc3e28b75.png">

Ça m'a aussi permis de repérer un bug que je vais corriger après : https://github.com/SocialGouv/mano/issues/558

Choix de design : j'ai directement proposé un selecteur rempli par défaut plutôt que de rattacher en coulisses pour éviter les comportements cachés ("ah bon ça associe à ma team, mais je ne veux pas moi... et surtout j'avais pas compris") et les questions plus tard ("alors en fait pour telle orga ils trouvent que le rattachement auto à la team en cours n'est pas adapté, ils voudraient un fonctionnement différent. Là ils sont obligé de créer puis éditer ensuite ...")

Ticket : https://trello.com/c/whdgxuCR/625-en-tant-quutilisateur-jai-besoin-que-le-dossier-de-la-personne-suivie-soit-automatiquement-assign%C3%A9e-%C3%A0-l%C3%A9quipe-avec-lauqelle-il-a

Pour l'instant c'est la partie dashboard, je fais une PR pour l'app.