### PR TITLE
chore: remove item field in comment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1949 +1,2273 @@
 ## [1.83.1](https://github.com/SocialGouv/mano/compare/v1.83.0...v1.83.1) (2022-04-01)
 
+
 ### Bug Fixes
 
-- user should not be able to delete themselves ([#568](https://github.com/SocialGouv/mano/issues/568)) ([1ba98da](https://github.com/SocialGouv/mano/commit/1ba98da11bd89defaadb38c49507f2c07ab549ca))
+* user should not be able to delete themselves ([#568](https://github.com/SocialGouv/mano/issues/568)) ([1ba98da](https://github.com/SocialGouv/mano/commit/1ba98da11bd89defaadb38c49507f2c07ab549ca))
 
 # [1.83.0](https://github.com/SocialGouv/mano/compare/v1.82.0...v1.83.0) (2022-04-01)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix 566 ([3921130](https://github.com/SocialGouv/mano/commit/39211308b98f39612c57c1286d3e2d674eaf9465))
+* **dashboard:** fix 566 ([3921130](https://github.com/SocialGouv/mano/commit/39211308b98f39612c57c1286d3e2d674eaf9465))
+
 
 ### Features
 
-- **app:** update mobile version ([5367191](https://github.com/SocialGouv/mano/commit/53671912a4939829677e8ba17cbbafb9c57f8a78))
+* **app:** update mobile version ([5367191](https://github.com/SocialGouv/mano/commit/53671912a4939829677e8ba17cbbafb9c57f8a78))
 
 # [1.82.0](https://github.com/SocialGouv/mano/compare/v1.81.3...v1.82.0) (2022-04-01)
 
+
 ### Features
 
-- **app:** suggest team association when create person ([#560](https://github.com/SocialGouv/mano/issues/560)) ([67af25e](https://github.com/SocialGouv/mano/commit/67af25ead8cf33d34d843bab83a16fc6db626d27))
+* **app:** suggest team association when create person ([#560](https://github.com/SocialGouv/mano/issues/560)) ([67af25e](https://github.com/SocialGouv/mano/commit/67af25ead8cf33d34d843bab83a16fc6db626d27))
 
 ## [1.81.3](https://github.com/SocialGouv/mano/compare/v1.81.2...v1.81.3) (2022-04-01)
 
+
 ### Bug Fixes
 
-- **app:** loose bottom navigation bar ([#546](https://github.com/SocialGouv/mano/issues/546)) ([97c23cd](https://github.com/SocialGouv/mano/commit/97c23cd91219009c31d30060473633a379a634d1))
+* **app:** loose bottom navigation bar ([#546](https://github.com/SocialGouv/mano/issues/546)) ([97c23cd](https://github.com/SocialGouv/mano/commit/97c23cd91219009c31d30060473633a379a634d1))
 
 ## [1.81.2](https://github.com/SocialGouv/mano/compare/v1.81.1...v1.81.2) (2022-03-30)
 
+
 ### Bug Fixes
 
-- **dash:** sanitize custom field ([#554](https://github.com/SocialGouv/mano/issues/554)) ([21ea43c](https://github.com/SocialGouv/mano/commit/21ea43c1371c7184a55ab2220619c5df42492cfa))
+* **dash:** sanitize custom field ([#554](https://github.com/SocialGouv/mano/issues/554)) ([21ea43c](https://github.com/SocialGouv/mano/commit/21ea43c1371c7184a55ab2220619c5df42492cfa))
 
 ## [1.81.1](https://github.com/SocialGouv/mano/compare/v1.81.0...v1.81.1) (2022-03-30)
 
+
 ### Bug Fixes
 
-- **api:** add onlyHealthcareProfessional to checked fields ([#553](https://github.com/SocialGouv/mano/issues/553)) ([00550b6](https://github.com/SocialGouv/mano/commit/00550b647e2f98d14385cd50879aacd8a26eab58))
+* **api:** add onlyHealthcareProfessional to checked fields ([#553](https://github.com/SocialGouv/mano/issues/553)) ([00550b6](https://github.com/SocialGouv/mano/commit/00550b647e2f98d14385cd50879aacd8a26eab58))
 
 # [1.81.0](https://github.com/SocialGouv/mano/compare/v1.80.1...v1.81.0) (2022-03-28)
 
+
 ### Features
 
-- **dashboard,app:** only healthcare professional ([#543](https://github.com/SocialGouv/mano/issues/543)) ([64ff190](https://github.com/SocialGouv/mano/commit/64ff190c3ca79e2a91716745b7f213e7c03e20f8))
+* **dashboard,app:** only healthcare professional ([#543](https://github.com/SocialGouv/mano/issues/543)) ([64ff190](https://github.com/SocialGouv/mano/commit/64ff190c3ca79e2a91716745b7f213e7c03e20f8))
 
 ## [1.80.1](https://github.com/SocialGouv/mano/compare/v1.80.0...v1.80.1) (2022-03-28)
 
+
 ### Bug Fixes
 
-- **app:** ignore noisy errors for mobile ([#539](https://github.com/SocialGouv/mano/issues/539)) ([156a2c2](https://github.com/SocialGouv/mano/commit/156a2c2c32260ae0a607ca40640e581ec32d9bf1))
+* **app:** ignore noisy errors for mobile ([#539](https://github.com/SocialGouv/mano/issues/539)) ([156a2c2](https://github.com/SocialGouv/mano/commit/156a2c2c32260ae0a607ca40640e581ec32d9bf1))
 
 # [1.80.0](https://github.com/SocialGouv/mano/compare/v1.79.9...v1.80.0) (2022-03-25)
 
+
 ### Features
 
-- **dashboard:** add autre to outOfActiveListReasonOptions ([86ea129](https://github.com/SocialGouv/mano/commit/86ea129d3e2c5ff6b07211122a3c5b6e768728b3))
+* **dashboard:** add autre to outOfActiveListReasonOptions ([86ea129](https://github.com/SocialGouv/mano/commit/86ea129d3e2c5ff6b07211122a3c5b6e768728b3))
 
 ## [1.79.9](https://github.com/SocialGouv/mano/compare/v1.79.8...v1.79.9) (2022-03-25)
 
+
 ### Bug Fixes
 
-- **dashboard:** completedAt was overridden ([83dbd18](https://github.com/SocialGouv/mano/commit/83dbd18ff75dab4e606c898cba5625fe0fe7b281))
+* **dashboard:** completedAt was overridden ([83dbd18](https://github.com/SocialGouv/mano/commit/83dbd18ff75dab4e606c898cba5625fe0fe7b281))
 
 ## [1.79.8](https://github.com/SocialGouv/mano/compare/v1.79.7...v1.79.8) (2022-03-25)
 
+
 ### Bug Fixes
 
-- **dashboard:** sanitize imports ([#530](https://github.com/SocialGouv/mano/issues/530)) ([a4fed0e](https://github.com/SocialGouv/mano/commit/a4fed0ea6b2c5b54cebbe93dba22166499ebcf00))
+* **dashboard:** sanitize imports ([#530](https://github.com/SocialGouv/mano/issues/530)) ([a4fed0e](https://github.com/SocialGouv/mano/commit/a4fed0ea6b2c5b54cebbe93dba22166499ebcf00))
 
 ## [1.79.7](https://github.com/SocialGouv/mano/compare/v1.79.6...v1.79.7) (2022-03-24)
 
+
 ### Bug Fixes
 
-- **api:** trigger api release ([31d35df](https://github.com/SocialGouv/mano/commit/31d35dffc1beffe7dd6f5db29b227c852a898534))
-- **app,dashboard,api:** remove ability to PUT createdAt of comment ([#503](https://github.com/SocialGouv/mano/issues/503)) ([dfde586](https://github.com/SocialGouv/mano/commit/dfde586bb068188cae984714fff2a9443787950a))
-- **dashboard:** editingField may exist but not have options ([15a6dd5](https://github.com/SocialGouv/mano/commit/15a6dd582ed99aa6321875e19511423f4ee78a81))
-- migrations not activated yet in app ([#529](https://github.com/SocialGouv/mano/issues/529)) ([c5cb5bd](https://github.com/SocialGouv/mano/commit/c5cb5bd5f8c28fb196e2e6c357f55c8b59771442))
+* **api:** trigger api release ([31d35df](https://github.com/SocialGouv/mano/commit/31d35dffc1beffe7dd6f5db29b227c852a898534))
+* **app,dashboard,api:** remove ability to PUT createdAt of comment ([#503](https://github.com/SocialGouv/mano/issues/503)) ([dfde586](https://github.com/SocialGouv/mano/commit/dfde586bb068188cae984714fff2a9443787950a))
+* **dashboard:** editingField may exist but not have options ([15a6dd5](https://github.com/SocialGouv/mano/commit/15a6dd582ed99aa6321875e19511423f4ee78a81))
+* migrations not activated yet in app ([#529](https://github.com/SocialGouv/mano/issues/529)) ([c5cb5bd](https://github.com/SocialGouv/mano/commit/c5cb5bd5f8c28fb196e2e6c357f55c8b59771442))
 
 ## [1.79.6](https://github.com/SocialGouv/mano/compare/v1.79.5...v1.79.6) (2022-03-24)
 
+
 ### Bug Fixes
 
-- normal user also can migrate ([d3a14be](https://github.com/SocialGouv/mano/commit/d3a14be71ab8261c1b823161da0c0e80e844df63))
+* normal user also can migrate ([d3a14be](https://github.com/SocialGouv/mano/commit/d3a14be71ab8261c1b823161da0c0e80e844df63))
 
 ## [1.79.5](https://github.com/SocialGouv/mano/compare/v1.79.4...v1.79.5) (2022-03-24)
 
+
 ### Bug Fixes
 
-- **dashboard:** import crashed with team after [#487](https://github.com/SocialGouv/mano/issues/487) refactor ([14a2bae](https://github.com/SocialGouv/mano/commit/14a2baefbae53cafc6d9d13c6c792fa1e7c389e8))
+* **dashboard:** import crashed with team after [#487](https://github.com/SocialGouv/mano/issues/487) refactor ([14a2bae](https://github.com/SocialGouv/mano/commit/14a2baefbae53cafc6d9d13c6c792fa1e7c389e8))
 
 ## [1.79.4](https://github.com/SocialGouv/mano/compare/v1.79.3...v1.79.4) (2022-03-23)
 
+
 ### Bug Fixes
 
-- **dashboard:** prevent reports updating non stop ([#518](https://github.com/SocialGouv/mano/issues/518)) ([19ea779](https://github.com/SocialGouv/mano/commit/19ea779a3170704648d4186bbcc489a93d85aee3))
+* **dashboard:** prevent reports updating non stop ([#518](https://github.com/SocialGouv/mano/issues/518)) ([19ea779](https://github.com/SocialGouv/mano/commit/19ea779a3170704648d4186bbcc489a93d85aee3))
 
 ## [1.79.3](https://github.com/SocialGouv/mano/compare/v1.79.2...v1.79.3) (2022-03-23)
 
+
 ### Bug Fixes
 
-- **dashboard:** number of comments ([#517](https://github.com/SocialGouv/mano/issues/517)) ([f974537](https://github.com/SocialGouv/mano/commit/f974537235e70acc9983f3788ee2e2b6f23fb1d5))
+* **dashboard:** number of comments ([#517](https://github.com/SocialGouv/mano/issues/517)) ([f974537](https://github.com/SocialGouv/mano/commit/f974537235e70acc9983f3788ee2e2b6f23fb1d5))
 
 ## [1.79.2](https://github.com/SocialGouv/mano/compare/v1.79.1...v1.79.2) (2022-03-23)
 
+
 ### Bug Fixes
 
-- **dashboard:** bugs related to new passage migration ([#516](https://github.com/SocialGouv/mano/issues/516)) ([a05fd7d](https://github.com/SocialGouv/mano/commit/a05fd7d1324d41a3255217329d1fb5fbd14c0ffc))
+* **dashboard:**  bugs related to new passage migration ([#516](https://github.com/SocialGouv/mano/issues/516)) ([a05fd7d](https://github.com/SocialGouv/mano/commit/a05fd7d1324d41a3255217329d1fb5fbd14c0ffc))
 
 ## [1.79.1](https://github.com/SocialGouv/mano/compare/v1.79.0...v1.79.1) (2022-03-23)
 
+
 ### Bug Fixes
 
-- cors update to include tauri ([#515](https://github.com/SocialGouv/mano/issues/515)) ([b634df0](https://github.com/SocialGouv/mano/commit/b634df061d455289160ab226d09cb397b9fa581d))
+* cors update to include tauri ([#515](https://github.com/SocialGouv/mano/issues/515)) ([b634df0](https://github.com/SocialGouv/mano/commit/b634df061d455289160ab226d09cb397b9fa581d))
 
 # [1.79.0](https://github.com/SocialGouv/mano/compare/v1.78.2...v1.79.0) (2022-03-22)
 
+
 ### Features
 
-- **api,dashboard:** passages migration cherry picked ([#493](https://github.com/SocialGouv/mano/issues/493)) ([32b940e](https://github.com/SocialGouv/mano/commit/32b940e7a10261a9cd20b0e05601b66f0970ac49))
+* **api,dashboard:**  passages migration cherry picked ([#493](https://github.com/SocialGouv/mano/issues/493)) ([32b940e](https://github.com/SocialGouv/mano/commit/32b940e7a10261a9cd20b0e05601b66f0970ac49))
 
 ## [1.78.2](https://github.com/SocialGouv/mano/compare/v1.78.1...v1.78.2) (2022-03-21)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix am-pm dates ([#513](https://github.com/SocialGouv/mano/issues/513)) ([1cb83d0](https://github.com/SocialGouv/mano/commit/1cb83d034d3e3db638c72d90bb58d24c425007df))
+* **dashboard:** fix am-pm dates ([#513](https://github.com/SocialGouv/mano/issues/513)) ([1cb83d0](https://github.com/SocialGouv/mano/commit/1cb83d034d3e3db638c72d90bb58d24c425007df))
 
 ## [1.78.1](https://github.com/SocialGouv/mano/compare/v1.78.0...v1.78.1) (2022-03-21)
 
+
 ### Bug Fixes
 
-- **app:** delete person confirm in app ([#498](https://github.com/SocialGouv/mano/issues/498)) ([3b206a5](https://github.com/SocialGouv/mano/commit/3b206a5681b9842c538a54f9783e51c19cf6b661))
+* **app:** delete person confirm in app ([#498](https://github.com/SocialGouv/mano/issues/498)) ([3b206a5](https://github.com/SocialGouv/mano/commit/3b206a5681b9842c538a54f9783e51c19cf6b661))
 
 # [1.78.0](https://github.com/SocialGouv/mano/compare/v1.77.0...v1.78.0) (2022-03-21)
 
+
 ### Features
 
-- **dashboard:** improve browser support ([#494](https://github.com/SocialGouv/mano/issues/494)) ([d2c75d5](https://github.com/SocialGouv/mano/commit/d2c75d5e3f6ad7069f5674c7754690115ad1b74e))
+* **dashboard:** improve browser support ([#494](https://github.com/SocialGouv/mano/issues/494)) ([d2c75d5](https://github.com/SocialGouv/mano/commit/d2c75d5e3f6ad7069f5674c7754690115ad1b74e))
 
 # [1.77.0](https://github.com/SocialGouv/mano/compare/v1.76.1...v1.77.0) (2022-03-21)
 
+
 ### Features
 
-- add healthcare professional property on users ([#492](https://github.com/SocialGouv/mano/issues/492)) ([417f65b](https://github.com/SocialGouv/mano/commit/417f65b6d6a42dac5b345b0bc37c40a1898799bd))
+* add healthcare professional property on users ([#492](https://github.com/SocialGouv/mano/issues/492)) ([417f65b](https://github.com/SocialGouv/mano/commit/417f65b6d6a42dac5b345b0bc37c40a1898799bd))
 
 ## [1.76.1](https://github.com/SocialGouv/mano/compare/v1.76.0...v1.76.1) (2022-03-18)
 
+
 ### Bug Fixes
 
-- **app:** can delete territory ([#499](https://github.com/SocialGouv/mano/issues/499)) ([210d623](https://github.com/SocialGouv/mano/commit/210d623289d0aa2fadb1ef3771978a221541fad4))
+* **app:** can delete territory ([#499](https://github.com/SocialGouv/mano/issues/499)) ([210d623](https://github.com/SocialGouv/mano/commit/210d623289d0aa2fadb1ef3771978a221541fad4))
 
 # [1.76.0](https://github.com/SocialGouv/mano/compare/v1.75.0...v1.76.0) (2022-03-17)
 
+
 ### Features
 
-- **dashboard:** warning before delete person ([#491](https://github.com/SocialGouv/mano/issues/491)) ([4617e05](https://github.com/SocialGouv/mano/commit/4617e053211ba7d88647d0dc324c916f95313e72))
+* **dashboard:** warning before delete person ([#491](https://github.com/SocialGouv/mano/issues/491)) ([4617e05](https://github.com/SocialGouv/mano/commit/4617e053211ba7d88647d0dc324c916f95313e72))
 
 # [1.75.0](https://github.com/SocialGouv/mano/compare/v1.74.0...v1.75.0) (2022-03-17)
 
+
 ### Features
 
-- **dashboard:** remove abstractions ([#487](https://github.com/SocialGouv/mano/issues/487)) ([d4a7566](https://github.com/SocialGouv/mano/commit/d4a75665f0fb37e5445919f2490868225b2469a0))
+* **dashboard:**  remove abstractions ([#487](https://github.com/SocialGouv/mano/issues/487)) ([d4a7566](https://github.com/SocialGouv/mano/commit/d4a75665f0fb37e5445919f2490868225b2469a0))
 
 # [1.74.0](https://github.com/SocialGouv/mano/compare/v1.73.1...v1.74.0) (2022-03-16)
 
+
 ### Features
 
-- **dashboard:** outdated version checker ([#485](https://github.com/SocialGouv/mano/issues/485)) ([2a46d17](https://github.com/SocialGouv/mano/commit/2a46d1783948dc254f1551f1adfb03d2e84c01cc))
+* **dashboard:** outdated version checker ([#485](https://github.com/SocialGouv/mano/issues/485)) ([2a46d17](https://github.com/SocialGouv/mano/commit/2a46d1783948dc254f1551f1adfb03d2e84c01cc))
 
 ## [1.73.1](https://github.com/SocialGouv/mano/compare/v1.73.0...v1.73.1) (2022-03-16)
 
+
 ### Bug Fixes
 
-- **api:** password disclosure in sentry ([#486](https://github.com/SocialGouv/mano/issues/486)) ([80827e1](https://github.com/SocialGouv/mano/commit/80827e11948b0d14ef359f9996f1480f276dc4ba))
+* **api:** password disclosure in sentry ([#486](https://github.com/SocialGouv/mano/issues/486)) ([80827e1](https://github.com/SocialGouv/mano/commit/80827e11948b0d14ef359f9996f1480f276dc4ba))
 
 # [1.73.0](https://github.com/SocialGouv/mano/compare/v1.72.2...v1.73.0) (2022-03-15)
 
+
 ### Features
 
-- **dashboard:** show version in drawer ([#484](https://github.com/SocialGouv/mano/issues/484)) ([b8d2ad0](https://github.com/SocialGouv/mano/commit/b8d2ad048ac37f028a9e5069583f36b8281aa6d7))
+* **dashboard:** show version in drawer ([#484](https://github.com/SocialGouv/mano/issues/484)) ([b8d2ad0](https://github.com/SocialGouv/mano/commit/b8d2ad048ac37f028a9e5069583f36b8281aa6d7))
 
 ## [1.72.2](https://github.com/SocialGouv/mano/compare/v1.72.1...v1.72.2) (2022-03-14)
 
+
 ### Bug Fixes
 
-- **dashboard:** boolean custom field display ([#477](https://github.com/SocialGouv/mano/issues/477)) ([c0d35b1](https://github.com/SocialGouv/mano/commit/c0d35b13636b3ad7cca530d2bd0b52c20a2238dd))
+* **dashboard:** boolean custom field display ([#477](https://github.com/SocialGouv/mano/issues/477)) ([c0d35b1](https://github.com/SocialGouv/mano/commit/c0d35b13636b3ad7cca530d2bd0b52c20a2238dd))
 
 ## [1.72.1](https://github.com/SocialGouv/mano/compare/v1.72.0...v1.72.1) (2022-03-14)
 
+
 ### Bug Fixes
 
-- **dashboard:** outOfActiveList message ([76ac7a0](https://github.com/SocialGouv/mano/commit/76ac7a076bbca9ce92430a2e6a7682ea1820345e))
+* **dashboard:** outOfActiveList message ([76ac7a0](https://github.com/SocialGouv/mano/commit/76ac7a076bbca9ce92430a2e6a7682ea1820345e))
 
 # [1.72.0](https://github.com/SocialGouv/mano/compare/v1.71.26...v1.72.0) (2022-03-14)
 
+
 ### Features
 
-- **dashboard:** link to q&a ([#483](https://github.com/SocialGouv/mano/issues/483)) ([5485214](https://github.com/SocialGouv/mano/commit/54852140aa695ecd4b4ac8f23e61bec592c76d71))
+* **dashboard:** link to q&a ([#483](https://github.com/SocialGouv/mano/issues/483)) ([5485214](https://github.com/SocialGouv/mano/commit/54852140aa695ecd4b4ac8f23e61bec592c76d71))
 
 ## [1.71.26](https://github.com/SocialGouv/mano/compare/v1.71.25...v1.71.26) (2022-03-14)
 
+
 ### Bug Fixes
 
-- **dashboard:** enable/disable reception ([#482](https://github.com/SocialGouv/mano/issues/482)) ([ffbce3f](https://github.com/SocialGouv/mano/commit/ffbce3f62c0f53c860daaa9449a76cc5326dbdcb))
+* **dashboard:** enable/disable reception ([#482](https://github.com/SocialGouv/mano/issues/482)) ([ffbce3f](https://github.com/SocialGouv/mano/commit/ffbce3f62c0f53c860daaa9449a76cc5326dbdcb))
 
 ## [1.71.25](https://github.com/SocialGouv/mano/compare/v1.71.24...v1.71.25) (2022-03-11)
 
+
 ### Bug Fixes
 
-- **dashboard:** reports date team ([#476](https://github.com/SocialGouv/mano/issues/476)) ([0c99d1c](https://github.com/SocialGouv/mano/commit/0c99d1ccd805767b40261e4de58e8d34a3e24496))
+* **dashboard:**  reports date team ([#476](https://github.com/SocialGouv/mano/issues/476)) ([0c99d1c](https://github.com/SocialGouv/mano/commit/0c99d1ccd805767b40261e4de58e8d34a3e24496))
 
 ## [1.71.24](https://github.com/SocialGouv/mano/compare/v1.71.23...v1.71.24) (2022-03-11)
 
+
 ### Bug Fixes
 
-- **api:** capture invalid requests ([#478](https://github.com/SocialGouv/mano/issues/478)) ([e580208](https://github.com/SocialGouv/mano/commit/e5802089a8ec36b96556a413af7e5b7373cbafd1))
+* **api:** capture invalid requests ([#478](https://github.com/SocialGouv/mano/issues/478)) ([e580208](https://github.com/SocialGouv/mano/commit/e5802089a8ec36b96556a413af7e5b7373cbafd1))
 
 ## [1.71.23](https://github.com/SocialGouv/mano/compare/v1.71.22...v1.71.23) (2022-03-11)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix "optimization" ([d9509ac](https://github.com/SocialGouv/mano/commit/d9509ace1cc36bb5c92e8817fb4083dc58af938b))
+* **dashboard:** fix "optimization" ([d9509ac](https://github.com/SocialGouv/mano/commit/d9509ace1cc36bb5c92e8817fb4083dc58af938b))
 
 ## [1.71.22](https://github.com/SocialGouv/mano/compare/v1.71.21...v1.71.22) (2022-03-11)
 
+
 ### Bug Fixes
 
-- **app:** value if null ([#473](https://github.com/SocialGouv/mano/issues/473)) ([0953851](https://github.com/SocialGouv/mano/commit/095385103ab34dcf3ee588c6ef498b484299e487))
+* **app:** value if null ([#473](https://github.com/SocialGouv/mano/issues/473)) ([0953851](https://github.com/SocialGouv/mano/commit/095385103ab34dcf3ee588c6ef498b484299e487))
 
 ## [1.71.21](https://github.com/SocialGouv/mano/compare/v1.71.20...v1.71.21) (2022-03-11)
 
+
 ### Bug Fixes
 
-- **dashboard:** change signin process ([#471](https://github.com/SocialGouv/mano/issues/471)) ([69f5011](https://github.com/SocialGouv/mano/commit/69f50114f12df1f7a5cdd5da7d6f85de21115200))
+* **dashboard:** change signin process ([#471](https://github.com/SocialGouv/mano/issues/471)) ([69f5011](https://github.com/SocialGouv/mano/commit/69f50114f12df1f7a5cdd5da7d6f85de21115200))
 
 ## [1.71.20](https://github.com/SocialGouv/mano/compare/v1.71.19...v1.71.20) (2022-03-10)
 
+
 ### Bug Fixes
 
-- fix table sort ([#458](https://github.com/SocialGouv/mano/issues/458)) ([09dd5f7](https://github.com/SocialGouv/mano/commit/09dd5f769480a612541d520df80c498709ee2505))
+* fix table sort ([#458](https://github.com/SocialGouv/mano/issues/458)) ([09dd5f7](https://github.com/SocialGouv/mano/commit/09dd5f769480a612541d520df80c498709ee2505))
 
 ## [1.71.19](https://github.com/SocialGouv/mano/compare/v1.71.18...v1.71.19) (2022-03-10)
 
+
 ### Bug Fixes
 
-- **api:** validate actual body ([33415cb](https://github.com/SocialGouv/mano/commit/33415cbdb88e5a1ff29976cd768141f0f7244933))
+* **api:** validate actual body ([33415cb](https://github.com/SocialGouv/mano/commit/33415cbdb88e5a1ff29976cd768141f0f7244933))
 
 ## [1.71.18](https://github.com/SocialGouv/mano/compare/v1.71.17...v1.71.18) (2022-03-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** delete custom field ([d97889a](https://github.com/SocialGouv/mano/commit/d97889af5ab9cb4edf2da3d7eb3708f784d4c86e))
+* **dashboard:** delete custom field ([d97889a](https://github.com/SocialGouv/mano/commit/d97889af5ab9cb4edf2da3d7eb3708f784d4c86e))
 
 ## [1.71.17](https://github.com/SocialGouv/mano/compare/v1.71.16...v1.71.17) (2022-03-10)
 
+
 ### Bug Fixes
 
-- **dahsboard:** fix #MANO-64 ([454f396](https://github.com/SocialGouv/mano/commit/454f396ab256a24ac76980caece84a83fab0ebf2)), closes [#MANO-64](https://github.com/SocialGouv/mano/issues/MANO-64)
+* **dahsboard:** fix #MANO-64 ([454f396](https://github.com/SocialGouv/mano/commit/454f396ab256a24ac76980caece84a83fab0ebf2)), closes [#MANO-64](https://github.com/SocialGouv/mano/issues/MANO-64)
 
 ## [1.71.16](https://github.com/SocialGouv/mano/compare/v1.71.15...v1.71.16) (2022-03-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix #MANO-9M ([#456](https://github.com/SocialGouv/mano/issues/456)) ([c88432d](https://github.com/SocialGouv/mano/commit/c88432de6bcaaa4ee1df9fad7c9e50e6482f7394)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+* **dashboard:** fix #MANO-9M ([#456](https://github.com/SocialGouv/mano/issues/456)) ([c88432d](https://github.com/SocialGouv/mano/commit/c88432de6bcaaa4ee1df9fad7c9e50e6482f7394)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.15](https://github.com/SocialGouv/mano/compare/v1.71.14...v1.71.15) (2022-03-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix #MANO-9K ([b10ab24](https://github.com/SocialGouv/mano/commit/b10ab24f1a189fa4c0c13eba9c805d4c5b0d583f)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+* **dashboard:** fix #MANO-9K ([b10ab24](https://github.com/SocialGouv/mano/commit/b10ab24f1a189fa4c0c13eba9c805d4c5b0d583f)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.14](https://github.com/SocialGouv/mano/compare/v1.71.13...v1.71.14) (2022-03-10)
 
+
 ### Bug Fixes
 
-- super admin connexion ([6397210](https://github.com/SocialGouv/mano/commit/63972106d7d32007b1c82b667a4a8e1a3aeb94ad))
+* super admin connexion ([6397210](https://github.com/SocialGouv/mano/commit/63972106d7d32007b1c82b667a4a8e1a3aeb94ad))
 
 ## [1.71.13](https://github.com/SocialGouv/mano/compare/v1.71.12...v1.71.13) (2022-03-08)
 
+
 ### Bug Fixes
 
-- **security:** remove injection in structure search ([332c722](https://github.com/SocialGouv/mano/commit/332c72263e4d27910cd4d0d81a6caa1f32aa7566))
+* **security:** remove injection in structure search ([332c722](https://github.com/SocialGouv/mano/commit/332c72263e4d27910cd4d0d81a6caa1f32aa7566))
 
 ## [1.71.12](https://github.com/SocialGouv/mano/compare/v1.71.11...v1.71.12) (2022-03-08)
 
+
 ### Bug Fixes
 
-- **app:** release version ([195f5a9](https://github.com/SocialGouv/mano/commit/195f5a9a5233a773822aec5a6ea2bd868b5d0862))
+* **app:** release version ([195f5a9](https://github.com/SocialGouv/mano/commit/195f5a9a5233a773822aec5a6ea2bd868b5d0862))
 
 ## [1.71.11](https://github.com/SocialGouv/mano/compare/v1.71.10...v1.71.11) (2022-03-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix #MANO-9J ([a68255b](https://github.com/SocialGouv/mano/commit/a68255bf7adf7cc6754bd759f10982ae2bc80f02)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+* **dashboard:** fix #MANO-9J ([a68255b](https://github.com/SocialGouv/mano/commit/a68255bf7adf7cc6754bd759f10982ae2bc80f02)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.10](https://github.com/SocialGouv/mano/compare/v1.71.9...v1.71.10) (2022-03-08)
 
+
 ### Bug Fixes
 
-- **app:** fix #MANO-9F ([7f66699](https://github.com/SocialGouv/mano/commit/7f666993707422c0c8277b93c77663ca77133428)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+* **app:** fix #MANO-9F ([7f66699](https://github.com/SocialGouv/mano/commit/7f666993707422c0c8277b93c77663ca77133428)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.9](https://github.com/SocialGouv/mano/compare/v1.71.8...v1.71.9) (2022-03-08)
 
+
 ### Bug Fixes
 
-- fix optional date ([fc21424](https://github.com/SocialGouv/mano/commit/fc21424ca681b4d733f1a73b04a99cf16ed06685))
+* fix optional date ([fc21424](https://github.com/SocialGouv/mano/commit/fc21424ca681b4d733f1a73b04a99cf16ed06685))
 
 ## [1.71.8](https://github.com/SocialGouv/mano/compare/v1.71.7...v1.71.8) (2022-03-07)
 
+
 ### Bug Fixes
 
-- **dashboard:** limit actions 1000 ([f19fcfd](https://github.com/SocialGouv/mano/commit/f19fcfd6a9d2ee48c18baad4326097379137d8b0))
+* **dashboard:** limit actions 1000 ([f19fcfd](https://github.com/SocialGouv/mano/commit/f19fcfd6a9d2ee48c18baad4326097379137d8b0))
 
 ## [1.71.7](https://github.com/SocialGouv/mano/compare/v1.71.6...v1.71.7) (2022-03-07)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix not found on comment from reports ([435b2b0](https://github.com/SocialGouv/mano/commit/435b2b0f6029ac9c78f3bb88e2c510c41c1ad1be))
+* **dashboard:** fix not found on comment from reports ([435b2b0](https://github.com/SocialGouv/mano/commit/435b2b0f6029ac9c78f3bb88e2c510c41c1ad1be))
 
 ## [1.71.6](https://github.com/SocialGouv/mano/compare/v1.71.5...v1.71.6) (2022-03-07)
 
+
 ### Bug Fixes
 
-- **api:** add security on actions ([#448](https://github.com/SocialGouv/mano/issues/448)) ([4e34c4c](https://github.com/SocialGouv/mano/commit/4e34c4cf5b0a8b5c4ed999885f171888509bad69))
+* **api:** add security on actions ([#448](https://github.com/SocialGouv/mano/issues/448)) ([4e34c4c](https://github.com/SocialGouv/mano/commit/4e34c4cf5b0a8b5c4ed999885f171888509bad69))
 
 ## [1.71.5](https://github.com/SocialGouv/mano/compare/v1.71.4...v1.71.5) (2022-03-07)
 
+
 ### Bug Fixes
 
-- **app:** release app with person fix ([69ae276](https://github.com/SocialGouv/mano/commit/69ae27661089ec1f4e510ecb2eb03bd24e4bb2c6))
+* **app:** release app with person fix ([69ae276](https://github.com/SocialGouv/mano/commit/69ae27661089ec1f4e510ecb2eb03bd24e4bb2c6))
 
 ## [1.71.4](https://github.com/SocialGouv/mano/compare/v1.71.3...v1.71.4) (2022-03-07)
 
+
 ### Bug Fixes
 
-- **app:** person name ([4465d86](https://github.com/SocialGouv/mano/commit/4465d86b4d8d315a46db5ee655a6d701bc7a11e3))
+* **app:** person name ([4465d86](https://github.com/SocialGouv/mano/commit/4465d86b4d8d315a46db5ee655a6d701bc7a11e3))
 
 ## [1.71.3](https://github.com/SocialGouv/mano/compare/v1.71.2...v1.71.3) (2022-03-07)
 
+
 ### Bug Fixes
 
-- categories empty ([781dac9](https://github.com/SocialGouv/mano/commit/781dac97fcb70815266f6e62b607be35f8280f12))
+* categories empty ([781dac9](https://github.com/SocialGouv/mano/commit/781dac97fcb70815266f6e62b607be35f8280f12))
 
 ## [1.71.2](https://github.com/SocialGouv/mano/compare/v1.71.1...v1.71.2) (2022-03-07)
 
+
 ### Bug Fixes
 
-- up ([b7a7376](https://github.com/SocialGouv/mano/commit/b7a7376b6ec9a464f6d0128d375a34612ef07e94))
+* up ([b7a7376](https://github.com/SocialGouv/mano/commit/b7a7376b6ec9a464f6d0128d375a34612ef07e94))
 
 ## [1.71.1](https://github.com/SocialGouv/mano/compare/v1.71.0...v1.71.1) (2022-03-07)
 
+
 ### Bug Fixes
 
-- cat value must be set ([0c37f60](https://github.com/SocialGouv/mano/commit/0c37f6069a85e43add4dae1ec22f5220126e95f7))
+* cat value must be set ([0c37f60](https://github.com/SocialGouv/mano/commit/0c37f6069a85e43add4dae1ec22f5220126e95f7))
 
 # [1.71.0](https://github.com/SocialGouv/mano/compare/v1.70.4...v1.71.0) (2022-03-07)
 
+
 ### Features
 
-- **dashboard:** can rename services categories ([#447](https://github.com/SocialGouv/mano/issues/447)) ([99f7424](https://github.com/SocialGouv/mano/commit/99f742406f2fbbf2db4cf5dc339ef6116a09246f))
+* **dashboard:** can rename services categories ([#447](https://github.com/SocialGouv/mano/issues/447)) ([99f7424](https://github.com/SocialGouv/mano/commit/99f742406f2fbbf2db4cf5dc339ef6116a09246f))
 
 ## [1.70.4](https://github.com/SocialGouv/mano/compare/v1.70.3...v1.70.4) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **app:** action empty #MANO-99 ([#446](https://github.com/SocialGouv/mano/issues/446)) ([d65a9b9](https://github.com/SocialGouv/mano/commit/d65a9b99dd7ff9d21c1d720242ffe876bb708b0f)), closes [#MANO-99](https://github.com/SocialGouv/mano/issues/MANO-99)
+* **app:** action empty #MANO-99 ([#446](https://github.com/SocialGouv/mano/issues/446)) ([d65a9b9](https://github.com/SocialGouv/mano/commit/d65a9b99dd7ff9d21c1d720242ffe876bb708b0f)), closes [#MANO-99](https://github.com/SocialGouv/mano/issues/MANO-99)
 
 ## [1.70.3](https://github.com/SocialGouv/mano/compare/v1.70.2...v1.70.3) (2022-03-04)
 
+
 ### Bug Fixes
 
-- remove unsecure password generation ([#442](https://github.com/SocialGouv/mano/issues/442)) ([512a7c3](https://github.com/SocialGouv/mano/commit/512a7c363eb65b2e1b35533e8a021aff3dffcc75))
+* remove unsecure password generation ([#442](https://github.com/SocialGouv/mano/issues/442)) ([512a7c3](https://github.com/SocialGouv/mano/commit/512a7c363eb65b2e1b35533e8a021aff3dffcc75))
 
 ## [1.70.2](https://github.com/SocialGouv/mano/compare/v1.70.1...v1.70.2) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **api:** fix uuid ([4e4ac67](https://github.com/SocialGouv/mano/commit/4e4ac674cf76b97155b62cbdc9b5f2852c1b5629))
+* **api:** fix uuid ([4e4ac67](https://github.com/SocialGouv/mano/commit/4e4ac674cf76b97155b62cbdc9b5f2852c1b5629))
 
 ## [1.70.1](https://github.com/SocialGouv/mano/compare/v1.70.0...v1.70.1) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **dashboard:** loader message ([#445](https://github.com/SocialGouv/mano/issues/445)) ([dc12a25](https://github.com/SocialGouv/mano/commit/dc12a25959a19f9601d6e47c559c0b503fe7b64a))
+* **dashboard:** loader message ([#445](https://github.com/SocialGouv/mano/issues/445)) ([dc12a25](https://github.com/SocialGouv/mano/commit/dc12a25959a19f9601d6e47c559c0b503fe7b64a))
 
 # [1.70.0](https://github.com/SocialGouv/mano/compare/v1.69.0...v1.70.0) (2022-03-04)
 
+
 ### Features
 
-- **dashboard:** show comments on superadmin ([#443](https://github.com/SocialGouv/mano/issues/443)) ([b0ac051](https://github.com/SocialGouv/mano/commit/b0ac0519acc6df98ba265315be8f6affc87b53de))
+* **dashboard:** show comments on superadmin ([#443](https://github.com/SocialGouv/mano/issues/443)) ([b0ac051](https://github.com/SocialGouv/mano/commit/b0ac0519acc6df98ba265315be8f6affc87b53de))
 
 # [1.69.0](https://github.com/SocialGouv/mano/compare/v1.68.4...v1.69.0) (2022-03-04)
 
+
 ### Features
 
-- **app:** ask permissions before accessing to stuff + can change nam… ([#435](https://github.com/SocialGouv/mano/issues/435)) ([5fa6167](https://github.com/SocialGouv/mano/commit/5fa61674bb433e1ca7a2ebe4afc954976e89117e))
+* **app:** ask permissions before accessing to stuff + can change nam… ([#435](https://github.com/SocialGouv/mano/issues/435)) ([5fa6167](https://github.com/SocialGouv/mano/commit/5fa61674bb433e1ca7a2ebe4afc954976e89117e))
 
 ## [1.68.4](https://github.com/SocialGouv/mano/compare/v1.68.3...v1.68.4) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **app:** duplicate comments on duplicate action ([#433](https://github.com/SocialGouv/mano/issues/433)) ([0949a71](https://github.com/SocialGouv/mano/commit/0949a71ae908aead47b34239424dfb000c56b69c))
+* **app:** duplicate comments on duplicate action ([#433](https://github.com/SocialGouv/mano/issues/433)) ([0949a71](https://github.com/SocialGouv/mano/commit/0949a71ae908aead47b34239424dfb000c56b69c))
 
 ## [1.68.3](https://github.com/SocialGouv/mano/compare/v1.68.2...v1.68.3) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **app:** show only a few actions ([#439](https://github.com/SocialGouv/mano/issues/439)) ([3b82473](https://github.com/SocialGouv/mano/commit/3b82473353f7b9e3d621787d52a2f783727024fe))
+* **app:** show only a few actions ([#439](https://github.com/SocialGouv/mano/issues/439)) ([3b82473](https://github.com/SocialGouv/mano/commit/3b82473353f7b9e3d621787d52a2f783727024fe))
 
 ## [1.68.2](https://github.com/SocialGouv/mano/compare/v1.68.1...v1.68.2) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **dashboard:** stop throw error on fail api request ([#441](https://github.com/SocialGouv/mano/issues/441)) ([2d06ded](https://github.com/SocialGouv/mano/commit/2d06ded8b587707849daab4420df253a4c146ab3))
+* **dashboard:** stop throw error on fail api request ([#441](https://github.com/SocialGouv/mano/issues/441)) ([2d06ded](https://github.com/SocialGouv/mano/commit/2d06ded8b587707849daab4420df253a4c146ab3))
 
 ## [1.68.1](https://github.com/SocialGouv/mano/compare/v1.68.0...v1.68.1) (2022-03-04)
 
+
 ### Bug Fixes
 
-- noisy error ([65e12c8](https://github.com/SocialGouv/mano/commit/65e12c8ab03109648fa0a4f5eb0232bc5fbba4ea))
+* noisy error ([65e12c8](https://github.com/SocialGouv/mano/commit/65e12c8ab03109648fa0a4f5eb0232bc5fbba4ea))
 
 # [1.68.0](https://github.com/SocialGouv/mano/compare/v1.67.6...v1.68.0) (2022-03-04)
 
+
 ### Features
 
-- **dashboard:** reorder services categories and custom fields ([#423](https://github.com/SocialGouv/mano/issues/423)) ([5022f9c](https://github.com/SocialGouv/mano/commit/5022f9c5fabe6a28460b6b743133cbca8ca28d96))
+* **dashboard:** reorder services categories and custom fields ([#423](https://github.com/SocialGouv/mano/issues/423)) ([5022f9c](https://github.com/SocialGouv/mano/commit/5022f9c5fabe6a28460b6b743133cbca8ca28d96))
 
 ## [1.67.6](https://github.com/SocialGouv/mano/compare/v1.67.5...v1.67.6) (2022-03-04)
 
+
 ### Bug Fixes
 
-- **app:** app perfs ([#428](https://github.com/SocialGouv/mano/issues/428)) ([92857fd](https://github.com/SocialGouv/mano/commit/92857fd18d303cfa00827d6e5797fb0be7961755))
+* **app:**  app perfs ([#428](https://github.com/SocialGouv/mano/issues/428)) ([92857fd](https://github.com/SocialGouv/mano/commit/92857fd18d303cfa00827d6e5797fb0be7961755))
 
 ## [1.67.5](https://github.com/SocialGouv/mano/compare/v1.67.4...v1.67.5) (2022-03-03)
 
+
 ### Bug Fixes
 
-- data validation ([#427](https://github.com/SocialGouv/mano/issues/427)) ([017ece4](https://github.com/SocialGouv/mano/commit/017ece4cf40c745bb00eaaaa09adfe005fb541ff))
+* data validation ([#427](https://github.com/SocialGouv/mano/issues/427)) ([017ece4](https://github.com/SocialGouv/mano/commit/017ece4cf40c745bb00eaaaa09adfe005fb541ff))
 
 ## [1.67.4](https://github.com/SocialGouv/mano/compare/v1.67.3...v1.67.4) (2022-03-03)
 
+
 ### Bug Fixes
 
-- **dashboard,app:** addressDetails as enum not text filter ([#432](https://github.com/SocialGouv/mano/issues/432)) ([416fcbf](https://github.com/SocialGouv/mano/commit/416fcbf27e7880823ea3536301ad8134b08a8bd7))
+* **dashboard,app:** addressDetails as enum not text filter ([#432](https://github.com/SocialGouv/mano/issues/432)) ([416fcbf](https://github.com/SocialGouv/mano/commit/416fcbf27e7880823ea3536301ad8134b08a8bd7))
 
 ## [1.67.3](https://github.com/SocialGouv/mano/compare/v1.67.2...v1.67.3) (2022-03-03)
 
+
 ### Bug Fixes
 
-- **dashboard:** celan ([#431](https://github.com/SocialGouv/mano/issues/431)) ([43ac42c](https://github.com/SocialGouv/mano/commit/43ac42ceb2ec1cb6b36c57e46412610e4c9c6635))
+* **dashboard:** celan ([#431](https://github.com/SocialGouv/mano/issues/431)) ([43ac42c](https://github.com/SocialGouv/mano/commit/43ac42ceb2ec1cb6b36c57e46412610e4c9c6635))
 
 ## [1.67.2](https://github.com/SocialGouv/mano/compare/v1.67.1...v1.67.2) (2022-03-03)
 
+
 ### Bug Fixes
 
-- **dashboard:** datepicker on small screens ([#429](https://github.com/SocialGouv/mano/issues/429)) ([c81138e](https://github.com/SocialGouv/mano/commit/c81138e2f85a9630941a11eb631e5b18788af481))
+* **dashboard:** datepicker on small screens ([#429](https://github.com/SocialGouv/mano/issues/429)) ([c81138e](https://github.com/SocialGouv/mano/commit/c81138e2f85a9630941a11eb631e5b18788af481))
 
 ## [1.67.1](https://github.com/SocialGouv/mano/compare/v1.67.0...v1.67.1) (2022-03-03)
 
+
 ### Bug Fixes
 
-- **app:** expired session ([#426](https://github.com/SocialGouv/mano/issues/426)) ([a954e73](https://github.com/SocialGouv/mano/commit/a954e73079b6c995d5a5c9c26b8d9f50973cd150))
+* **app:** expired session ([#426](https://github.com/SocialGouv/mano/issues/426)) ([a954e73](https://github.com/SocialGouv/mano/commit/a954e73079b6c995d5a5c9c26b8d9f50973cd150))
 
 # [1.67.0](https://github.com/SocialGouv/mano/compare/v1.66.2...v1.67.0) (2022-03-03)
 
+
 ### Features
 
-- **app,api:** app v2.12.0 ([#411](https://github.com/SocialGouv/mano/issues/411)) ([de02f60](https://github.com/SocialGouv/mano/commit/de02f60a48778a91b6df2ad1a6e2ddf2d360c2f4))
+* **app,api:** app v2.12.0 ([#411](https://github.com/SocialGouv/mano/issues/411)) ([de02f60](https://github.com/SocialGouv/mano/commit/de02f60a48778a91b6df2ad1a6e2ddf2d360c2f4))
 
 ## [1.66.2](https://github.com/SocialGouv/mano/compare/v1.66.1...v1.66.2) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **api:** authorize normal user to add collaboration ([#422](https://github.com/SocialGouv/mano/issues/422)) ([629b07a](https://github.com/SocialGouv/mano/commit/629b07a07ce2f0851a202afbcb89d4718b5f7063))
+* **api:** authorize normal user to add collaboration ([#422](https://github.com/SocialGouv/mano/issues/422)) ([629b07a](https://github.com/SocialGouv/mano/commit/629b07a07ce2f0851a202afbcb89d4718b5f7063))
 
 ## [1.66.1](https://github.com/SocialGouv/mano/compare/v1.66.0...v1.66.1) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** onboarding show encryption ([#421](https://github.com/SocialGouv/mano/issues/421)) ([3bddfd5](https://github.com/SocialGouv/mano/commit/3bddfd50b9dd1bf7a2adf7e9aead93fbeb69ea0a))
+* **dashboard:** onboarding show encryption ([#421](https://github.com/SocialGouv/mano/issues/421)) ([3bddfd5](https://github.com/SocialGouv/mano/commit/3bddfd50b9dd1bf7a2adf7e9aead93fbeb69ea0a))
 
 # [1.66.0](https://github.com/SocialGouv/mano/compare/v1.65.2...v1.66.0) (2022-03-02)
 
+
 ### Features
 
-- **dashboard:** reorganize organisation setup ([#408](https://github.com/SocialGouv/mano/issues/408)) ([e5f0450](https://github.com/SocialGouv/mano/commit/e5f0450dd3cb9448b5f359be91a18cd786f3addf))
+* **dashboard:** reorganize organisation setup ([#408](https://github.com/SocialGouv/mano/issues/408)) ([e5f0450](https://github.com/SocialGouv/mano/commit/e5f0450dd3cb9448b5f359be91a18cd786f3addf))
 
 ## [1.65.2](https://github.com/SocialGouv/mano/compare/v1.65.1...v1.65.2) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** sort reports on creation ([#420](https://github.com/SocialGouv/mano/issues/420)) ([cb8b8ab](https://github.com/SocialGouv/mano/commit/cb8b8abe99b8ded03e7f3ea2152d4dfbcd6b92b8))
+* **dashboard:** sort reports on creation ([#420](https://github.com/SocialGouv/mano/issues/420)) ([cb8b8ab](https://github.com/SocialGouv/mano/commit/cb8b8abe99b8ded03e7f3ea2152d4dfbcd6b92b8))
 
 ## [1.65.1](https://github.com/SocialGouv/mano/compare/v1.65.0...v1.65.1) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** prev next report ([#419](https://github.com/SocialGouv/mano/issues/419)) ([3c4f2cb](https://github.com/SocialGouv/mano/commit/3c4f2cbb846b519f76d9c35b82cf9c994cedbd03))
+* **dashboard:** prev next report ([#419](https://github.com/SocialGouv/mano/issues/419)) ([3c4f2cb](https://github.com/SocialGouv/mano/commit/3c4f2cbb846b519f76d9c35b82cf9c994cedbd03))
 
 # [1.65.0](https://github.com/SocialGouv/mano/compare/v1.64.5...v1.65.0) (2022-03-02)
 
+
 ### Features
 
-- **api:** send platform and version to sentry ([#418](https://github.com/SocialGouv/mano/issues/418)) ([e51d63e](https://github.com/SocialGouv/mano/commit/e51d63e1a600b2c2e2e474d8203068a1b0be18d3))
+* **api:** send platform and version to sentry ([#418](https://github.com/SocialGouv/mano/issues/418)) ([e51d63e](https://github.com/SocialGouv/mano/commit/e51d63e1a600b2c2e2e474d8203068a1b0be18d3))
 
 ## [1.64.5](https://github.com/SocialGouv/mano/compare/v1.64.4...v1.64.5) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **app,dashboard:** check date before showing ([#417](https://github.com/SocialGouv/mano/issues/417)) ([87d63ba](https://github.com/SocialGouv/mano/commit/87d63baf28397247ba1d09b122d58b79dd7296a0))
+* **app,dashboard:**  check date before showing ([#417](https://github.com/SocialGouv/mano/issues/417)) ([87d63ba](https://github.com/SocialGouv/mano/commit/87d63baf28397247ba1d09b122d58b79dd7296a0))
 
 ## [1.64.4](https://github.com/SocialGouv/mano/compare/v1.64.3...v1.64.4) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **api:** add orinigal url to sentry ([#416](https://github.com/SocialGouv/mano/issues/416)) ([3090a12](https://github.com/SocialGouv/mano/commit/3090a12bbfb09fe1adb2327e80ad62ea6d505355))
+* **api:** add orinigal url to sentry ([#416](https://github.com/SocialGouv/mano/issues/416)) ([3090a12](https://github.com/SocialGouv/mano/commit/3090a12bbfb09fe1adb2327e80ad62ea6d505355))
 
 ## [1.64.3](https://github.com/SocialGouv/mano/compare/v1.64.2...v1.64.3) (2022-03-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** auto report create in reception ([#415](https://github.com/SocialGouv/mano/issues/415)) ([8a04b22](https://github.com/SocialGouv/mano/commit/8a04b2241526289c139dfee4219baa4e36cc5dec))
+* **dashboard:** auto report create in reception ([#415](https://github.com/SocialGouv/mano/issues/415)) ([8a04b22](https://github.com/SocialGouv/mano/commit/8a04b2241526289c139dfee4219baa4e36cc5dec))
 
 ## [1.64.2](https://github.com/SocialGouv/mano/compare/v1.64.1...v1.64.2) (2022-03-01)
 
+
 ### Bug Fixes
 
-- **dashboard:** loader on comments ([#412](https://github.com/SocialGouv/mano/issues/412)) ([abc3786](https://github.com/SocialGouv/mano/commit/abc3786d01266009a3a0a452a429bbad02956475))
+* **dashboard:** loader on comments ([#412](https://github.com/SocialGouv/mano/issues/412)) ([abc3786](https://github.com/SocialGouv/mano/commit/abc3786d01266009a3a0a452a429bbad02956475))
 
 ## [1.64.1](https://github.com/SocialGouv/mano/compare/v1.64.0...v1.64.1) (2022-03-01)
 
+
 ### Bug Fixes
 
-- **dashboard:** better loader ([#407](https://github.com/SocialGouv/mano/issues/407)) ([c56fbb0](https://github.com/SocialGouv/mano/commit/c56fbb0765020634277d51ab011de83401362006))
+* **dashboard:** better loader ([#407](https://github.com/SocialGouv/mano/issues/407)) ([c56fbb0](https://github.com/SocialGouv/mano/commit/c56fbb0765020634277d51ab011de83401362006))
 
 # [1.64.0](https://github.com/SocialGouv/mano/compare/v1.63.0...v1.64.0) (2022-03-01)
 
+
 ### Features
 
-- **dashboard:** improve filters for persons ([#405](https://github.com/SocialGouv/mano/issues/405)) ([0eb73db](https://github.com/SocialGouv/mano/commit/0eb73dbd6ac79106b5f709858a6bb64bd1838f04))
+* **dashboard:** improve filters for persons ([#405](https://github.com/SocialGouv/mano/issues/405)) ([0eb73db](https://github.com/SocialGouv/mano/commit/0eb73dbd6ac79106b5f709858a6bb64bd1838f04))
 
 # [1.63.0](https://github.com/SocialGouv/mano/compare/v1.62.0...v1.63.0) (2022-03-01)
 
+
 ### Features
 
-- **app,api:** update documents from mobile ([#400](https://github.com/SocialGouv/mano/issues/400)) ([ad096f1](https://github.com/SocialGouv/mano/commit/ad096f1ba6ca6425873232478514c71000556ae1))
+* **app,api:** update documents from mobile ([#400](https://github.com/SocialGouv/mano/issues/400)) ([ad096f1](https://github.com/SocialGouv/mano/commit/ad096f1ba6ca6425873232478514c71000556ae1))
 
 # [1.62.0](https://github.com/SocialGouv/mano/compare/v1.61.0...v1.62.0) (2022-02-28)
 
+
 ### Features
 
-- **dashboard:** remove organisation stats button when only one team ([#402](https://github.com/SocialGouv/mano/issues/402)) ([3f3b9b3](https://github.com/SocialGouv/mano/commit/3f3b9b33384bc88cc61eeb24172adffc24895f3f))
+* **dashboard:** remove organisation stats button when only one team ([#402](https://github.com/SocialGouv/mano/issues/402)) ([3f3b9b3](https://github.com/SocialGouv/mano/commit/3f3b9b33384bc88cc61eeb24172adffc24895f3f))
 
 # [1.61.0](https://github.com/SocialGouv/mano/compare/v1.60.0...v1.61.0) (2022-02-28)
 
+
 ### Features
 
-- validate organisation encryption ([#383](https://github.com/SocialGouv/mano/issues/383)) ([ff82af7](https://github.com/SocialGouv/mano/commit/ff82af760f30a9f01f0d15d8b2a5ee90c83a6aa1))
+* validate organisation encryption ([#383](https://github.com/SocialGouv/mano/issues/383)) ([ff82af7](https://github.com/SocialGouv/mano/commit/ff82af760f30a9f01f0d15d8b2a5ee90c83a6aa1))
 
 # [1.60.0](https://github.com/SocialGouv/mano/compare/v1.59.0...v1.60.0) (2022-02-28)
 
+
 ### Features
 
-- **dashboard:** refresh button everywhere ([#404](https://github.com/SocialGouv/mano/issues/404)) ([a3ac762](https://github.com/SocialGouv/mano/commit/a3ac76226eef3d9d63e6740391bc751b8a265175))
+* **dashboard:** refresh button everywhere ([#404](https://github.com/SocialGouv/mano/issues/404)) ([a3ac762](https://github.com/SocialGouv/mano/commit/a3ac76226eef3d9d63e6740391bc751b8a265175))
 
 # [1.59.0](https://github.com/SocialGouv/mano/compare/v1.58.4...v1.59.0) (2022-02-28)
 
+
 ### Features
 
-- **dashboard:** show date also in comment research ([#403](https://github.com/SocialGouv/mano/issues/403)) ([270283a](https://github.com/SocialGouv/mano/commit/270283a639d1c9ef004575071391e1e75b699421))
+* **dashboard:** show date also in comment research ([#403](https://github.com/SocialGouv/mano/issues/403)) ([270283a](https://github.com/SocialGouv/mano/commit/270283a639d1c9ef004575071391e1e75b699421))
 
 ## [1.58.4](https://github.com/SocialGouv/mano/compare/v1.58.3...v1.58.4) (2022-02-28)
 
+
 ### Bug Fixes
 
-- **dashboard:** create collaboration ([#401](https://github.com/SocialGouv/mano/issues/401)) ([7db8abd](https://github.com/SocialGouv/mano/commit/7db8abd5063f88cbba1d3d80dec2714f5ffbc5be))
+* **dashboard:** create collaboration ([#401](https://github.com/SocialGouv/mano/issues/401)) ([7db8abd](https://github.com/SocialGouv/mano/commit/7db8abd5063f88cbba1d3d80dec2714f5ffbc5be))
 
 ## [1.58.3](https://github.com/SocialGouv/mano/compare/v1.58.2...v1.58.3) (2022-02-25)
 
+
 ### Bug Fixes
 
-- **api:** remove orgEncryptionKeyCacheForDebug ([244d406](https://github.com/SocialGouv/mano/commit/244d406f87bd62431ddfefa3d012ae8f35c46980))
+* **api:** remove orgEncryptionKeyCacheForDebug ([244d406](https://github.com/SocialGouv/mano/commit/244d406f87bd62431ddfefa3d012ae8f35c46980))
 
 ## [1.58.2](https://github.com/SocialGouv/mano/compare/v1.58.1...v1.58.2) (2022-02-25)
 
+
 ### Bug Fixes
 
-- **api:** remove capture ([379c7fe](https://github.com/SocialGouv/mano/commit/379c7fe0bdc38d6a14dd880d048df174c8ad57a7))
+* **api:** remove capture ([379c7fe](https://github.com/SocialGouv/mano/commit/379c7fe0bdc38d6a14dd880d048df174c8ad57a7))
 
 ## [1.58.1](https://github.com/SocialGouv/mano/compare/v1.58.0...v1.58.1) (2022-02-25)
 
+
 ### Bug Fixes
 
-- bump ([5752399](https://github.com/SocialGouv/mano/commit/5752399ef0f267e7bffe2828ffa557309b814247))
-- up ([1c6bdd0](https://github.com/SocialGouv/mano/commit/1c6bdd01b8d7c2bbe0b65b5bbb7f52c35bf5f4f7))
-- **api:** action update ([a0e9b56](https://github.com/SocialGouv/mano/commit/a0e9b56fdbbf089ff911f879739906f6c7889958))
-- **api:** only admin can update org ([c3bce83](https://github.com/SocialGouv/mano/commit/c3bce83a47577d28a4270c1deadfd1c78d3cd0fb))
-- **api:** remove team check since it does not exist anymore on tables ([f147dff](https://github.com/SocialGouv/mano/commit/f147dff82d7a782caf0d6a9586a14d99de10493f))
-- **app:** text color on dark mode ([#395](https://github.com/SocialGouv/mano/issues/395)) ([8c0038c](https://github.com/SocialGouv/mano/commit/8c0038c5d999af1340863779a816048d025e7a01))
+* bump ([5752399](https://github.com/SocialGouv/mano/commit/5752399ef0f267e7bffe2828ffa557309b814247))
+* up ([1c6bdd0](https://github.com/SocialGouv/mano/commit/1c6bdd01b8d7c2bbe0b65b5bbb7f52c35bf5f4f7))
+* **api:** action update ([a0e9b56](https://github.com/SocialGouv/mano/commit/a0e9b56fdbbf089ff911f879739906f6c7889958))
+* **api:** only admin can update org ([c3bce83](https://github.com/SocialGouv/mano/commit/c3bce83a47577d28a4270c1deadfd1c78d3cd0fb))
+* **api:** remove team check since it does not exist anymore on tables ([f147dff](https://github.com/SocialGouv/mano/commit/f147dff82d7a782caf0d6a9586a14d99de10493f))
+* **app:** text color on dark mode ([#395](https://github.com/SocialGouv/mano/issues/395)) ([8c0038c](https://github.com/SocialGouv/mano/commit/8c0038c5d999af1340863779a816048d025e7a01))
 
 # [1.58.0](https://github.com/SocialGouv/mano/compare/v1.57.2...v1.58.0) (2022-02-25)
 
+
 ### Features
 
-- remove encrypted field from columns ([#364](https://github.com/SocialGouv/mano/issues/364)) ([d76fcc3](https://github.com/SocialGouv/mano/commit/d76fcc3502ef7a21e3f9ea67e7fdab25c0a96825))
+* remove encrypted field from columns ([#364](https://github.com/SocialGouv/mano/issues/364)) ([d76fcc3](https://github.com/SocialGouv/mano/commit/d76fcc3502ef7a21e3f9ea67e7fdab25c0a96825))
 
 ## [1.57.2](https://github.com/SocialGouv/mano/compare/v1.57.1...v1.57.2) (2022-02-25)
 
+
 ### Bug Fixes
 
-- **app:** refactor refresher + fix clear cache when change organisation ([#394](https://github.com/SocialGouv/mano/issues/394)) ([4a1b151](https://github.com/SocialGouv/mano/commit/4a1b151cf069821f1fc45d1e28c47295a853f962))
+* **app:** refactor refresher + fix clear cache when change organisation ([#394](https://github.com/SocialGouv/mano/issues/394)) ([4a1b151](https://github.com/SocialGouv/mano/commit/4a1b151cf069821f1fc45d1e28c47295a853f962))
 
 ## [1.57.1](https://github.com/SocialGouv/mano/compare/v1.57.0...v1.57.1) (2022-02-25)
 
+
 ### Bug Fixes
 
-- update yarn.lock ([fae2114](https://github.com/SocialGouv/mano/commit/fae21142614c7d757894b2456e08e7a9656657e0))
+* update yarn.lock ([fae2114](https://github.com/SocialGouv/mano/commit/fae21142614c7d757894b2456e08e7a9656657e0))
 
 # [1.57.0](https://github.com/SocialGouv/mano/compare/v1.56.3...v1.57.0) (2022-02-24)
 
+
 ### Features
 
-- **app,api:** new version ([#393](https://github.com/SocialGouv/mano/issues/393)) ([df9dd0d](https://github.com/SocialGouv/mano/commit/df9dd0d7e6dad91a223d203c15b506ec4864753a))
+* **app,api:** new version ([#393](https://github.com/SocialGouv/mano/issues/393)) ([df9dd0d](https://github.com/SocialGouv/mano/commit/df9dd0d7e6dad91a223d203c15b506ec4864753a))
 
 ## [1.56.3](https://github.com/SocialGouv/mano/compare/v1.56.2...v1.56.3) (2022-02-24)
 
+
 ### Bug Fixes
 
-- **app:** cannot update aciton with no name ([#392](https://github.com/SocialGouv/mano/issues/392)) ([a01b2dc](https://github.com/SocialGouv/mano/commit/a01b2dcc7b512f49cc313a3eb77b41109b1d87f9))
+* **app:** cannot update aciton with no name ([#392](https://github.com/SocialGouv/mano/issues/392)) ([a01b2dc](https://github.com/SocialGouv/mano/commit/a01b2dcc7b512f49cc313a3eb77b41109b1d87f9))
 
 ## [1.56.2](https://github.com/SocialGouv/mano/compare/v1.56.1...v1.56.2) (2022-02-24)
 
+
 ### Bug Fixes
 
-- **app,dashboard:** last fixes before encryption ([#391](https://github.com/SocialGouv/mano/issues/391)) ([06a3a8a](https://github.com/SocialGouv/mano/commit/06a3a8a286e1922c1d8e7f04eec924323e509543))
+* **app,dashboard:**  last fixes before encryption ([#391](https://github.com/SocialGouv/mano/issues/391)) ([06a3a8a](https://github.com/SocialGouv/mano/commit/06a3a8a286e1922c1d8e7f04eec924323e509543))
 
 ## [1.56.1](https://github.com/SocialGouv/mano/compare/v1.56.0...v1.56.1) (2022-02-24)
 
+
 ### Bug Fixes
 
-- **app:** remove mano-tests from dependencies ([#388](https://github.com/SocialGouv/mano/issues/388)) ([d26373d](https://github.com/SocialGouv/mano/commit/d26373db8a3b127ac77f367ee354b58efd99dd5f))
+* **app:** remove mano-tests from dependencies ([#388](https://github.com/SocialGouv/mano/issues/388)) ([d26373d](https://github.com/SocialGouv/mano/commit/d26373db8a3b127ac77f367ee354b58efd99dd5f))
 
 # [1.56.0](https://github.com/SocialGouv/mano/compare/v1.55.0...v1.56.0) (2022-02-24)
 
+
 ### Features
 
-- **app:** test with detox ([#387](https://github.com/SocialGouv/mano/issues/387)) ([be86e19](https://github.com/SocialGouv/mano/commit/be86e19939407b4ebcb90c9126bd824bf307ca7b))
+* **app:** test with detox ([#387](https://github.com/SocialGouv/mano/issues/387)) ([be86e19](https://github.com/SocialGouv/mano/commit/be86e19939407b4ebcb90c9126bd824bf307ca7b))
 
 # [1.55.0](https://github.com/SocialGouv/mano/compare/v1.54.3...v1.55.0) (2022-02-23)
 
+
 ### Features
 
-- **dashboard:** tests persons/actions/territories ([#382](https://github.com/SocialGouv/mano/issues/382)) ([08b1857](https://github.com/SocialGouv/mano/commit/08b1857f95f76cabc5211a8a70f0c62231f5191c))
+* **dashboard:** tests persons/actions/territories ([#382](https://github.com/SocialGouv/mano/issues/382)) ([08b1857](https://github.com/SocialGouv/mano/commit/08b1857f95f76cabc5211a8a70f0c62231f5191c))
 
 ## [1.54.3](https://github.com/SocialGouv/mano/compare/v1.54.2...v1.54.3) (2022-02-22)
 
+
 ### Bug Fixes
 
-- **dashboard:** can go to prev/next report + can change services in report ([#379](https://github.com/SocialGouv/mano/issues/379)) ([2765a47](https://github.com/SocialGouv/mano/commit/2765a47eac0bb3a79b73ac0ce1229f626e75ab56))
+* **dashboard:** can go to prev/next report + can change services in report ([#379](https://github.com/SocialGouv/mano/issues/379)) ([2765a47](https://github.com/SocialGouv/mano/commit/2765a47eac0bb3a79b73ac0ce1229f626e75ab56))
 
 ## [1.54.2](https://github.com/SocialGouv/mano/compare/v1.54.1...v1.54.2) (2022-02-21)
 
+
 ### Bug Fixes
 
-- **api:** use transaction in find ([046714f](https://github.com/SocialGouv/mano/commit/046714fde43c9b2ae209ed470ecf1f2c724cf1fb))
+* **api:** use transaction in find ([046714f](https://github.com/SocialGouv/mano/commit/046714fde43c9b2ae209ed470ecf1f2c724cf1fb))
 
 ## [1.54.1](https://github.com/SocialGouv/mano/compare/v1.54.0...v1.54.1) (2022-02-21)
 
+
 ### Bug Fixes
 
-- **app:** findIndex fail ([4549038](https://github.com/SocialGouv/mano/commit/4549038cd5a547b4d9e01a1349ca58beaaf9e58b))
+* **app:** findIndex fail ([4549038](https://github.com/SocialGouv/mano/commit/4549038cd5a547b4d9e01a1349ca58beaaf9e58b))
 
 # [1.54.0](https://github.com/SocialGouv/mano/compare/v1.53.17...v1.54.0) (2022-02-21)
 
+
 ### Features
 
-- **dashboard:** remove cancel encryption ([1b047d3](https://github.com/SocialGouv/mano/commit/1b047d3e68d6a2b40c04c84e71d33f661b32bbd6))
+* **dashboard:** remove cancel encryption ([1b047d3](https://github.com/SocialGouv/mano/commit/1b047d3e68d6a2b40c04c84e71d33f661b32bbd6))
 
 ## [1.53.17](https://github.com/SocialGouv/mano/compare/v1.53.16...v1.53.17) (2022-02-21)
 
+
 ### Bug Fixes
 
-- **dashboard:** google translation ([15406a6](https://github.com/SocialGouv/mano/commit/15406a658ec3987210277e642d550e5b01dfddf3))
+* **dashboard:** google translation ([15406a6](https://github.com/SocialGouv/mano/commit/15406a658ec3987210277e642d550e5b01dfddf3))
 
 ## [1.53.16](https://github.com/SocialGouv/mano/compare/v1.53.15...v1.53.16) (2022-02-21)
 
+
 ### Bug Fixes
 
-- **dashboard:** message and capture when upload doc fails ([#378](https://github.com/SocialGouv/mano/issues/378)) ([aa39dc5](https://github.com/SocialGouv/mano/commit/aa39dc5b4bbbda30ff12138e0abd5e1a39142eea))
+* **dashboard:** message and capture when upload doc fails ([#378](https://github.com/SocialGouv/mano/issues/378)) ([aa39dc5](https://github.com/SocialGouv/mano/commit/aa39dc5b4bbbda30ff12138e0abd5e1a39142eea))
 
 ## [1.53.15](https://github.com/SocialGouv/mano/compare/v1.53.14...v1.53.15) (2022-02-21)
 
+
 ### Bug Fixes
 
-- **api:** minimum mobile version ([a713b13](https://github.com/SocialGouv/mano/commit/a713b131f107f316d9df4796c292309952f7ab82))
+* **api:** minimum mobile version ([a713b13](https://github.com/SocialGouv/mano/commit/a713b131f107f316d9df4796c292309952f7ab82))
 
 ## [1.53.14](https://github.com/SocialGouv/mano/compare/v1.53.13...v1.53.14) (2022-02-17)
 
+
 ### Bug Fixes
 
-- **app:** comment edit / person delete / action delete / popup on duplicate ([#374](https://github.com/SocialGouv/mano/issues/374)) ([9c65334](https://github.com/SocialGouv/mano/commit/9c65334bca9c89ecd7ccc4a6e8f53d6ef99ee58c))
+* **app:** comment edit / person delete / action delete / popup on duplicate ([#374](https://github.com/SocialGouv/mano/issues/374)) ([9c65334](https://github.com/SocialGouv/mano/commit/9c65334bca9c89ecd7ccc4a6e8f53d6ef99ee58c))
 
 ## [1.53.13](https://github.com/SocialGouv/mano/compare/v1.53.12...v1.53.13) (2022-02-17)
 
+
 ### Bug Fixes
 
-- **app:** button done/cancel for action ([#373](https://github.com/SocialGouv/mano/issues/373)) ([6213681](https://github.com/SocialGouv/mano/commit/6213681bcf9174edc3a8b1c5763f2b09792c9079))
+* **app:** button done/cancel for action ([#373](https://github.com/SocialGouv/mano/issues/373)) ([6213681](https://github.com/SocialGouv/mano/commit/6213681bcf9174edc3a8b1c5763f2b09792c9079))
 
 ## [1.53.12](https://github.com/SocialGouv/mano/compare/v1.53.11...v1.53.12) (2022-02-15)
 
+
 ### Bug Fixes
 
-- **api:** try to relaunch ([#372](https://github.com/SocialGouv/mano/issues/372)) ([17017cc](https://github.com/SocialGouv/mano/commit/17017cc55f4a09aa1d90fade8f61c4d2f6fbd357))
+* **api:** try to relaunch ([#372](https://github.com/SocialGouv/mano/issues/372)) ([17017cc](https://github.com/SocialGouv/mano/commit/17017cc55f4a09aa1d90fade8f61c4d2f6fbd357))
 
 ## [1.53.11](https://github.com/SocialGouv/mano/compare/v1.53.10...v1.53.11) (2022-02-14)
 
+
 ### Bug Fixes
 
-- get args in errors ([40e2b74](https://github.com/SocialGouv/mano/commit/40e2b74f394a530dafa4ec709deee6c3d0f6ee02))
+* get args in errors ([40e2b74](https://github.com/SocialGouv/mano/commit/40e2b74f394a530dafa4ec709deee6c3d0f6ee02))
 
 ## [1.53.10](https://github.com/SocialGouv/mano/compare/v1.53.9...v1.53.10) (2022-02-14)
 
+
 ### Bug Fixes
 
-- up ([e2dcc4c](https://github.com/SocialGouv/mano/commit/e2dcc4ca6bd99eaf0a9242b44b0d63a64e02023e))
+* up ([e2dcc4c](https://github.com/SocialGouv/mano/commit/e2dcc4ca6bd99eaf0a9242b44b0d63a64e02023e))
 
 ## [1.53.9](https://github.com/SocialGouv/mano/compare/v1.53.8...v1.53.9) (2022-02-14)
 
+
 ### Bug Fixes
 
-- fix recoil ([e60417f](https://github.com/SocialGouv/mano/commit/e60417f7ec4220fe973855d72a6db5ad4cdecf03))
+* fix recoil ([e60417f](https://github.com/SocialGouv/mano/commit/e60417f7ec4220fe973855d72a6db5ad4cdecf03))
 
 ## [1.53.8](https://github.com/SocialGouv/mano/compare/v1.53.7...v1.53.8) (2022-02-11)
 
+
 ### Bug Fixes
 
-- upgrade oauth2 ([#363](https://github.com/SocialGouv/mano/issues/363)) ([94fa8ec](https://github.com/SocialGouv/mano/commit/94fa8ec8bfd458d4f86ab0bbb98cca41b8cdad85))
+* upgrade oauth2 ([#363](https://github.com/SocialGouv/mano/issues/363)) ([94fa8ec](https://github.com/SocialGouv/mano/commit/94fa8ec8bfd458d4f86ab0bbb98cca41b8cdad85))
 
 ## [1.53.7](https://github.com/SocialGouv/mano/compare/v1.53.6...v1.53.7) (2022-02-11)
 
+
 ### Bug Fixes
 
-- **api:** update sentry ([#361](https://github.com/SocialGouv/mano/issues/361)) ([a1ffbec](https://github.com/SocialGouv/mano/commit/a1ffbec47afda63ec30ab14727de2ac1d7471ca2))
+* **api:** update sentry ([#361](https://github.com/SocialGouv/mano/issues/361)) ([a1ffbec](https://github.com/SocialGouv/mano/commit/a1ffbec47afda63ec30ab14727de2ac1d7471ca2))
 
 ## [1.53.6](https://github.com/SocialGouv/mano/compare/v1.53.5...v1.53.6) (2022-02-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** actions on connection ([3d58eee](https://github.com/SocialGouv/mano/commit/3d58eee5ec3a1e1cfcb75255beb08e2e5258f290))
+* **dashboard:** actions on connection ([3d58eee](https://github.com/SocialGouv/mano/commit/3d58eee5ec3a1e1cfcb75255beb08e2e5258f290))
 
 ## [1.53.5](https://github.com/SocialGouv/mano/compare/v1.53.4...v1.53.5) (2022-02-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** again ([c09ca24](https://github.com/SocialGouv/mano/commit/c09ca240bd3dd03f4bba10168154f6b34addedf7))
+* **dashboard:** again ([c09ca24](https://github.com/SocialGouv/mano/commit/c09ca240bd3dd03f4bba10168154f6b34addedf7))
 
 ## [1.53.4](https://github.com/SocialGouv/mano/compare/v1.53.3...v1.53.4) (2022-02-09)
 
+
 ### Bug Fixes
 
-- **dashboard:** create action ([6ba2af8](https://github.com/SocialGouv/mano/commit/6ba2af8e6bc1dcaa3e705f20fb009e7de3f799f7))
+* **dashboard:** create action ([6ba2af8](https://github.com/SocialGouv/mano/commit/6ba2af8e6bc1dcaa3e705f20fb009e7de3f799f7))
 
 ## [1.53.3](https://github.com/SocialGouv/mano/compare/v1.53.2...v1.53.3) (2022-02-09)
 
+
 ### Bug Fixes
 
-- **dashboard:** selectedPersons length ([103db71](https://github.com/SocialGouv/mano/commit/103db711fd8e72aecf2d2c19cfd36ea500a11aa1))
+* **dashboard:** selectedPersons length ([103db71](https://github.com/SocialGouv/mano/commit/103db711fd8e72aecf2d2c19cfd36ea500a11aa1))
 
 ## [1.53.2](https://github.com/SocialGouv/mano/compare/v1.53.1...v1.53.2) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **api:** remove sentry in non-production env ([438f632](https://github.com/SocialGouv/mano/commit/438f632ebf0de61f2043df76d534bc4f21cfaa1b))
+* **api:** remove sentry in non-production env ([438f632](https://github.com/SocialGouv/mano/commit/438f632ebf0de61f2043df76d534bc4f21cfaa1b))
 
 ## [1.53.1](https://github.com/SocialGouv/mano/compare/v1.53.0...v1.53.1) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix dates for date range picker ([98394bd](https://github.com/SocialGouv/mano/commit/98394bd1d3f6c9c5dbabbdb6ac4078881ce387b6))
+* **dashboard:** fix dates for date range picker ([98394bd](https://github.com/SocialGouv/mano/commit/98394bd1d3f6c9c5dbabbdb6ac4078881ce387b6))
 
 # [1.53.0](https://github.com/SocialGouv/mano/compare/v1.52.0...v1.53.0) (2022-02-08)
 
+
 ### Features
 
-- **k8s:** add configmap for api production ([#355](https://github.com/SocialGouv/mano/issues/355)) ([8ce916c](https://github.com/SocialGouv/mano/commit/8ce916c4fcc6e566114549f0191fe2bc2c4095cd))
+* **k8s:** add configmap for api production ([#355](https://github.com/SocialGouv/mano/issues/355)) ([8ce916c](https://github.com/SocialGouv/mano/commit/8ce916c4fcc6e566114549f0191fe2bc2c4095cd))
 
 # [1.52.0](https://github.com/SocialGouv/mano/compare/v1.51.0...v1.52.0) (2022-02-08)
 
+
 ### Features
 
-- **app:** release app ([4dde5bb](https://github.com/SocialGouv/mano/commit/4dde5bbf919302b514d0898846c7cd65ac2e1dbb))
+* **app:** release app ([4dde5bb](https://github.com/SocialGouv/mano/commit/4dde5bbf919302b514d0898846c7cd65ac2e1dbb))
 
 # [1.51.0](https://github.com/SocialGouv/mano/compare/v1.50.4...v1.51.0) (2022-02-08)
 
+
 ### Features
 
-- **api:** do not return encrypted fields ([#326](https://github.com/SocialGouv/mano/issues/326)) ([ef6e275](https://github.com/SocialGouv/mano/commit/ef6e2751ce02f6f34933cf2472492b1d5cd028d6))
+* **api:** do not return encrypted fields ([#326](https://github.com/SocialGouv/mano/issues/326)) ([ef6e275](https://github.com/SocialGouv/mano/commit/ef6e2751ce02f6f34933cf2472492b1d5cd028d6))
 
 ## [1.50.4](https://github.com/SocialGouv/mano/compare/v1.50.3...v1.50.4) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** add user in territory ([d0411d7](https://github.com/SocialGouv/mano/commit/d0411d7d7a1e0d6def5e263131c489379dcf2547))
+* **dashboard:** add user in territory ([d0411d7](https://github.com/SocialGouv/mano/commit/d0411d7d7a1e0d6def5e263131c489379dcf2547))
 
 ## [1.50.3](https://github.com/SocialGouv/mano/compare/v1.50.2...v1.50.3) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **app:** add user in new action form ([0743443](https://github.com/SocialGouv/mano/commit/074344372eb444bfdc0e54cc3b513098957fb8ea))
+* **app:** add user in new action form ([0743443](https://github.com/SocialGouv/mano/commit/074344372eb444bfdc0e54cc3b513098957fb8ea))
 
 ## [1.50.2](https://github.com/SocialGouv/mano/compare/v1.50.1...v1.50.2) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** action needs a user ([0dca670](https://github.com/SocialGouv/mano/commit/0dca67055fe96561676377ded4682e3a589ee863))
+* **dashboard:** action needs a user ([0dca670](https://github.com/SocialGouv/mano/commit/0dca67055fe96561676377ded4682e3a589ee863))
 
 ## [1.50.1](https://github.com/SocialGouv/mano/compare/v1.50.0...v1.50.1) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix key issue ([7e5c893](https://github.com/SocialGouv/mano/commit/7e5c893c7d0e3eabef959b60c94733eeac28be6f))
+* **dashboard:** fix key issue ([7e5c893](https://github.com/SocialGouv/mano/commit/7e5c893c7d0e3eabef959b60c94733eeac28be6f))
 
 # [1.50.0](https://github.com/SocialGouv/mano/compare/v1.49.8...v1.50.0) (2022-02-08)
 
+
 ### Features
 
-- **app:** update mobile version ([4e46264](https://github.com/SocialGouv/mano/commit/4e462640c17aaae2c58e7d0211f6b4f3c9de2c4d))
+* **app:** update mobile version ([4e46264](https://github.com/SocialGouv/mano/commit/4e462640c17aaae2c58e7d0211f6b4f3c9de2c4d))
 
 ## [1.49.8](https://github.com/SocialGouv/mano/compare/v1.49.7...v1.49.8) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix iedge error for scroll ([6345382](https://github.com/SocialGouv/mano/commit/63453823b7f915398e44a118c4aa7731f21f11d4))
+* **dashboard:** fix iedge error for scroll ([6345382](https://github.com/SocialGouv/mano/commit/63453823b7f915398e44a118c4aa7731f21f11d4))
 
 ## [1.49.7](https://github.com/SocialGouv/mano/compare/v1.49.6...v1.49.7) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix refresher bugs ([#353](https://github.com/SocialGouv/mano/issues/353)) ([5831d61](https://github.com/SocialGouv/mano/commit/5831d614fb45379f42d988ecbc447472aabd1ef2))
+* **dashboard:** fix refresher bugs ([#353](https://github.com/SocialGouv/mano/issues/353)) ([5831d61](https://github.com/SocialGouv/mano/commit/5831d614fb45379f42d988ecbc447472aabd1ef2))
 
 ## [1.49.6](https://github.com/SocialGouv/mano/compare/v1.49.5...v1.49.6) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **app:** remove cache when changing organisation ([#354](https://github.com/SocialGouv/mano/issues/354)) ([4d37cbe](https://github.com/SocialGouv/mano/commit/4d37cbee461c90d988ddebdeb83d6552cc3c5190))
+* **app:** remove cache when changing organisation ([#354](https://github.com/SocialGouv/mano/issues/354)) ([4d37cbe](https://github.com/SocialGouv/mano/commit/4d37cbee461c90d988ddebdeb83d6552cc3c5190))
 
 ## [1.49.5](https://github.com/SocialGouv/mano/compare/v1.49.4...v1.49.5) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** categories can be empty ([a8ecbb1](https://github.com/SocialGouv/mano/commit/a8ecbb1d283f2e35f097272ba35803bfef94eaa6))
+* **dashboard:** categories can be empty ([a8ecbb1](https://github.com/SocialGouv/mano/commit/a8ecbb1d283f2e35f097272ba35803bfef94eaa6))
 
 ## [1.49.4](https://github.com/SocialGouv/mano/compare/v1.49.3...v1.49.4) (2022-02-08)
 
+
 ### Bug Fixes
 
-- **app:** fix action on save ([2f32f25](https://github.com/SocialGouv/mano/commit/2f32f251a769674aa7384abd60785aab51e3bb1a))
+* **app:** fix action on save ([2f32f25](https://github.com/SocialGouv/mano/commit/2f32f251a769674aa7384abd60785aab51e3bb1a))
 
 ## [1.49.3](https://github.com/SocialGouv/mano/compare/v1.49.2...v1.49.3) (2022-02-07)
 
+
 ### Bug Fixes
 
-- bump release ([8d0a49a](https://github.com/SocialGouv/mano/commit/8d0a49a6c3cc30f355a77e5d92fb139113961002))
+* bump release ([8d0a49a](https://github.com/SocialGouv/mano/commit/8d0a49a6c3cc30f355a77e5d92fb139113961002))
 
 ## [1.49.2](https://github.com/SocialGouv/mano/compare/v1.49.1...v1.49.2) (2022-02-07)
 
+
 ### Bug Fixes
 
-- **dashboard:** display teams ([24a7ae1](https://github.com/SocialGouv/mano/commit/24a7ae14770a1c0a32a58ac1dca1a01d549e545a))
+* **dashboard:** display teams ([24a7ae1](https://github.com/SocialGouv/mano/commit/24a7ae14770a1c0a32a58ac1dca1a01d549e545a))
 
 ## [1.49.1](https://github.com/SocialGouv/mano/compare/v1.49.0...v1.49.1) (2022-02-07)
 
+
 ### Bug Fixes
 
-- **dashboard:** error deleting person due to casade ([#347](https://github.com/SocialGouv/mano/issues/347)) ([0e808a1](https://github.com/SocialGouv/mano/commit/0e808a1e228e0ee9145ea985302a09633ca72da5))
-- **dashboard:** old dates in import aka 1940 bug ([#345](https://github.com/SocialGouv/mano/issues/345)) ([0051651](https://github.com/SocialGouv/mano/commit/00516516a019c601287e5ba61270b43dbd96e9c9))
+* **dashboard:** error deleting person due to casade ([#347](https://github.com/SocialGouv/mano/issues/347)) ([0e808a1](https://github.com/SocialGouv/mano/commit/0e808a1e228e0ee9145ea985302a09633ca72da5))
+* **dashboard:** old dates in import aka 1940 bug ([#345](https://github.com/SocialGouv/mano/issues/345)) ([0051651](https://github.com/SocialGouv/mano/commit/00516516a019c601287e5ba61270b43dbd96e9c9))
 
 # [1.49.0](https://github.com/SocialGouv/mano/compare/v1.48.5...v1.49.0) (2022-02-07)
 
+
 ### Bug Fixes
 
-- **dashboard:** import boolean ([#344](https://github.com/SocialGouv/mano/issues/344)) ([cf2e5b9](https://github.com/SocialGouv/mano/commit/cf2e5b9b2202e573132f3c40145ff16956709015))
+* **dashboard:** import boolean ([#344](https://github.com/SocialGouv/mano/issues/344)) ([cf2e5b9](https://github.com/SocialGouv/mano/commit/cf2e5b9b2202e573132f3c40145ff16956709015))
+
 
 ### Features
 
-- **dashboard:** more info in download example ([#343](https://github.com/SocialGouv/mano/issues/343)) ([8bd7f21](https://github.com/SocialGouv/mano/commit/8bd7f2144e11967a7c1d2100df89534e567ccc65))
-- **import:** improve description in import ([#342](https://github.com/SocialGouv/mano/issues/342)) ([065fc52](https://github.com/SocialGouv/mano/commit/065fc528c81546aad088b1db77004eabc13e3d63))
+* **dashboard:** more info in download example ([#343](https://github.com/SocialGouv/mano/issues/343)) ([8bd7f21](https://github.com/SocialGouv/mano/commit/8bd7f2144e11967a7c1d2100df89534e567ccc65))
+* **import:** improve description in import ([#342](https://github.com/SocialGouv/mano/issues/342)) ([065fc52](https://github.com/SocialGouv/mano/commit/065fc528c81546aad088b1db77004eabc13e3d63))
 
 ## [1.48.5](https://github.com/SocialGouv/mano/compare/v1.48.4...v1.48.5) (2022-02-07)
 
+
 ### Bug Fixes
 
-- typo fr ([#348](https://github.com/SocialGouv/mano/issues/348)) ([6875c97](https://github.com/SocialGouv/mano/commit/6875c97feb01ea6af54e66d900ffe068015ace00))
-- **typo:** and mise a jour ([#349](https://github.com/SocialGouv/mano/issues/349)) ([29497aa](https://github.com/SocialGouv/mano/commit/29497aab2c228e86ba11b9e378317037a433bbd3))
+* typo fr ([#348](https://github.com/SocialGouv/mano/issues/348)) ([6875c97](https://github.com/SocialGouv/mano/commit/6875c97feb01ea6af54e66d900ffe068015ace00))
+* **typo:** and mise a jour ([#349](https://github.com/SocialGouv/mano/issues/349)) ([29497aa](https://github.com/SocialGouv/mano/commit/29497aab2c228e86ba11b9e378317037a433bbd3))
 
 ## [1.48.4](https://github.com/SocialGouv/mano/compare/v1.48.3...v1.48.4) (2022-02-07)
 
+
 ### Bug Fixes
 
-- fix error ([b82a482](https://github.com/SocialGouv/mano/commit/b82a4828ecd2804f1e81e17fe4f333657fe6777e))
+* fix error ([b82a482](https://github.com/SocialGouv/mano/commit/b82a4828ecd2804f1e81e17fe4f333657fe6777e))
 
 ## [1.48.3](https://github.com/SocialGouv/mano/compare/v1.48.2...v1.48.3) (2022-02-04)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency xlsx to ^0.18.0 ([#336](https://github.com/SocialGouv/mano/issues/336)) ([2e02a18](https://github.com/SocialGouv/mano/commit/2e02a18cdb38cacd99aebe85758c21043dd81172))
+* **deps:** update dependency xlsx to ^0.18.0 ([#336](https://github.com/SocialGouv/mano/issues/336)) ([2e02a18](https://github.com/SocialGouv/mano/commit/2e02a18cdb38cacd99aebe85758c21043dd81172))
 
 ## [1.48.2](https://github.com/SocialGouv/mano/compare/v1.48.1...v1.48.2) (2022-02-03)
 
+
 ### Bug Fixes
 
-- **dashboard:** dates with dayjs ([#334](https://github.com/SocialGouv/mano/issues/334)) ([4a4bfa4](https://github.com/SocialGouv/mano/commit/4a4bfa4aedbbd17a514455a84935e27c9148a465))
+* **dashboard:** dates with dayjs ([#334](https://github.com/SocialGouv/mano/issues/334)) ([4a4bfa4](https://github.com/SocialGouv/mano/commit/4a4bfa4aedbbd17a514455a84935e27c9148a465))
 
 ## [1.48.1](https://github.com/SocialGouv/mano/compare/v1.48.0...v1.48.1) (2022-02-03)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency dotenv to v16 ([#340](https://github.com/SocialGouv/mano/issues/340)) ([5009147](https://github.com/SocialGouv/mano/commit/5009147266fbd8ad95f742a29b275e0b6c1257f2))
+* **deps:** update dependency dotenv to v16 ([#340](https://github.com/SocialGouv/mano/issues/340)) ([5009147](https://github.com/SocialGouv/mano/commit/5009147266fbd8ad95f742a29b275e0b6c1257f2))
 
 # [1.48.0](https://github.com/SocialGouv/mano/compare/v1.47.0...v1.48.0) (2022-02-03)
 
+
 ### Features
 
-- **api,dashboard,app:** remove relPersonTeam usage ([#327](https://github.com/SocialGouv/mano/issues/327)) ([b34607d](https://github.com/SocialGouv/mano/commit/b34607d11a21bdfce4a6f11c9f07dfc1bd6c0fc8))
+* **api,dashboard,app:** remove relPersonTeam usage ([#327](https://github.com/SocialGouv/mano/issues/327)) ([b34607d](https://github.com/SocialGouv/mano/commit/b34607d11a21bdfce4a6f11c9f07dfc1bd6c0fc8))
 
 # [1.47.0](https://github.com/SocialGouv/mano/compare/v1.46.6...v1.47.0) (2022-02-03)
 
+
 ### Features
 
-- **dahsboard,app:** add hotel ([fb41665](https://github.com/SocialGouv/mano/commit/fb41665984ef8ed3d46521ce3c0c4934b755ef41))
+* **dahsboard,app:** add hotel ([fb41665](https://github.com/SocialGouv/mano/commit/fb41665984ef8ed3d46521ce3c0c4934b755ef41))
 
 ## [1.46.6](https://github.com/SocialGouv/mano/compare/v1.46.5...v1.46.6) (2022-02-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** rollback reactselect and reactstrap ([#338](https://github.com/SocialGouv/mano/issues/338)) ([3152b65](https://github.com/SocialGouv/mano/commit/3152b65a0a5310d41c3a6075402e1786988a83fe))
+* **dashboard:** rollback reactselect and reactstrap ([#338](https://github.com/SocialGouv/mano/issues/338)) ([3152b65](https://github.com/SocialGouv/mano/commit/3152b65a0a5310d41c3a6075402e1786988a83fe))
 
 ## [1.46.5](https://github.com/SocialGouv/mano/compare/v1.46.4...v1.46.5) (2022-02-02)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency reactstrap to v9 ([#321](https://github.com/SocialGouv/mano/issues/321)) ([c647abe](https://github.com/SocialGouv/mano/commit/c647abe350e12594baf828a5907327080fa63285))
+* **deps:** update dependency reactstrap to v9 ([#321](https://github.com/SocialGouv/mano/issues/321)) ([c647abe](https://github.com/SocialGouv/mano/commit/c647abe350e12594baf828a5907327080fa63285))
 
 ## [1.46.4](https://github.com/SocialGouv/mano/compare/v1.46.3...v1.46.4) (2022-02-02)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency dotenv to v15 ([#319](https://github.com/SocialGouv/mano/issues/319)) ([f1d9470](https://github.com/SocialGouv/mano/commit/f1d9470f1966a5853a864e073e054c80dda2c891))
+* **deps:** update dependency dotenv to v15 ([#319](https://github.com/SocialGouv/mano/issues/319)) ([f1d9470](https://github.com/SocialGouv/mano/commit/f1d9470f1966a5853a864e073e054c80dda2c891))
 
 ## [1.46.3](https://github.com/SocialGouv/mano/compare/v1.46.2...v1.46.3) (2022-02-02)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency react-select to v5 ([#320](https://github.com/SocialGouv/mano/issues/320)) ([ce6722b](https://github.com/SocialGouv/mano/commit/ce6722bdb167971ca3c40c3f023fba94bc47c085))
+* **deps:** update dependency react-select to v5 ([#320](https://github.com/SocialGouv/mano/issues/320)) ([ce6722b](https://github.com/SocialGouv/mano/commit/ce6722bdb167971ca3c40c3f023fba94bc47c085))
 
 ## [1.46.2](https://github.com/SocialGouv/mano/compare/v1.46.1...v1.46.2) (2022-02-01)
 
+
 ### Bug Fixes
 
-- **ci:** fix proxy secrets ([#332](https://github.com/SocialGouv/mano/issues/332)) ([6df6793](https://github.com/SocialGouv/mano/commit/6df67937330b78684f78e40a431ab948ff279090))
+* **ci:** fix proxy secrets ([#332](https://github.com/SocialGouv/mano/issues/332)) ([6df6793](https://github.com/SocialGouv/mano/commit/6df67937330b78684f78e40a431ab948ff279090))
 
 ## [1.46.1](https://github.com/SocialGouv/mano/compare/v1.46.0...v1.46.1) (2022-02-01)
 
+
 ### Bug Fixes
 
-- **dashboard:** debug false ([ebf3f29](https://github.com/SocialGouv/mano/commit/ebf3f29594fad4021b5214eef06ee96d602731aa))
+* **dashboard:** debug false ([ebf3f29](https://github.com/SocialGouv/mano/commit/ebf3f29594fad4021b5214eef06ee96d602731aa))
 
 # [1.46.0](https://github.com/SocialGouv/mano/compare/v1.45.3...v1.46.0) (2022-02-01)
 
+
 ### Features
 
-- **metabase:** add github auth proxy ([#293](https://github.com/SocialGouv/mano/issues/293)) ([87e9edb](https://github.com/SocialGouv/mano/commit/87e9edbce2891dd481c17190637b693908032906))
+* **metabase:** add github auth proxy ([#293](https://github.com/SocialGouv/mano/issues/293)) ([87e9edb](https://github.com/SocialGouv/mano/commit/87e9edbce2891dd481c17190637b693908032906))
 
 ## [1.45.3](https://github.com/SocialGouv/mano/compare/v1.45.2...v1.45.3) (2022-01-31)
 
+
 ### Bug Fixes
 
-- **dashboard:** fix stats for passages ([d49ef27](https://github.com/SocialGouv/mano/commit/d49ef27d2e589dabddd5ca52122418bf7977c839))
+* **dashboard:** fix stats for passages ([d49ef27](https://github.com/SocialGouv/mano/commit/d49ef27d2e589dabddd5ca52122418bf7977c839))
 
 ## [1.45.2](https://github.com/SocialGouv/mano/compare/v1.45.1...v1.45.2) (2022-01-31)
 
+
 ### Bug Fixes
 
-- fix passages count in stat ([#314](https://github.com/SocialGouv/mano/issues/314)) ([8a31646](https://github.com/SocialGouv/mano/commit/8a31646d25b7955d9a3745d22686b2216b5bbdd1))
+* fix passages count in stat ([#314](https://github.com/SocialGouv/mano/issues/314)) ([8a31646](https://github.com/SocialGouv/mano/commit/8a31646d25b7955d9a3745d22686b2216b5bbdd1))
 
 ## [1.45.1](https://github.com/SocialGouv/mano/compare/v1.45.0...v1.45.1) (2022-01-31)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency recoil to ^0.6.0 ([#318](https://github.com/SocialGouv/mano/issues/318)) ([3afbc08](https://github.com/SocialGouv/mano/commit/3afbc089723452edefa1d25f664493ced021d530))
+* **deps:** update dependency recoil to ^0.6.0 ([#318](https://github.com/SocialGouv/mano/issues/318)) ([3afbc08](https://github.com/SocialGouv/mano/commit/3afbc089723452edefa1d25f664493ced021d530))
 
 # [1.45.0](https://github.com/SocialGouv/mano/compare/v1.44.3...v1.45.0) (2022-01-31)
 
+
 ### Features
 
-- **dashboard:** import teams ([#312](https://github.com/SocialGouv/mano/issues/312)) ([f6d195d](https://github.com/SocialGouv/mano/commit/f6d195d44c8eae5a44500a77b9366b8676a90cfe))
+* **dashboard:** import teams ([#312](https://github.com/SocialGouv/mano/issues/312)) ([f6d195d](https://github.com/SocialGouv/mano/commit/f6d195d44c8eae5a44500a77b9366b8676a90cfe))
 
 ## [1.44.3](https://github.com/SocialGouv/mano/compare/v1.44.2...v1.44.3) (2022-01-29)
 
+
 ### Bug Fixes
 
-- **deps:** update nivo monorepo ([#304](https://github.com/SocialGouv/mano/issues/304)) ([7ae10d9](https://github.com/SocialGouv/mano/commit/7ae10d99376fb3a1b5e13e069810597b1fa6f2eb))
+* **deps:** update nivo monorepo ([#304](https://github.com/SocialGouv/mano/issues/304)) ([7ae10d9](https://github.com/SocialGouv/mano/commit/7ae10d99376fb3a1b5e13e069810597b1fa6f2eb))
 
 ## [1.44.2](https://github.com/SocialGouv/mano/compare/v1.44.1...v1.44.2) (2022-01-28)
 
+
 ### Bug Fixes
 
-- **app:** remove classes ([#308](https://github.com/SocialGouv/mano/issues/308)) ([bca118f](https://github.com/SocialGouv/mano/commit/bca118fd72f23d59abd4506ab51f5429ecc66bfb))
+* **app:** remove classes ([#308](https://github.com/SocialGouv/mano/issues/308)) ([bca118f](https://github.com/SocialGouv/mano/commit/bca118fd72f23d59abd4506ab51f5429ecc66bfb))
 
 ## [1.44.1](https://github.com/SocialGouv/mano/compare/v1.44.0...v1.44.1) (2022-01-27)
 
+
 ### Bug Fixes
 
-- **dashboard:** import custom fields ([#311](https://github.com/SocialGouv/mano/issues/311)) ([9a2e88f](https://github.com/SocialGouv/mano/commit/9a2e88f2988e9ee7872f0243b20fe30f5d9951c2))
+* **dashboard:** import custom fields ([#311](https://github.com/SocialGouv/mano/issues/311)) ([9a2e88f](https://github.com/SocialGouv/mano/commit/9a2e88f2988e9ee7872f0243b20fe30f5d9951c2))
 
 # [1.44.0](https://github.com/SocialGouv/mano/compare/v1.43.4...v1.44.0) (2022-01-27)
 
+
 ### Features
 
-- **dashboard:** scroll to top on page change ([#287](https://github.com/SocialGouv/mano/issues/287)) ([f062519](https://github.com/SocialGouv/mano/commit/f062519b647c19943a59beedb5a89953db81c8e3))
+* **dashboard:** scroll to top on page change ([#287](https://github.com/SocialGouv/mano/issues/287)) ([f062519](https://github.com/SocialGouv/mano/commit/f062519b647c19943a59beedb5a89953db81c8e3))
 
 ## [1.43.4](https://github.com/SocialGouv/mano/compare/v1.43.3...v1.43.4) (2022-01-27)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency node-fetch to v2.6.7 [security] ([#296](https://github.com/SocialGouv/mano/issues/296)) ([bbf66e7](https://github.com/SocialGouv/mano/commit/bbf66e702bdc9010e12dd0cbfe057f608bbc1e0b))
+* **deps:** update dependency node-fetch to v2.6.7 [security] ([#296](https://github.com/SocialGouv/mano/issues/296)) ([bbf66e7](https://github.com/SocialGouv/mano/commit/bbf66e702bdc9010e12dd0cbfe057f608bbc1e0b))
 
 ## [1.43.3](https://github.com/SocialGouv/mano/compare/v1.43.2...v1.43.3) (2022-01-26)
 
+
 ### Bug Fixes
 
-- **dashboard:** import data ([#298](https://github.com/SocialGouv/mano/issues/298)) ([8ef6e12](https://github.com/SocialGouv/mano/commit/8ef6e12fe7cf9080f56b30701d0489da74714fec))
+* **dashboard:** import data ([#298](https://github.com/SocialGouv/mano/issues/298)) ([8ef6e12](https://github.com/SocialGouv/mano/commit/8ef6e12fe7cf9080f56b30701d0489da74714fec))
 
 ## [1.43.2](https://github.com/SocialGouv/mano/compare/v1.43.1...v1.43.2) (2022-01-26)
 
+
 ### Bug Fixes
 
-- **api:** no need password ([#297](https://github.com/SocialGouv/mano/issues/297)) ([e40b1ea](https://github.com/SocialGouv/mano/commit/e40b1ea13581f4180322b08cb9bf76e5e3348afd))
+* **api:** no need password ([#297](https://github.com/SocialGouv/mano/issues/297)) ([e40b1ea](https://github.com/SocialGouv/mano/commit/e40b1ea13581f4180322b08cb9bf76e5e3348afd))
 
 ## [1.43.1](https://github.com/SocialGouv/mano/compare/v1.43.0...v1.43.1) (2022-01-26)
 
+
 ### Bug Fixes
 
-- **app:** dont show undefined in terrotiry observations ([#288](https://github.com/SocialGouv/mano/issues/288)) ([0d2aade](https://github.com/SocialGouv/mano/commit/0d2aade7b2f7cbb41738f383360065aead392b97))
+* **app:** dont show undefined in terrotiry observations ([#288](https://github.com/SocialGouv/mano/issues/288)) ([0d2aade](https://github.com/SocialGouv/mano/commit/0d2aade7b2f7cbb41738f383360065aead392b97))
 
 # [1.43.0](https://github.com/SocialGouv/mano/compare/v1.42.2...v1.43.0) (2022-01-26)
 
+
 ### Features
 
-- **dash:** onboarding with encryption ([#285](https://github.com/SocialGouv/mano/issues/285)) ([7e25424](https://github.com/SocialGouv/mano/commit/7e25424e579272b99f39d466703db784391f7bbe))
+* **dash:** onboarding with encryption ([#285](https://github.com/SocialGouv/mano/issues/285)) ([7e25424](https://github.com/SocialGouv/mano/commit/7e25424e579272b99f39d466703db784391f7bbe))
 
 ## [1.42.2](https://github.com/SocialGouv/mano/compare/v1.42.1...v1.42.2) (2022-01-25)
 
+
 ### Bug Fixes
 
-- **dashboad:** fix import custom fields ([5b1422b](https://github.com/SocialGouv/mano/commit/5b1422be960dd2f0244c485fdec69a0353c914a6))
+* **dashboad:** fix import custom fields ([5b1422b](https://github.com/SocialGouv/mano/commit/5b1422be960dd2f0244c485fdec69a0353c914a6))
 
 ## [1.42.1](https://github.com/SocialGouv/mano/compare/v1.42.0...v1.42.1) (2022-01-07)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency react-datepicker to v4 ([#271](https://github.com/SocialGouv/mano/issues/271)) ([2e70b96](https://github.com/SocialGouv/mano/commit/2e70b96c8262a292a8ae4a396f51331bf8b4d4d4))
+* **deps:** update dependency react-datepicker to v4 ([#271](https://github.com/SocialGouv/mano/issues/271)) ([2e70b96](https://github.com/SocialGouv/mano/commit/2e70b96c8262a292a8ae4a396f51331bf8b4d4d4))
 
 # [1.42.0](https://github.com/SocialGouv/mano/compare/v1.41.9...v1.42.0) (2022-01-07)
 
+
 ### Features
 
-- **dashboard:** upload docs ([#276](https://github.com/SocialGouv/mano/issues/276)) ([9f5d7b7](https://github.com/SocialGouv/mano/commit/9f5d7b7dd1e8d8202fdfeea793d8ea2a5606352f))
+* **dashboard:** upload docs ([#276](https://github.com/SocialGouv/mano/issues/276)) ([9f5d7b7](https://github.com/SocialGouv/mano/commit/9f5d7b7dd1e8d8202fdfeea793d8ea2a5606352f))
 
 ## [1.41.9](https://github.com/SocialGouv/mano/compare/v1.41.8...v1.41.9) (2021-12-21)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency urijs to v1.19.7 [security] ([#274](https://github.com/SocialGouv/mano/issues/274)) ([72a3e85](https://github.com/SocialGouv/mano/commit/72a3e85c89ae33b83f1194fdbbfd556013b14974))
+* **deps:** update dependency urijs to v1.19.7 [security] ([#274](https://github.com/SocialGouv/mano/issues/274)) ([72a3e85](https://github.com/SocialGouv/mano/commit/72a3e85c89ae33b83f1194fdbbfd556013b14974))
 
 ## [1.41.8](https://github.com/SocialGouv/mano/compare/v1.41.7...v1.41.8) (2021-12-21)
 
+
 ### Bug Fixes
 
-- bump release ([8361d04](https://github.com/SocialGouv/mano/commit/8361d04965b538e2f2ee9d9d9951edd22664c29e))
+* bump release ([8361d04](https://github.com/SocialGouv/mano/commit/8361d04965b538e2f2ee9d9d9951edd22664c29e))
 
 ## [1.41.7](https://github.com/SocialGouv/mano/compare/v1.41.6...v1.41.7) (2021-12-21)
 
+
 ### Bug Fixes
 
-- bump release ([9215a49](https://github.com/SocialGouv/mano/commit/9215a4910a0cae0efcd1503fb35f73579b293412))
+* bump release ([9215a49](https://github.com/SocialGouv/mano/commit/9215a4910a0cae0efcd1503fb35f73579b293412))
 
 ## [1.41.6](https://github.com/SocialGouv/mano/compare/v1.41.5...v1.41.6) (2021-12-21)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency dotenv to v10 ([#260](https://github.com/SocialGouv/mano/issues/260)) ([8e5f90e](https://github.com/SocialGouv/mano/commit/8e5f90edf9d9b50618a4c4e2a98b2014f3d1bfe7))
+* **deps:** update dependency dotenv to v10 ([#260](https://github.com/SocialGouv/mano/issues/260)) ([8e5f90e](https://github.com/SocialGouv/mano/commit/8e5f90edf9d9b50618a4c4e2a98b2014f3d1bfe7))
 
 ## [1.41.5](https://github.com/SocialGouv/mano/compare/v1.41.4...v1.41.5) (2021-12-21)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency npm to v8 ([#269](https://github.com/SocialGouv/mano/issues/269)) ([11c532f](https://github.com/SocialGouv/mano/commit/11c532fc2178182f2bd1ad2e7088229e785da518))
+* **deps:** update dependency npm to v8 ([#269](https://github.com/SocialGouv/mano/issues/269)) ([11c532f](https://github.com/SocialGouv/mano/commit/11c532fc2178182f2bd1ad2e7088229e785da518))
 
 ## [1.41.4](https://github.com/SocialGouv/mano/compare/v1.41.3...v1.41.4) (2021-12-20)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency helmet to v4 ([#263](https://github.com/SocialGouv/mano/issues/263)) ([71e214c](https://github.com/SocialGouv/mano/commit/71e214c154fcd7b630e4912cc48c7a5b25eb6fe6))
+* **deps:** update dependency helmet to v4 ([#263](https://github.com/SocialGouv/mano/issues/263)) ([71e214c](https://github.com/SocialGouv/mano/commit/71e214c154fcd7b630e4912cc48c7a5b25eb6fe6))
 
 ## [1.41.3](https://github.com/SocialGouv/mano/compare/v1.41.2...v1.41.3) (2021-12-20)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency next to v12 ([#264](https://github.com/SocialGouv/mano/issues/264)) ([521ae70](https://github.com/SocialGouv/mano/commit/521ae70183f64062d4bacbb6c817a744ddda9ec7))
+* **deps:** update dependency next to v12 ([#264](https://github.com/SocialGouv/mano/issues/264)) ([521ae70](https://github.com/SocialGouv/mano/commit/521ae70183f64062d4bacbb6c817a744ddda9ec7))
 
 ## [1.41.2](https://github.com/SocialGouv/mano/compare/v1.41.1...v1.41.2) (2021-12-20)
 
+
 ### Bug Fixes
 
-- **dashboard:** comment.person can be empty ([9feb344](https://github.com/SocialGouv/mano/commit/9feb344fccc16d6be1c551fc868800fe865352a0))
+* **dashboard:** comment.person can be empty ([9feb344](https://github.com/SocialGouv/mano/commit/9feb344fccc16d6be1c551fc868800fe865352a0))
 
 ## [1.41.1](https://github.com/SocialGouv/mano/compare/v1.41.0...v1.41.1) (2021-12-20)
 
+
 ### Bug Fixes
 
-- **dashboard:** at least one team for user ([#252](https://github.com/SocialGouv/mano/issues/252)) ([bd7e205](https://github.com/SocialGouv/mano/commit/bd7e205f401e0ae515071a37b6526a413b600a7e))
+* **dashboard:** at least one team for user ([#252](https://github.com/SocialGouv/mano/issues/252)) ([bd7e205](https://github.com/SocialGouv/mano/commit/bd7e205f401e0ae515071a37b6526a413b600a7e))
 
 # [1.41.0](https://github.com/SocialGouv/mano/compare/v1.40.6...v1.41.0) (2021-12-17)
 
+
 ### Features
 
-- **dashboard:** all fields in create action modal ([#247](https://github.com/SocialGouv/mano/issues/247)) ([18766ea](https://github.com/SocialGouv/mano/commit/18766ea596cfcab712fd6a8f8c45877225a0a2a1))
+* **dashboard:** all fields in create action modal ([#247](https://github.com/SocialGouv/mano/issues/247)) ([18766ea](https://github.com/SocialGouv/mano/commit/18766ea596cfcab712fd6a8f8c45877225a0a2a1))
 
 ## [1.40.6](https://github.com/SocialGouv/mano/compare/v1.40.5...v1.40.6) (2021-12-17)
 
+
 ### Bug Fixes
 
-- **deps:** update react monorepo ([#244](https://github.com/SocialGouv/mano/issues/244)) ([11aea86](https://github.com/SocialGouv/mano/commit/11aea8673e1beafb5ad6240bc1c1bb1d29f8c9f2))
+* **deps:** update react monorepo ([#244](https://github.com/SocialGouv/mano/issues/244)) ([11aea86](https://github.com/SocialGouv/mano/commit/11aea8673e1beafb5ad6240bc1c1bb1d29f8c9f2))
 
 ## [1.40.5](https://github.com/SocialGouv/mano/compare/v1.40.4...v1.40.5) (2021-12-17)
 
+
 ### Bug Fixes
 
-- **deps:** update nivo monorepo to ^0.75.0 ([#243](https://github.com/SocialGouv/mano/issues/243)) ([a389f7e](https://github.com/SocialGouv/mano/commit/a389f7ead8f87f1f0fb1eaff2ad98491cf63c609))
+* **deps:** update nivo monorepo to ^0.75.0 ([#243](https://github.com/SocialGouv/mano/issues/243)) ([a389f7e](https://github.com/SocialGouv/mano/commit/a389f7ead8f87f1f0fb1eaff2ad98491cf63c609))
 
 ## [1.40.4](https://github.com/SocialGouv/mano/compare/v1.40.3...v1.40.4) (2021-12-17)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency @socialgouv/kosko-charts to ^9.8.21 ([#232](https://github.com/SocialGouv/mano/issues/232)) ([e15a270](https://github.com/SocialGouv/mano/commit/e15a270cdb12db03c994011d0b2e8b2099b1ba61))
-- **deps:** update dependency react-select to ^4.3.1 ([#229](https://github.com/SocialGouv/mano/issues/229)) ([457c60c](https://github.com/SocialGouv/mano/commit/457c60ce808d1793cffc52e4584d2371a013344c))
-- **deps:** update dependency recoil to ^0.5.2 ([#230](https://github.com/SocialGouv/mano/issues/230)) ([9dc91e8](https://github.com/SocialGouv/mano/commit/9dc91e8084bd510677217a05b5900414119be737))
+* **deps:** update dependency @socialgouv/kosko-charts to ^9.8.21 ([#232](https://github.com/SocialGouv/mano/issues/232)) ([e15a270](https://github.com/SocialGouv/mano/commit/e15a270cdb12db03c994011d0b2e8b2099b1ba61))
+* **deps:** update dependency react-select to ^4.3.1 ([#229](https://github.com/SocialGouv/mano/issues/229)) ([457c60c](https://github.com/SocialGouv/mano/commit/457c60ce808d1793cffc52e4584d2371a013344c))
+* **deps:** update dependency recoil to ^0.5.2 ([#230](https://github.com/SocialGouv/mano/issues/230)) ([9dc91e8](https://github.com/SocialGouv/mano/commit/9dc91e8084bd510677217a05b5900414119be737))
 
 ## [1.40.3](https://github.com/SocialGouv/mano/compare/v1.40.2...v1.40.3) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency react-native-config to ^1.4.5 ([#224](https://github.com/SocialGouv/mano/issues/224)) ([15102ee](https://github.com/SocialGouv/mano/commit/15102ee6e13eadca925b6de6071c40dfc1292d29))
-- **deps:** update dependency react-native-svg to ^12.1.1 ([#225](https://github.com/SocialGouv/mano/issues/225)) ([e08266a](https://github.com/SocialGouv/mano/commit/e08266a21522650796dc9902ff5163310556e821))
+* **deps:** update dependency react-native-config to ^1.4.5 ([#224](https://github.com/SocialGouv/mano/issues/224)) ([15102ee](https://github.com/SocialGouv/mano/commit/15102ee6e13eadca925b6de6071c40dfc1292d29))
+* **deps:** update dependency react-native-svg to ^12.1.1 ([#225](https://github.com/SocialGouv/mano/issues/225)) ([e08266a](https://github.com/SocialGouv/mano/commit/e08266a21522650796dc9902ff5163310556e821))
 
 ## [1.40.2](https://github.com/SocialGouv/mano/compare/v1.40.1...v1.40.2) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency react-redux to ^7.2.6 ([#226](https://github.com/SocialGouv/mano/issues/226)) ([ef29390](https://github.com/SocialGouv/mano/commit/ef2939059ce1a5537e159c104079070d9b7f483d))
+* **deps:** update dependency react-redux to ^7.2.6 ([#226](https://github.com/SocialGouv/mano/issues/226)) ([ef29390](https://github.com/SocialGouv/mano/commit/ef2939059ce1a5537e159c104079070d9b7f483d))
 
 ## [1.40.1](https://github.com/SocialGouv/mano/compare/v1.40.0...v1.40.1) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency helmet to ^3.23.3 ([#219](https://github.com/SocialGouv/mano/issues/219)) ([ad75b75](https://github.com/SocialGouv/mano/commit/ad75b75eb47f80601f441c48bbaba130476f3310))
+* **deps:** update dependency helmet to ^3.23.3 ([#219](https://github.com/SocialGouv/mano/issues/219)) ([ad75b75](https://github.com/SocialGouv/mano/commit/ad75b75eb47f80601f441c48bbaba130476f3310))
 
 # [1.40.0](https://github.com/SocialGouv/mano/compare/v1.39.4...v1.40.0) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency react-icons to ^4.3.1 ([#222](https://github.com/SocialGouv/mano/issues/222)) ([0d64687](https://github.com/SocialGouv/mano/commit/0d646874c331bb13f1f8e4985734755bbd9bd34f))
+* **deps:** update dependency react-icons to ^4.3.1 ([#222](https://github.com/SocialGouv/mano/issues/222)) ([0d64687](https://github.com/SocialGouv/mano/commit/0d646874c331bb13f1f8e4985734755bbd9bd34f))
+
 
 ### Features
 
-- **dashboard:** filter by territory on stats ([#208](https://github.com/SocialGouv/mano/issues/208)) ([6d58054](https://github.com/SocialGouv/mano/commit/6d58054269b2085f2db43ccd0db1ba62d87a4f2d))
+* **dashboard:** filter by territory on stats ([#208](https://github.com/SocialGouv/mano/issues/208)) ([6d58054](https://github.com/SocialGouv/mano/commit/6d58054269b2085f2db43ccd0db1ba62d87a4f2d))
 
 ## [1.39.4](https://github.com/SocialGouv/mano/compare/v1.39.3...v1.39.4) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency react-datepicker to ^3.8.0 ([#221](https://github.com/SocialGouv/mano/issues/221)) ([310cda4](https://github.com/SocialGouv/mano/commit/310cda4ab777155cdc06af5a5121646978047aec))
+* **deps:** update dependency react-datepicker to ^3.8.0 ([#221](https://github.com/SocialGouv/mano/issues/221)) ([310cda4](https://github.com/SocialGouv/mano/commit/310cda4ab777155cdc06af5a5121646978047aec))
 
 ## [1.39.3](https://github.com/SocialGouv/mano/compare/v1.39.2...v1.39.3) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency formik to ^2.2.9 ([#211](https://github.com/SocialGouv/mano/issues/211)) ([f46152e](https://github.com/SocialGouv/mano/commit/f46152e716d726526e26cf28958ccf286f295955))
+* **deps:** update dependency formik to ^2.2.9 ([#211](https://github.com/SocialGouv/mano/issues/211)) ([f46152e](https://github.com/SocialGouv/mano/commit/f46152e716d726526e26cf28958ccf286f295955))
 
 ## [1.39.2](https://github.com/SocialGouv/mano/compare/v1.39.1...v1.39.2) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency dotenv to ^8.6.0 ([#218](https://github.com/SocialGouv/mano/issues/218)) ([12172ae](https://github.com/SocialGouv/mano/commit/12172ae878d14983d6394af648c0c9fed8916f9f))
+* **deps:** update dependency dotenv to ^8.6.0 ([#218](https://github.com/SocialGouv/mano/issues/218)) ([12172ae](https://github.com/SocialGouv/mano/commit/12172ae878d14983d6394af648c0c9fed8916f9f))
 
 ## [1.39.1](https://github.com/SocialGouv/mano/compare/v1.39.0...v1.39.1) (2021-12-16)
 
+
 ### Bug Fixes
 
-- **deps:** update dependency @headlessui/react to ^1.4.2 ([#206](https://github.com/SocialGouv/mano/issues/206)) ([235b054](https://github.com/SocialGouv/mano/commit/235b0549822f235efcebd26f84f7226363dec5d2))
-- **deps:** update dependency bootstrap to ^4.6.1 ([#207](https://github.com/SocialGouv/mano/issues/207)) ([d465daf](https://github.com/SocialGouv/mano/commit/d465daf08726a9b31ae7f70129187f5b7f5df9b1))
+* **deps:** update dependency @headlessui/react to ^1.4.2 ([#206](https://github.com/SocialGouv/mano/issues/206)) ([235b054](https://github.com/SocialGouv/mano/commit/235b0549822f235efcebd26f84f7226363dec5d2))
+* **deps:** update dependency bootstrap to ^4.6.1 ([#207](https://github.com/SocialGouv/mano/issues/207)) ([d465daf](https://github.com/SocialGouv/mano/commit/d465daf08726a9b31ae7f70129187f5b7f5df9b1))
 
 # [1.39.0](https://github.com/SocialGouv/mano/compare/v1.38.1...v1.39.0) (2021-12-16)
 
+
 ### Features
 
-- **dashboard:** delete orga for superadmin ([#203](https://github.com/SocialGouv/mano/issues/203)) ([8327791](https://github.com/SocialGouv/mano/commit/832779191e1ae63e83ff08646837b7238b28a7ff))
+* **dashboard:** delete orga for superadmin ([#203](https://github.com/SocialGouv/mano/issues/203)) ([8327791](https://github.com/SocialGouv/mano/commit/832779191e1ae63e83ff08646837b7238b28a7ff))
 
 ## [1.38.1](https://github.com/SocialGouv/mano/compare/v1.38.0...v1.38.1) (2021-12-16)
 
+
 ### Bug Fixes
 
-- select territory from search tab ([d6e4de1](https://github.com/SocialGouv/mano/commit/d6e4de124ff132e2af06fab6f0dccedc908dfe09))
+* select territory from search tab ([d6e4de1](https://github.com/SocialGouv/mano/commit/d6e4de124ff132e2af06fab6f0dccedc908dfe09))
 
 # [1.38.0](https://github.com/SocialGouv/mano/compare/v1.37.1...v1.38.0) (2021-12-16)
 
+
 ### Features
 
-- **dashboard:** add custom fields in filters ([#202](https://github.com/SocialGouv/mano/issues/202)) ([7d83a3f](https://github.com/SocialGouv/mano/commit/7d83a3f18ab9284d1a0138c27e2242f57051dff3))
+* **dashboard:** add custom fields in filters ([#202](https://github.com/SocialGouv/mano/issues/202)) ([7d83a3f](https://github.com/SocialGouv/mano/commit/7d83a3f18ab9284d1a0138c27e2242f57051dff3))
 
 ## [1.37.1](https://github.com/SocialGouv/mano/compare/v1.37.0...v1.37.1) (2021-12-14)
 
+
 ### Bug Fixes
 
-- **dashboard:** 2 stats repeated twice ([#201](https://github.com/SocialGouv/mano/issues/201)) ([7bcc3fd](https://github.com/SocialGouv/mano/commit/7bcc3fd6b7c908b1d49c172f813cffa6c872bf8c))
+* **dashboard:** 2 stats repeated twice ([#201](https://github.com/SocialGouv/mano/issues/201)) ([7bcc3fd](https://github.com/SocialGouv/mano/commit/7bcc3fd6b7c908b1d49c172f813cffa6c872bf8c))
 
 # [1.37.0](https://github.com/SocialGouv/mano/compare/v1.36.7...v1.37.0) (2021-12-14)
 
+
 ### Bug Fixes
 
-- **api:** fix logout in production ([#200](https://github.com/SocialGouv/mano/issues/200)) ([fde016e](https://github.com/SocialGouv/mano/commit/fde016e094e8bf9e6e18a50b8708927ace818ac4))
-- **dashboard:** filterable fields person ([#199](https://github.com/SocialGouv/mano/issues/199)) ([f8116f1](https://github.com/SocialGouv/mano/commit/f8116f1224a2f2e2fdf0c4717cc6f519b0d3f2dc))
+* **api:** fix logout in production ([#200](https://github.com/SocialGouv/mano/issues/200)) ([fde016e](https://github.com/SocialGouv/mano/commit/fde016e094e8bf9e6e18a50b8708927ace818ac4))
+* **dashboard:** filterable fields person ([#199](https://github.com/SocialGouv/mano/issues/199)) ([f8116f1](https://github.com/SocialGouv/mano/commit/f8116f1224a2f2e2fdf0c4717cc6f519b0d3f2dc))
+
 
 ### Features
 
-- **dashboard:** stats orga and team ([#198](https://github.com/SocialGouv/mano/issues/198)) ([cea0d1c](https://github.com/SocialGouv/mano/commit/cea0d1c571450d803f0f9fbfbd2777acd0581170))
+* **dashboard:** stats orga and team ([#198](https://github.com/SocialGouv/mano/issues/198)) ([cea0d1c](https://github.com/SocialGouv/mano/commit/cea0d1c571450d803f0f9fbfbd2777acd0581170))
 
 ## [1.36.7](https://github.com/SocialGouv/mano/compare/v1.36.6...v1.36.7) (2021-12-13)
 
+
 ### Bug Fixes
 
-- **secu:** add k8s network policies and update snaps ([#188](https://github.com/SocialGouv/mano/issues/188)) ([413e043](https://github.com/SocialGouv/mano/commit/413e0431ae948c0eabb1e392df3ad5fc03652471))
+* **secu:** add k8s network policies and update snaps ([#188](https://github.com/SocialGouv/mano/issues/188)) ([413e043](https://github.com/SocialGouv/mano/commit/413e0431ae948c0eabb1e392df3ad5fc03652471))
 
 ## [1.36.6](https://github.com/SocialGouv/mano/compare/v1.36.5...v1.36.6) (2021-12-13)
 
+
 ### Bug Fixes
 
-- **api,dashboard:** setting encryptedVerificationKey for non admin ([#197](https://github.com/SocialGouv/mano/issues/197)) ([6406ada](https://github.com/SocialGouv/mano/commit/6406ada735983caf0c5c849914258426ef0ea77f))
+* **api,dashboard:** setting encryptedVerificationKey for non admin ([#197](https://github.com/SocialGouv/mano/issues/197)) ([6406ada](https://github.com/SocialGouv/mano/commit/6406ada735983caf0c5c849914258426ef0ea77f))
 
 ## [1.36.5](https://github.com/SocialGouv/mano/compare/v1.36.4...v1.36.5) (2021-12-13)
 
+
 ### Bug Fixes
 
-- upgrade metabase ([#196](https://github.com/SocialGouv/mano/issues/196)) ([677fb6a](https://github.com/SocialGouv/mano/commit/677fb6acf3d5f4b108a39a0d20dd1bc1f89ee8aa))
+* upgrade metabase ([#196](https://github.com/SocialGouv/mano/issues/196)) ([677fb6a](https://github.com/SocialGouv/mano/commit/677fb6acf3d5f4b108a39a0d20dd1bc1f89ee8aa))
 
 ## [1.36.4](https://github.com/SocialGouv/mano/compare/v1.36.3...v1.36.4) (2021-12-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** clean api in dashboard ([#173](https://github.com/SocialGouv/mano/issues/173)) ([fb724e6](https://github.com/SocialGouv/mano/commit/fb724e61b8afc5f23d9b6af6a02fa7ff8fe783ca))
+* **dashboard:** clean api in dashboard ([#173](https://github.com/SocialGouv/mano/issues/173)) ([fb724e6](https://github.com/SocialGouv/mano/commit/fb724e61b8afc5f23d9b6af6a02fa7ff8fe783ca))
 
 ## [1.36.3](https://github.com/SocialGouv/mano/compare/v1.36.2...v1.36.3) (2021-12-10)
 
+
 ### Bug Fixes
 
-- **api:** remove migration script for passages ([#195](https://github.com/SocialGouv/mano/issues/195)) ([c346215](https://github.com/SocialGouv/mano/commit/c346215bd08c5a7860de22141a2b28c4baad1101))
+* **api:** remove migration script for passages ([#195](https://github.com/SocialGouv/mano/issues/195)) ([c346215](https://github.com/SocialGouv/mano/commit/c346215bd08c5a7860de22141a2b28c4baad1101))
 
 ## [1.36.2](https://github.com/SocialGouv/mano/compare/v1.36.1...v1.36.2) (2021-12-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** passages ([#177](https://github.com/SocialGouv/mano/issues/177)) ([c0bb89d](https://github.com/SocialGouv/mano/commit/c0bb89dccc25edce2b05e8d60c73627437612653))
+* **dashboard:** passages ([#177](https://github.com/SocialGouv/mano/issues/177)) ([c0bb89d](https://github.com/SocialGouv/mano/commit/c0bb89dccc25edce2b05e8d60c73627437612653))
 
 ## [1.36.1](https://github.com/SocialGouv/mano/compare/v1.36.0...v1.36.1) (2021-12-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** organisationEncryptionKey can also be setup by non-admin ([#191](https://github.com/SocialGouv/mano/issues/191)) ([e71cfec](https://github.com/SocialGouv/mano/commit/e71cfece5d57068d1b0e052088fd9b971a76d763))
+* **dashboard:** organisationEncryptionKey can also be setup by non-admin ([#191](https://github.com/SocialGouv/mano/issues/191)) ([e71cfec](https://github.com/SocialGouv/mano/commit/e71cfece5d57068d1b0e052088fd9b971a76d763))
 
 # [1.36.0](https://github.com/SocialGouv/mano/compare/v1.35.0...v1.36.0) (2021-12-10)
 
+
 ### Features
 
-- **dashboard:** reset recoil on organisation change ([#194](https://github.com/SocialGouv/mano/issues/194)) ([507549d](https://github.com/SocialGouv/mano/commit/507549df8a9b15a5b24b85fa5d121d387d02dfe6))
+* **dashboard:** reset recoil on organisation change ([#194](https://github.com/SocialGouv/mano/issues/194)) ([507549d](https://github.com/SocialGouv/mano/commit/507549df8a9b15a5b24b85fa5d121d387d02dfe6))
 
 # [1.35.0](https://github.com/SocialGouv/mano/compare/v1.34.2...v1.35.0) (2021-12-10)
 
+
 ### Features
 
-- **dashboard:** import custom fields ([#187](https://github.com/SocialGouv/mano/issues/187)) ([cbaccc6](https://github.com/SocialGouv/mano/commit/cbaccc6d8d0a6738001d748ccecdc3bfb60a9a23))
+* **dashboard:** import custom fields ([#187](https://github.com/SocialGouv/mano/issues/187)) ([cbaccc6](https://github.com/SocialGouv/mano/commit/cbaccc6d8d0a6738001d748ccecdc3bfb60a9a23))
 
 ## [1.34.2](https://github.com/SocialGouv/mano/compare/v1.34.1...v1.34.2) (2021-12-10)
 
+
 ### Bug Fixes
 
-- **dashboard:** on chart click do nothing when nothing to do ([#192](https://github.com/SocialGouv/mano/issues/192)) ([9ef8d0f](https://github.com/SocialGouv/mano/commit/9ef8d0f28551f3b0ecac497ddf4ddb944e9bf579))
+* **dashboard:** on chart click do nothing when nothing to do ([#192](https://github.com/SocialGouv/mano/issues/192)) ([9ef8d0f](https://github.com/SocialGouv/mano/commit/9ef8d0f28551f3b0ecac497ddf4ddb944e9bf579))
 
 ## [1.34.1](https://github.com/SocialGouv/mano/compare/v1.34.0...v1.34.1) (2021-12-10)
 
+
 ### Bug Fixes
 
-- **api:** remove migration script for reports ([#190](https://github.com/SocialGouv/mano/issues/190)) ([300f58c](https://github.com/SocialGouv/mano/commit/300f58c08c6808e71c82d94cb47a107bad17fe35))
+* **api:** remove migration script for reports ([#190](https://github.com/SocialGouv/mano/issues/190)) ([300f58c](https://github.com/SocialGouv/mano/commit/300f58c08c6808e71c82d94cb47a107bad17fe35))
 
 # [1.34.0](https://github.com/SocialGouv/mano/compare/v1.33.1...v1.34.0) (2021-12-07)
 
+
 ### Features
 
-- add new medical default fields ([#186](https://github.com/SocialGouv/mano/issues/186)) ([ffac343](https://github.com/SocialGouv/mano/commit/ffac34324557ff1336f4119245815f0bf99711e5))
+* add new medical default fields ([#186](https://github.com/SocialGouv/mano/issues/186)) ([ffac343](https://github.com/SocialGouv/mano/commit/ffac34324557ff1336f4119245815f0bf99711e5))
 
 ## [1.33.1](https://github.com/SocialGouv/mano/compare/v1.33.0...v1.33.1) (2021-12-07)
 
+
 ### Bug Fixes
 
-- **dashboard:** invalid attempt to spread non-iterable instance ([eb983b0](https://github.com/SocialGouv/mano/commit/eb983b056f152a1e70487c3ece0f0dd2d0f3609b))
+* **dashboard:** invalid attempt to spread non-iterable instance ([eb983b0](https://github.com/SocialGouv/mano/commit/eb983b056f152a1e70487c3ece0f0dd2d0f3609b))
 
 # [1.33.0](https://github.com/SocialGouv/mano/compare/v1.32.2...v1.33.0) (2021-12-06)
 
+
 ### Features
 
-- **dashboard,api:** import xlsx ([#178](https://github.com/SocialGouv/mano/issues/178)) ([0c8cb4a](https://github.com/SocialGouv/mano/commit/0c8cb4a9911b68517b8f76fbfa2e708010080a78))
+* **dashboard,api:** import xlsx ([#178](https://github.com/SocialGouv/mano/issues/178)) ([0c8cb4a](https://github.com/SocialGouv/mano/commit/0c8cb4a9911b68517b8f76fbfa2e708010080a78))
 
 ## [1.32.2](https://github.com/SocialGouv/mano/compare/v1.32.1...v1.32.2) (2021-12-03)
 
+
 ### Bug Fixes
 
-- **api:** migration on reports ([#184](https://github.com/SocialGouv/mano/issues/184)) ([f32db49](https://github.com/SocialGouv/mano/commit/f32db494f5119739079cadbd1fd95e0ddfa13dee))
+* **api:** migration on reports ([#184](https://github.com/SocialGouv/mano/issues/184)) ([f32db49](https://github.com/SocialGouv/mano/commit/f32db494f5119739079cadbd1fd95e0ddfa13dee))
 
 ## [1.32.1](https://github.com/SocialGouv/mano/compare/v1.32.0...v1.32.1) (2021-12-03)
 
+
 ### Bug Fixes
 
-- **api:** stop creating multiple reports ([#183](https://github.com/SocialGouv/mano/issues/183)) ([da6d27a](https://github.com/SocialGouv/mano/commit/da6d27aae2382508c4d0dda54a733c0da9eb297c))
+* **api:** stop creating multiple reports ([#183](https://github.com/SocialGouv/mano/issues/183)) ([da6d27a](https://github.com/SocialGouv/mano/commit/da6d27aae2382508c4d0dda54a733c0da9eb297c))
 
 # [1.32.0](https://github.com/SocialGouv/mano/compare/v1.31.0...v1.32.0) (2021-12-03)
 
+
 ### Features
 
-- release mobile app version ([9bc3c8d](https://github.com/SocialGouv/mano/commit/9bc3c8d2e32d516d7ca1ca82d604bfd982bbe5aa))
+* release mobile app version ([9bc3c8d](https://github.com/SocialGouv/mano/commit/9bc3c8d2e32d516d7ca1ca82d604bfd982bbe5aa))
 
 # [1.31.0](https://github.com/SocialGouv/mano/compare/v1.30.1...v1.31.0) (2021-12-03)
 
+
 ### Features
 
-- custom fields on persons ([#171](https://github.com/SocialGouv/mano/issues/171)) ([71c06d4](https://github.com/SocialGouv/mano/commit/71c06d4204cd45c99a5d51d1a6a0725a43cb77bb))
+* custom fields on persons ([#171](https://github.com/SocialGouv/mano/issues/171)) ([71c06d4](https://github.com/SocialGouv/mano/commit/71c06d4204cd45c99a5d51d1a6a0725a43cb77bb))
 
 ## [1.30.1](https://github.com/SocialGouv/mano/compare/v1.30.0...v1.30.1) (2021-12-03)
 
+
 ### Bug Fixes
 
-- **dashboard:** debug encryption ([#182](https://github.com/SocialGouv/mano/issues/182)) ([a999891](https://github.com/SocialGouv/mano/commit/a999891b416f798d2fed5c45694fca46270a8125))
+* **dashboard:** debug encryption ([#182](https://github.com/SocialGouv/mano/issues/182)) ([a999891](https://github.com/SocialGouv/mano/commit/a999891b416f798d2fed5c45694fca46270a8125))
 
 # [1.30.0](https://github.com/SocialGouv/mano/compare/v1.29.7...v1.30.0) (2021-12-03)
 
+
 ### Features
 
-- **dashboard:** debug encryption ([#181](https://github.com/SocialGouv/mano/issues/181)) ([acef89c](https://github.com/SocialGouv/mano/commit/acef89cbc61f6d5a895e46d0caac5262d45fed5a))
+* **dashboard:** debug encryption ([#181](https://github.com/SocialGouv/mano/issues/181)) ([acef89c](https://github.com/SocialGouv/mano/commit/acef89cbc61f6d5a895e46d0caac5262d45fed5a))
 
 ## [1.29.7](https://github.com/SocialGouv/mano/compare/v1.29.6...v1.29.7) (2021-12-03)
 
+
 ### Bug Fixes
 
-- **api,dashboard:** change sentry url ([#180](https://github.com/SocialGouv/mano/issues/180)) ([41dce39](https://github.com/SocialGouv/mano/commit/41dce39d3cb4cf0b295a34b82cec72f18b694d38))
+* **api,dashboard:** change sentry url ([#180](https://github.com/SocialGouv/mano/issues/180)) ([41dce39](https://github.com/SocialGouv/mano/commit/41dce39d3cb4cf0b295a34b82cec72f18b694d38))
 
 ## [1.29.6](https://github.com/SocialGouv/mano/compare/v1.29.5...v1.29.6) (2021-12-01)
 
+
 ### Bug Fixes
 
-- **dashboard:** can edit choices in multi-choices field ([#175](https://github.com/SocialGouv/mano/issues/175)) ([136e65a](https://github.com/SocialGouv/mano/commit/136e65a9431a84b21c9b386b00ed9079dc089cd0))
+* **dashboard:** can edit choices in multi-choices field ([#175](https://github.com/SocialGouv/mano/issues/175)) ([136e65a](https://github.com/SocialGouv/mano/commit/136e65a9431a84b21c9b386b00ed9079dc089cd0))
 
 ## [1.29.5](https://github.com/SocialGouv/mano/compare/v1.29.4...v1.29.5) (2021-11-29)
 
+
 ### Bug Fixes
 
-- **dashboard:** actions in reception ([#172](https://github.com/SocialGouv/mano/issues/172)) ([038575f](https://github.com/SocialGouv/mano/commit/038575f90be5cec31e5b369d5e2f01ec750586ac))
+* **dashboard:** actions in reception ([#172](https://github.com/SocialGouv/mano/issues/172)) ([038575f](https://github.com/SocialGouv/mano/commit/038575f90be5cec31e5b369d5e2f01ec750586ac))
 
 ## [1.29.4](https://github.com/SocialGouv/mano/compare/v1.29.3...v1.29.4) (2021-11-26)
 
+
 ### Bug Fixes
 
-- remove retrocompatibility for json observation custom fields ([725bc73](https://github.com/SocialGouv/mano/commit/725bc7314846ec2fc4f1f16220ad233d72307dff))
+* remove retrocompatibility for json observation custom fields ([725bc73](https://github.com/SocialGouv/mano/commit/725bc7314846ec2fc4f1f16220ad233d72307dff))
 
 ## [1.29.3](https://github.com/SocialGouv/mano/compare/v1.29.2...v1.29.3) (2021-11-25)
 
+
 ### Bug Fixes
 
-- **dashboard:** structure modification ([#170](https://github.com/SocialGouv/mano/issues/170)) ([1521127](https://github.com/SocialGouv/mano/commit/1521127edc734daa53a66577f791190aaf549782))
-- **dashboard:** team selector for action ([#169](https://github.com/SocialGouv/mano/issues/169)) ([09f0f0a](https://github.com/SocialGouv/mano/commit/09f0f0a9934c3a1f05130d25268fbd23555746c4))
+* **dashboard:** structure modification ([#170](https://github.com/SocialGouv/mano/issues/170)) ([1521127](https://github.com/SocialGouv/mano/commit/1521127edc734daa53a66577f791190aaf549782))
+* **dashboard:** team selector for action ([#169](https://github.com/SocialGouv/mano/issues/169)) ([09f0f0a](https://github.com/SocialGouv/mano/commit/09f0f0a9934c3a1f05130d25268fbd23555746c4))
 
 ## [1.29.2](https://github.com/SocialGouv/mano/compare/v1.29.1...v1.29.2) (2021-11-25)
 
+
 ### Bug Fixes
 
-- end 2 end timeout ([b2a9a9f](https://github.com/SocialGouv/mano/commit/b2a9a9fb1e384b6c0abd2607454a720f27dc6ce8))
+* end 2 end timeout ([b2a9a9f](https://github.com/SocialGouv/mano/commit/b2a9a9fb1e384b6c0abd2607454a720f27dc6ce8))
 
 ## [1.29.1](https://github.com/SocialGouv/mano/compare/v1.29.0...v1.29.1) (2021-11-25)
 
+
 ### Bug Fixes
 
-- **dashboard:** try more fetch if fail ([#166](https://github.com/SocialGouv/mano/issues/166)) ([cada9d4](https://github.com/SocialGouv/mano/commit/cada9d422f337ecdfab22032d744cb1cfc77d468))
+* **dashboard:** try more fetch if fail ([#166](https://github.com/SocialGouv/mano/issues/166)) ([cada9d4](https://github.com/SocialGouv/mano/commit/cada9d422f337ecdfab22032d744cb1cfc77d468))
 
 # [1.29.0](https://github.com/SocialGouv/mano/compare/v1.28.12...v1.29.0) (2021-11-23)
 
+
 ### Features
 
-- end to end tests ([#164](https://github.com/SocialGouv/mano/issues/164)) ([7de5040](https://github.com/SocialGouv/mano/commit/7de50405ebb06d9f0f3bf8b8fdd7c3673e6cbf8d))
+* end to end tests ([#164](https://github.com/SocialGouv/mano/issues/164)) ([7de5040](https://github.com/SocialGouv/mano/commit/7de50405ebb06d9f0f3bf8b8fdd7c3673e6cbf8d))
 
 ## [1.28.12](https://github.com/SocialGouv/mano/compare/v1.28.11...v1.28.12) (2021-11-23)
 
+
 ### Bug Fixes
 
-- **dashboard:** error when no options in list ([bed207e](https://github.com/SocialGouv/mano/commit/bed207edce2ef2c5ebd5be90ebd981f1204e0cc7))
+* **dashboard:** error when no options in list ([bed207e](https://github.com/SocialGouv/mano/commit/bed207edce2ef2c5ebd5be90ebd981f1204e0cc7))
 
 ## [1.28.11](https://github.com/SocialGouv/mano/compare/v1.28.10...v1.28.11) (2021-11-19)
 
+
 ### Bug Fixes
 
-- **dashboard:** login with no encryptionValidationKey ([#167](https://github.com/SocialGouv/mano/issues/167)) ([14cfad1](https://github.com/SocialGouv/mano/commit/14cfad18d868551b4f4fd751e75ffca4ef0402e4))
+* **dashboard:** login with no encryptionValidationKey ([#167](https://github.com/SocialGouv/mano/issues/167)) ([14cfad1](https://github.com/SocialGouv/mano/commit/14cfad18d868551b4f4fd751e75ffca4ef0402e4))
 
 ## [1.28.10](https://github.com/SocialGouv/mano/compare/v1.28.9...v1.28.10) (2021-11-19)
 
+
 ### Bug Fixes
 
-- **dashboard:** hashedOrgEncryptionKey === null even after setting good key ([#165](https://github.com/SocialGouv/mano/issues/165)) ([dac4e6c](https://github.com/SocialGouv/mano/commit/dac4e6c452502d4ed908cf0b4b67c292bd4ab931))
+* **dashboard:** hashedOrgEncryptionKey === null even after setting good key ([#165](https://github.com/SocialGouv/mano/issues/165)) ([dac4e6c](https://github.com/SocialGouv/mano/commit/dac4e6c452502d4ed908cf0b4b67c292bd4ab931))
 
 ## [1.28.9](https://github.com/SocialGouv/mano/compare/v1.28.8...v1.28.9) (2021-11-18)
 
+
 ### Bug Fixes
 
-- **dashboard:** encryption verification ([#163](https://github.com/SocialGouv/mano/issues/163)) ([8049741](https://github.com/SocialGouv/mano/commit/8049741bb0b899db70c983e5b6f4df76d58fc567))
+* **dashboard:** encryption verification ([#163](https://github.com/SocialGouv/mano/issues/163)) ([8049741](https://github.com/SocialGouv/mano/commit/8049741bb0b899db70c983e5b6f4df76d58fc567))
 
 ## [1.28.8](https://github.com/SocialGouv/mano/compare/v1.28.7...v1.28.8) (2021-11-16)
 
+
 ### Bug Fixes
 
-- **dashboard:** encryption ([#162](https://github.com/SocialGouv/mano/issues/162)) ([762b597](https://github.com/SocialGouv/mano/commit/762b5973e88efdab0575a358b349d3579b545b6c))
+* **dashboard:** encryption ([#162](https://github.com/SocialGouv/mano/issues/162)) ([762b597](https://github.com/SocialGouv/mano/commit/762b5973e88efdab0575a358b349d3579b545b6c))
 
 ## [1.28.7](https://github.com/SocialGouv/mano/compare/v1.28.6...v1.28.7) (2021-11-16)
 
+
 ### Bug Fixes
 
-- fix observation as JSON ([#161](https://github.com/SocialGouv/mano/issues/161)) ([412948c](https://github.com/SocialGouv/mano/commit/412948c16260581bcb50bc07520bbc48a0aaa597))
+* fix observation as JSON ([#161](https://github.com/SocialGouv/mano/issues/161)) ([412948c](https://github.com/SocialGouv/mano/commit/412948c16260581bcb50bc07520bbc48a0aaa597))
 
 ## [1.28.6](https://github.com/SocialGouv/mano/compare/v1.28.5...v1.28.6) (2021-11-16)
 
+
 ### Bug Fixes
 
-- customFields as object not string ([#158](https://github.com/SocialGouv/mano/issues/158)) ([55db0aa](https://github.com/SocialGouv/mano/commit/55db0aaa7aebf99a1fbc15563918ead97239e124))
+* customFields as object not string ([#158](https://github.com/SocialGouv/mano/issues/158)) ([55db0aa](https://github.com/SocialGouv/mano/commit/55db0aaa7aebf99a1fbc15563918ead97239e124))
 
 ## [1.28.5](https://github.com/SocialGouv/mano/compare/v1.28.4...v1.28.5) (2021-11-16)
 
+
 ### Bug Fixes
 
-- **dashboard:** action list filtered ([#160](https://github.com/SocialGouv/mano/issues/160)) ([6883fed](https://github.com/SocialGouv/mano/commit/6883fedd0a6c4040d7b6f1c713773daa0c429a33))
+* **dashboard:** action list filtered ([#160](https://github.com/SocialGouv/mano/issues/160)) ([6883fed](https://github.com/SocialGouv/mano/commit/6883fedd0a6c4040d7b6f1c713773daa0c429a33))
 
 ## [1.28.4](https://github.com/SocialGouv/mano/compare/v1.28.3...v1.28.4) (2021-11-16)
 
+
 ### Bug Fixes
 
-- trigger release ([d063ee2](https://github.com/SocialGouv/mano/commit/d063ee2a8428ce46020fa6e9fa7c9a08a5e1af1d))
+* trigger release ([d063ee2](https://github.com/SocialGouv/mano/commit/d063ee2a8428ce46020fa6e9fa7c9a08a5e1af1d))
 
 ## [1.28.3](https://github.com/SocialGouv/mano/compare/v1.28.2...v1.28.3) (2021-11-15)
 
+
 ### Bug Fixes
 
-- fix org key ([#159](https://github.com/SocialGouv/mano/issues/159)) ([e6de84f](https://github.com/SocialGouv/mano/commit/e6de84fd51ff5b55e376d323f797c54e57fca7d3))
+* fix org key ([#159](https://github.com/SocialGouv/mano/issues/159)) ([e6de84f](https://github.com/SocialGouv/mano/commit/e6de84fd51ff5b55e376d323f797c54e57fca7d3))
 
 ## [1.28.2](https://github.com/SocialGouv/mano/compare/v1.28.1...v1.28.2) (2021-11-12)
 
+
 ### Bug Fixes
 
-- **api:** send default error to user ([#146](https://github.com/SocialGouv/mano/issues/146)) ([f06d450](https://github.com/SocialGouv/mano/commit/f06d4502e2b77cdabac17b1c37453edcef8f8dbf))
+* **api:** send default error to user ([#146](https://github.com/SocialGouv/mano/issues/146)) ([f06d450](https://github.com/SocialGouv/mano/commit/f06d4502e2b77cdabac17b1c37453edcef8f8dbf))
 
 ## [1.28.1](https://github.com/SocialGouv/mano/compare/v1.28.0...v1.28.1) (2021-11-12)
 
+
 ### Bug Fixes
 
-- **dashboard:** slow search ([#157](https://github.com/SocialGouv/mano/issues/157)) ([b07912c](https://github.com/SocialGouv/mano/commit/b07912c1e41b3be6c3a76fa5d37d55c9c6c3a37c))
+* **dashboard:** slow search ([#157](https://github.com/SocialGouv/mano/issues/157)) ([b07912c](https://github.com/SocialGouv/mano/commit/b07912c1e41b3be6c3a76fa5d37d55c9c6c3a37c))
 
 # [1.28.0](https://github.com/SocialGouv/mano/compare/v1.27.6...v1.28.0) (2021-11-12)
 
+
 ### Features
 
-- **dashboard:** select team on action update ([#155](https://github.com/SocialGouv/mano/issues/155)) ([e621450](https://github.com/SocialGouv/mano/commit/e6214508d78b7b1eb32ac1a9201e0e42b0ff48b5))
+* **dashboard:** select team on action update ([#155](https://github.com/SocialGouv/mano/issues/155)) ([e621450](https://github.com/SocialGouv/mano/commit/e6214508d78b7b1eb32ac1a9201e0e42b0ff48b5))
 
 ## [1.27.6](https://github.com/SocialGouv/mano/compare/v1.27.5...v1.27.6) (2021-11-12)
 
+
 ### Bug Fixes
 
-- **dashboard:** state management with recoil ([#150](https://github.com/SocialGouv/mano/issues/150)) ([967a66a](https://github.com/SocialGouv/mano/commit/967a66acfdac8b53050542690ffb74cda3276b27))
+* **dashboard:** state management with recoil ([#150](https://github.com/SocialGouv/mano/issues/150)) ([967a66a](https://github.com/SocialGouv/mano/commit/967a66acfdac8b53050542690ffb74cda3276b27))
 
 ## [1.27.5](https://github.com/SocialGouv/mano/compare/v1.27.4...v1.27.5) (2021-11-12)
 
+
 ### Bug Fixes
 
-- **api:** fixes passwords flow (reset, change, etc.) ([#156](https://github.com/SocialGouv/mano/issues/156)) ([09666ef](https://github.com/SocialGouv/mano/commit/09666efcfaa2b2a2cdd529d6361bd49cecda6785))
+* **api:** fixes passwords flow (reset, change, etc.) ([#156](https://github.com/SocialGouv/mano/issues/156)) ([09666ef](https://github.com/SocialGouv/mano/commit/09666efcfaa2b2a2cdd529d6361bd49cecda6785))
 
 ## [1.27.4](https://github.com/SocialGouv/mano/compare/v1.27.3...v1.27.4) (2021-11-11)
 
+
 ### Bug Fixes
 
-- **api:** exclude sensitive data from user response ([#147](https://github.com/SocialGouv/mano/issues/147)) ([f7b8295](https://github.com/SocialGouv/mano/commit/f7b8295bd6378ab858fd83c3d4fefb192a320c6e))
+* **api:** exclude sensitive data from user response ([#147](https://github.com/SocialGouv/mano/issues/147)) ([f7b8295](https://github.com/SocialGouv/mano/commit/f7b8295bd6378ab858fd83c3d4fefb192a320c6e))
 
 ## [1.27.3](https://github.com/SocialGouv/mano/compare/v1.27.2...v1.27.3) (2021-11-11)
 
+
 ### Bug Fixes
 
-- **dashboard:** description linebreaks + prevent XSS ([#152](https://github.com/SocialGouv/mano/issues/152)) ([e247d57](https://github.com/SocialGouv/mano/commit/e247d577e17bbf8f3a9d17a3fb4fa49f5ddda9f2))
+* **dashboard:** description linebreaks + prevent XSS ([#152](https://github.com/SocialGouv/mano/issues/152)) ([e247d57](https://github.com/SocialGouv/mano/commit/e247d577e17bbf8f3a9d17a3fb4fa49f5ddda9f2))
 
 ## [1.27.2](https://github.com/SocialGouv/mano/compare/v1.27.1...v1.27.2) (2021-11-11)
 
+
 ### Bug Fixes
 
-- **dashboard:** e is not defined in createaction ([#154](https://github.com/SocialGouv/mano/issues/154)) ([e60b1c7](https://github.com/SocialGouv/mano/commit/e60b1c7fd0d034356d1d6eb985f6337497bef74f))
+* **dashboard:** e is not defined in createaction ([#154](https://github.com/SocialGouv/mano/issues/154)) ([e60b1c7](https://github.com/SocialGouv/mano/commit/e60b1c7fd0d034356d1d6eb985f6337497bef74f))
 
 ## [1.27.1](https://github.com/SocialGouv/mano/compare/v1.27.0...v1.27.1) (2021-11-10)
 
+
 ### Bug Fixes
 
-- **api:** clean ([#151](https://github.com/SocialGouv/mano/issues/151)) ([3a58997](https://github.com/SocialGouv/mano/commit/3a5899734d7b1e12f230613d2c901c1349ce867e))
+* **api:** clean ([#151](https://github.com/SocialGouv/mano/issues/151)) ([3a58997](https://github.com/SocialGouv/mano/commit/3a5899734d7b1e12f230613d2c901c1349ce867e))
 
 # [1.27.0](https://github.com/SocialGouv/mano/compare/v1.26.1...v1.27.0) (2021-11-08)
 
+
 ### Features
 
-- **dashboard:** stats for passages + services ([#149](https://github.com/SocialGouv/mano/issues/149)) ([c408764](https://github.com/SocialGouv/mano/commit/c408764432e612c6fdc06a427c2d517d90b144df))
+* **dashboard:** stats for passages + services ([#149](https://github.com/SocialGouv/mano/issues/149)) ([c408764](https://github.com/SocialGouv/mano/commit/c408764432e612c6fdc06a427c2d517d90b144df))
 
 ## [1.26.1](https://github.com/SocialGouv/mano/compare/v1.26.0...v1.26.1) (2021-11-08)
 
+
 ### Bug Fixes
 
-- **api:** current user in person when no user registered ([#145](https://github.com/SocialGouv/mano/issues/145)) ([14f3146](https://github.com/SocialGouv/mano/commit/14f3146adc71a546d5ba25079c0401a2a4bf4253))
+* **api:** current user in person when no user registered ([#145](https://github.com/SocialGouv/mano/issues/145)) ([14f3146](https://github.com/SocialGouv/mano/commit/14f3146adc71a546d5ba25079c0401a2a4bf4253))
 
 # [1.26.0](https://github.com/SocialGouv/mano/compare/v1.25.0...v1.26.0) (2021-11-08)
 
+
 ### Features
 
-- **dashboard:** enhance stats - new filters - click on pie to filter ([#140](https://github.com/SocialGouv/mano/issues/140)) ([c8be85a](https://github.com/SocialGouv/mano/commit/c8be85a7bed5f679ea09ced428254731608826f5))
+* **dashboard:** enhance stats - new filters - click on pie to filter ([#140](https://github.com/SocialGouv/mano/issues/140)) ([c8be85a](https://github.com/SocialGouv/mano/commit/c8be85a7bed5f679ea09ced428254731608826f5))
 
 # [1.25.0](https://github.com/SocialGouv/mano/compare/v1.24.6...v1.25.0) (2021-11-08)
 
+
 ### Features
 
-- **app,dashboard:** fetch-retry to prevent network error ([#144](https://github.com/SocialGouv/mano/issues/144)) ([06f8ff1](https://github.com/SocialGouv/mano/commit/06f8ff176ad97a85485695eeb203b79c4398c086))
+* **app,dashboard:** fetch-retry to prevent network error ([#144](https://github.com/SocialGouv/mano/issues/144)) ([06f8ff1](https://github.com/SocialGouv/mano/commit/06f8ff176ad97a85485695eeb203b79c4398c086))
 
 ## [1.24.6](https://github.com/SocialGouv/mano/compare/v1.24.5...v1.24.6) (2021-11-08)
 
+
 ### Bug Fixes
 
-- **website:** nathan instead of maxime ([#143](https://github.com/SocialGouv/mano/issues/143)) ([6408ab8](https://github.com/SocialGouv/mano/commit/6408ab86d74a563b69e622272a31a457019ce228))
+* **website:** nathan instead of maxime ([#143](https://github.com/SocialGouv/mano/issues/143)) ([6408ab8](https://github.com/SocialGouv/mano/commit/6408ab86d74a563b69e622272a31a457019ce228))
 
 ## [1.24.5](https://github.com/SocialGouv/mano/compare/v1.24.4...v1.24.5) (2021-11-08)
 
+
 ### Bug Fixes
 
-- **dashboard:** set encryption verification key only for encrypted organisations ([#142](https://github.com/SocialGouv/mano/issues/142)) ([05c886e](https://github.com/SocialGouv/mano/commit/05c886e2ab7a2aee3ef1d2e7261f563b6070f945))
+* **dashboard:** set encryption verification key only for encrypted organisations ([#142](https://github.com/SocialGouv/mano/issues/142)) ([05c886e](https://github.com/SocialGouv/mano/commit/05c886e2ab7a2aee3ef1d2e7261f563b6070f945))
 
 ## [1.24.4](https://github.com/SocialGouv/mano/compare/v1.24.3...v1.24.4) (2021-11-05)
 
+
 ### Bug Fixes
 
-- **app,api:** upgrade app version ([#139](https://github.com/SocialGouv/mano/issues/139)) ([61858ea](https://github.com/SocialGouv/mano/commit/61858ea54a07e99dd743b2a570e467756c6f5b4d))
+* **app,api:** upgrade app version ([#139](https://github.com/SocialGouv/mano/issues/139)) ([61858ea](https://github.com/SocialGouv/mano/commit/61858ea54a07e99dd743b2a570e467756c6f5b4d))
 
 ## [1.24.3](https://github.com/SocialGouv/mano/compare/v1.24.2...v1.24.3) (2021-11-05)
 
+
 ### Bug Fixes
 
-- **website:** email nathan ([#141](https://github.com/SocialGouv/mano/issues/141)) ([77b4c8e](https://github.com/SocialGouv/mano/commit/77b4c8e83914d5c0bddf111a4d502bbeb4189d80))
+* **website:** email nathan ([#141](https://github.com/SocialGouv/mano/issues/141)) ([77b4c8e](https://github.com/SocialGouv/mano/commit/77b4c8e83914d5c0bddf111a4d502bbeb4189d80))
 
 ## [1.24.2](https://github.com/SocialGouv/mano/compare/v1.24.1...v1.24.2) (2021-11-05)
 
+
 ### Bug Fixes
 
-- **dashboard:** encrypted field at the end of the file ([#138](https://github.com/SocialGouv/mano/issues/138)) ([1491a29](https://github.com/SocialGouv/mano/commit/1491a292b8ae2680f9703352903efd48057f3938))
-- **dashboard:** fix utc problem for display date ([#133](https://github.com/SocialGouv/mano/issues/133)) ([b2d108a](https://github.com/SocialGouv/mano/commit/b2d108a766e6d9c57e1fc09f1e3ba92c3edae747))
+* **dashboard:** encrypted field at the end of the file ([#138](https://github.com/SocialGouv/mano/issues/138)) ([1491a29](https://github.com/SocialGouv/mano/commit/1491a292b8ae2680f9703352903efd48057f3938))
+* **dashboard:** fix utc problem for display date ([#133](https://github.com/SocialGouv/mano/issues/133)) ([b2d108a](https://github.com/SocialGouv/mano/commit/b2d108a766e6d9c57e1fc09f1e3ba92c3edae747))
 
 ## [1.24.1](https://github.com/SocialGouv/mano/compare/v1.24.0...v1.24.1) (2021-11-05)
 
+
 ### Bug Fixes
 
-- **api,dashboard:** multiple collaborations ([#135](https://github.com/SocialGouv/mano/issues/135)) ([66f6946](https://github.com/SocialGouv/mano/commit/66f69469211046a68a706de20f4346c9c1fe0fe9))
-- **dashboard:** button for description ([#137](https://github.com/SocialGouv/mano/issues/137)) ([7c80e79](https://github.com/SocialGouv/mano/commit/7c80e7972a385edbb84667b06c34549a98192aa4))
+* **api,dashboard:** multiple collaborations ([#135](https://github.com/SocialGouv/mano/issues/135)) ([66f6946](https://github.com/SocialGouv/mano/commit/66f69469211046a68a706de20f4346c9c1fe0fe9))
+* **dashboard:** button for description ([#137](https://github.com/SocialGouv/mano/issues/137)) ([7c80e79](https://github.com/SocialGouv/mano/commit/7c80e7972a385edbb84667b06c34549a98192aa4))
 
 # [1.24.0](https://github.com/SocialGouv/mano/compare/v1.23.0...v1.24.0) (2021-11-05)
 
+
 ### Features
 
-- set encryption verification key ([#124](https://github.com/SocialGouv/mano/issues/124)) ([b283625](https://github.com/SocialGouv/mano/commit/b2836258d0fcd4e71dbbd617b0158265e127c414))
+* set encryption verification key ([#124](https://github.com/SocialGouv/mano/issues/124)) ([b283625](https://github.com/SocialGouv/mano/commit/b2836258d0fcd4e71dbbd617b0158265e127c414))
 
 # [1.23.0](https://github.com/SocialGouv/mano/compare/v1.22.0...v1.23.0) (2021-11-04)
 
+
 ### Features
 
-- **all:** deploy on node 16 ([#129](https://github.com/SocialGouv/mano/issues/129)) ([d65ffdd](https://github.com/SocialGouv/mano/commit/d65ffdd0227a1583dc1e9bc7a75bedba9c234201))
+* **all:** deploy on node 16 ([#129](https://github.com/SocialGouv/mano/issues/129)) ([d65ffdd](https://github.com/SocialGouv/mano/commit/d65ffdd0227a1583dc1e9bc7a75bedba9c234201))
 
 # [1.22.0](https://github.com/SocialGouv/mano/compare/v1.21.1...v1.22.0) (2021-11-04)
 
+
 ### Features
 
-- **dashboard:** onboarding for admin redirects to first team creation ([#128](https://github.com/SocialGouv/mano/issues/128)) ([0fc04ed](https://github.com/SocialGouv/mano/commit/0fc04eda3f621b594970cbdd11ce2494801ae755))
+* **dashboard:** onboarding for admin redirects to first team creation ([#128](https://github.com/SocialGouv/mano/issues/128)) ([0fc04ed](https://github.com/SocialGouv/mano/commit/0fc04eda3f621b594970cbdd11ce2494801ae755))
 
 ## [1.21.1](https://github.com/SocialGouv/mano/compare/v1.21.0...v1.21.1) (2021-11-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** wording on comments ([1c1f5ee](https://github.com/SocialGouv/mano/commit/1c1f5ee43fdcff0d0ee596c44cbb5ded1caa9056))
+* **dashboard:** wording on comments ([1c1f5ee](https://github.com/SocialGouv/mano/commit/1c1f5ee43fdcff0d0ee596c44cbb5ded1caa9056))
 
 # [1.21.0](https://github.com/SocialGouv/mano/compare/v1.20.1...v1.21.0) (2021-11-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** show message for custom fields when organisation not encrypted ([#126](https://github.com/SocialGouv/mano/issues/126)) ([de16299](https://github.com/SocialGouv/mano/commit/de16299b8d9fe5acd82fed1ff82692559e9003da))
+* **dashboard:** show message for custom fields when organisation not encrypted ([#126](https://github.com/SocialGouv/mano/issues/126)) ([de16299](https://github.com/SocialGouv/mano/commit/de16299b8d9fe5acd82fed1ff82692559e9003da))
+
 
 ### Features
 
-- **dashboard:** show more stuff in organisations for superadmin to better pilot ([#127](https://github.com/SocialGouv/mano/issues/127)) ([204703c](https://github.com/SocialGouv/mano/commit/204703cacb462e14d5634108ea948f4739325c9f))
+* **dashboard:** show more stuff in organisations for superadmin to better pilot ([#127](https://github.com/SocialGouv/mano/issues/127)) ([204703c](https://github.com/SocialGouv/mano/commit/204703cacb462e14d5634108ea948f4739325c9f))
 
 ## [1.20.1](https://github.com/SocialGouv/mano/compare/v1.20.0...v1.20.1) (2021-11-02)
 
+
 ### Bug Fixes
 
-- **dashboard:** wrong "connect again" behavior on dashboard ([#125](https://github.com/SocialGouv/mano/issues/125)) ([6a5b1ea](https://github.com/SocialGouv/mano/commit/6a5b1ea6ad2b907aa587cbc220ab277944836c23))
+* **dashboard:** wrong "connect again" behavior on dashboard ([#125](https://github.com/SocialGouv/mano/issues/125)) ([6a5b1ea](https://github.com/SocialGouv/mano/commit/6a5b1ea6ad2b907aa587cbc220ab277944836c23))
 
 # [1.20.0](https://github.com/SocialGouv/mano/compare/v1.19.0...v1.20.0) (2021-10-27)
 
+
 ### Features
 
-- model observations customizable ([#106](https://github.com/SocialGouv/mano/issues/106)) ([48701c8](https://github.com/SocialGouv/mano/commit/48701c89c5f49641b0b6066cdf700ed35d421f2a))
+* model observations customizable ([#106](https://github.com/SocialGouv/mano/issues/106)) ([48701c8](https://github.com/SocialGouv/mano/commit/48701c89c5f49641b0b6066cdf700ed35d421f2a))
 
 # [1.19.0](https://github.com/SocialGouv/mano/compare/v1.18.4...v1.19.0) (2021-10-27)
 
+
 ### Features
 
-- **app:** out of active list ([#113](https://github.com/SocialGouv/mano/issues/113)) ([6814421](https://github.com/SocialGouv/mano/commit/6814421ec0a51d3dcee4c0568a6ab81de9940376))
+* **app:** out of active list ([#113](https://github.com/SocialGouv/mano/issues/113)) ([6814421](https://github.com/SocialGouv/mano/commit/6814421ec0a51d3dcee4c0568a6ab81de9940376))
 
 ## [1.18.4](https://github.com/SocialGouv/mano/compare/v1.18.3...v1.18.4) (2021-10-26)
 
+
 ### Bug Fixes
 
-- **dashboard,app:** sort actions by dueDate desc ([#117](https://github.com/SocialGouv/mano/issues/117)) ([99d657e](https://github.com/SocialGouv/mano/commit/99d657e49be138a59ed6a112cebc8b0bebf5311c))
+* **dashboard,app:** sort actions by dueDate desc ([#117](https://github.com/SocialGouv/mano/issues/117)) ([99d657e](https://github.com/SocialGouv/mano/commit/99d657e49be138a59ed6a112cebc8b0bebf5311c))
 
 ## [1.18.3](https://github.com/SocialGouv/mano/compare/v1.18.2...v1.18.3) (2021-10-26)
 
+
 ### Bug Fixes
 
-- **website:** src root for img ([ae57f88](https://github.com/SocialGouv/mano/commit/ae57f8856dfafb73aad9c9b2ebf37ba516e12c28))
+* **website:** src root for img ([ae57f88](https://github.com/SocialGouv/mano/commit/ae57f8856dfafb73aad9c9b2ebf37ba516e12c28))
 
 ## [1.18.2](https://github.com/SocialGouv/mano/compare/v1.18.1...v1.18.2) (2021-10-26)
 
+
 ### Bug Fixes
 
-- static website ([#114](https://github.com/SocialGouv/mano/issues/114)) ([8ab9550](https://github.com/SocialGouv/mano/commit/8ab9550fdf281c3996d68685dc476b783901821c))
+* static website ([#114](https://github.com/SocialGouv/mano/issues/114)) ([8ab9550](https://github.com/SocialGouv/mano/commit/8ab9550fdf281c3996d68685dc476b783901821c))
 
 ## [1.18.1](https://github.com/SocialGouv/mano/compare/v1.18.0...v1.18.1) (2021-10-22)
 
+
 ### Bug Fixes
 
-- compulsory person in creating action from CreateAction ([#104](https://github.com/SocialGouv/mano/issues/104)) ([1f319bc](https://github.com/SocialGouv/mano/commit/1f319bcec2d9fe5c37d1f89f5f19d52ab76fcf82))
+* compulsory person in creating action from CreateAction ([#104](https://github.com/SocialGouv/mano/issues/104)) ([1f319bc](https://github.com/SocialGouv/mano/commit/1f319bcec2d9fe5c37d1f89f5f19d52ab76fcf82))
 
 # [1.18.0](https://github.com/SocialGouv/mano/compare/v1.17.0...v1.18.0) (2021-10-22)
 
+
 ### Features
 
-- **app:** local cache ([#107](https://github.com/SocialGouv/mano/issues/107)) ([b143d53](https://github.com/SocialGouv/mano/commit/b143d53404f40d37a1dfe1787b3af9353acecea2))
+* **app:** local cache ([#107](https://github.com/SocialGouv/mano/issues/107)) ([b143d53](https://github.com/SocialGouv/mano/commit/b143d53404f40d37a1dfe1787b3af9353acecea2))
 
 # [1.17.0](https://github.com/SocialGouv/mano/compare/v1.16.0...v1.17.0) (2021-10-21)
 
+
 ### Features
 
-- **website:** add matomo website ([#109](https://github.com/SocialGouv/mano/issues/109)) ([f5f8528](https://github.com/SocialGouv/mano/commit/f5f852866201f15e89afb98debb93409fc4fd6dc))
+* **website:** add matomo website ([#109](https://github.com/SocialGouv/mano/issues/109)) ([f5f8528](https://github.com/SocialGouv/mano/commit/f5f852866201f15e89afb98debb93409fc4fd6dc))
 
 # [1.16.0](https://github.com/SocialGouv/mano/compare/v1.15.0...v1.16.0) (2021-10-21)
 
+
 ### Features
 
-- add cookie to preserve session ([#96](https://github.com/SocialGouv/mano/issues/96)) ([9a20b48](https://github.com/SocialGouv/mano/commit/9a20b48357c7637141639da7ef7c493ec478aae0))
+* add cookie to preserve session ([#96](https://github.com/SocialGouv/mano/issues/96)) ([9a20b48](https://github.com/SocialGouv/mano/commit/9a20b48357c7637141639da7ef7c493ec478aae0))
 
 # [1.15.0](https://github.com/SocialGouv/mano/compare/v1.14.1...v1.15.0) (2021-10-21)
 
+
 ### Features
 
-- **dashboard:** add places in filters for persons ([#89](https://github.com/SocialGouv/mano/issues/89)) ([90aef52](https://github.com/SocialGouv/mano/commit/90aef52566faaa696714c71e7d13cd2ec9ab4488))
+* **dashboard:** add places in filters for persons ([#89](https://github.com/SocialGouv/mano/issues/89)) ([90aef52](https://github.com/SocialGouv/mano/commit/90aef52566faaa696714c71e7d13cd2ec9ab4488))
 
 ## [1.14.1](https://github.com/SocialGouv/mano/compare/v1.14.0...v1.14.1) (2021-10-21)
 
+
 ### Bug Fixes
 
-- create report when current team exists ([#105](https://github.com/SocialGouv/mano/issues/105)) ([fcc55f6](https://github.com/SocialGouv/mano/commit/fcc55f62fd340de79be688844abe0f03a93340d9))
+* create report when current team exists ([#105](https://github.com/SocialGouv/mano/issues/105)) ([fcc55f6](https://github.com/SocialGouv/mano/commit/fcc55f62fd340de79be688844abe0f03a93340d9))
 
 # [1.14.0](https://github.com/SocialGouv/mano/compare/v1.13.0...v1.14.0) (2021-10-19)
 
+
 ### Bug Fixes
 
-- **app:** phone number on app ([#99](https://github.com/SocialGouv/mano/issues/99)) ([d58a41f](https://github.com/SocialGouv/mano/commit/d58a41fc5b8c32032015428a0042d2e9e80c3780))
-- **app:** territory observation save ([#98](https://github.com/SocialGouv/mano/issues/98)) ([f5342e2](https://github.com/SocialGouv/mano/commit/f5342e2bd3afcf72e855977c682b0316df47256d))
+* **app:** phone number on app ([#99](https://github.com/SocialGouv/mano/issues/99)) ([d58a41f](https://github.com/SocialGouv/mano/commit/d58a41fc5b8c32032015428a0042d2e9e80c3780))
+* **app:** territory observation save ([#98](https://github.com/SocialGouv/mano/issues/98)) ([f5342e2](https://github.com/SocialGouv/mano/commit/f5342e2bd3afcf72e855977c682b0316df47256d))
+
 
 ### Features
 
-- **dashboard:** add categories in actions list ([#90](https://github.com/SocialGouv/mano/issues/90)) ([1831168](https://github.com/SocialGouv/mano/commit/18311681dacd7e90405192eb47fef6b9e7157327))
+* **dashboard:** add categories in actions list ([#90](https://github.com/SocialGouv/mano/issues/90)) ([1831168](https://github.com/SocialGouv/mano/commit/18311681dacd7e90405192eb47fef6b9e7157327))
 
 # [1.13.0](https://github.com/SocialGouv/mano/compare/v1.12.6...v1.13.0) (2021-10-19)
 
+
 ### Features
 
-- **dashboard:** active list ([#92](https://github.com/SocialGouv/mano/issues/92)) ([942476c](https://github.com/SocialGouv/mano/commit/942476c317d9b3f9a3d0cbbedd59f81b097e66aa))
+* **dashboard:** active list ([#92](https://github.com/SocialGouv/mano/issues/92)) ([942476c](https://github.com/SocialGouv/mano/commit/942476c317d9b3f9a3d0cbbedd59f81b097e66aa))
 
 ## [1.12.6](https://github.com/SocialGouv/mano/compare/v1.12.5...v1.12.6) (2021-10-15)
 
+
 ### Bug Fixes
 
-- **dashboard:** due at in action ([#95](https://github.com/SocialGouv/mano/issues/95)) ([18e6f50](https://github.com/SocialGouv/mano/commit/18e6f5065ccf9e28ce16413bec8b2aadd07d4431))
+* **dashboard:** due at in action ([#95](https://github.com/SocialGouv/mano/issues/95)) ([18e6f50](https://github.com/SocialGouv/mano/commit/18e6f5065ccf9e28ce16413bec8b2aadd07d4431))
 
 ## [1.12.5](https://github.com/SocialGouv/mano/compare/v1.12.4...v1.12.5) (2021-10-15)
 
+
 ### Bug Fixes
 
-- remove React does not recognize the showPassword prop on a DOM element warning ([#86](https://github.com/SocialGouv/mano/issues/86)) ([97cb377](https://github.com/SocialGouv/mano/commit/97cb37738d83131e6ae418cc83dfbabc4a93a830))
+* remove React does not recognize the showPassword prop on a DOM element warning ([#86](https://github.com/SocialGouv/mano/issues/86)) ([97cb377](https://github.com/SocialGouv/mano/commit/97cb37738d83131e6ae418cc83dfbabc4a93a830))
 
 ## [1.12.4](https://github.com/SocialGouv/mano/compare/v1.12.3...v1.12.4) (2021-10-11)
 
+
 ### Bug Fixes
 
-- **dashboard:** label is clickable ([cd90c73](https://github.com/SocialGouv/mano/commit/cd90c73f2ea33921c629fa564a5776a496d852a0))
-- **style:** remove invalid style ([aaa8d2c](https://github.com/SocialGouv/mano/commit/aaa8d2c1e55694dbfbe223cf4435e7f07b99e0ed))
+* **dashboard:** label is clickable ([cd90c73](https://github.com/SocialGouv/mano/commit/cd90c73f2ea33921c629fa564a5776a496d852a0))
+* **style:** remove invalid style ([aaa8d2c](https://github.com/SocialGouv/mano/commit/aaa8d2c1e55694dbfbe223cf4435e7f07b99e0ed))
 
 ## [1.12.3](https://github.com/SocialGouv/mano/compare/v1.12.2...v1.12.3) (2021-10-07)
 
+
 ### Bug Fixes
 
-- error message when resetting password ([#87](https://github.com/SocialGouv/mano/issues/87)) ([589c43d](https://github.com/SocialGouv/mano/commit/589c43d85502b8709309d7e8115ec5d3320962e7))
+* error message when resetting password ([#87](https://github.com/SocialGouv/mano/issues/87)) ([589c43d](https://github.com/SocialGouv/mano/commit/589c43d85502b8709309d7e8115ec5d3320962e7))
 
 ## [1.12.2](https://github.com/SocialGouv/mano/compare/v1.12.1...v1.12.2) (2021-10-04)
 
+
 ### Bug Fixes
 
-- **docker:** use nginx image ([#83](https://github.com/SocialGouv/mano/issues/83)) ([628c006](https://github.com/SocialGouv/mano/commit/628c006c7a600a4d9c2abb063d7512a5e7b52b68))
+* **docker:** use nginx image ([#83](https://github.com/SocialGouv/mano/issues/83)) ([628c006](https://github.com/SocialGouv/mano/commit/628c006c7a600a4d9c2abb063d7512a5e7b52b68))
 
 ## [1.12.1](https://github.com/SocialGouv/mano/compare/v1.12.0...v1.12.1) (2021-10-04)
 
+
 ### Bug Fixes
 
-- access person from actions list ([#79](https://github.com/SocialGouv/mano/issues/79)) ([c704ef0](https://github.com/SocialGouv/mano/commit/c704ef0884d41080febd22e5eaf94949833cf450))
+* access person from actions list ([#79](https://github.com/SocialGouv/mano/issues/79)) ([c704ef0](https://github.com/SocialGouv/mano/commit/c704ef0884d41080febd22e5eaf94949833cf450))
 
 # [1.12.0](https://github.com/SocialGouv/mano/compare/v1.11.3...v1.12.0) (2021-10-04)
 
+
 ### Bug Fixes
 
-- collaborations ([#78](https://github.com/SocialGouv/mano/issues/78)) ([cd4e5ef](https://github.com/SocialGouv/mano/commit/cd4e5ef44adb3b6b3f9fa5ec47616ee7bd25bbac))
+* collaborations ([#78](https://github.com/SocialGouv/mano/issues/78)) ([cd4e5ef](https://github.com/SocialGouv/mano/commit/cd4e5ef44adb3b6b3f9fa5ec47616ee7bd25bbac))
+
 
 ### Features
 
-- can make passwords visible ([#81](https://github.com/SocialGouv/mano/issues/81)) ([dfd7884](https://github.com/SocialGouv/mano/commit/dfd7884bebad0d3103c14ffc838ccadda43419f6))
+* can make passwords visible ([#81](https://github.com/SocialGouv/mano/issues/81)) ([dfd7884](https://github.com/SocialGouv/mano/commit/dfd7884bebad0d3103c14ffc838ccadda43419f6))
 
 ## [1.11.3](https://github.com/SocialGouv/mano/compare/v1.11.2...v1.11.3) (2021-09-29)
 
+
 ### Bug Fixes
 
-- sentry+small fixes ([#74](https://github.com/SocialGouv/mano/issues/74)) ([2b2a76b](https://github.com/SocialGouv/mano/commit/2b2a76b8e23537413d3e85143cbdb46126e6dc5f))
+* sentry+small fixes ([#74](https://github.com/SocialGouv/mano/issues/74)) ([2b2a76b](https://github.com/SocialGouv/mano/commit/2b2a76b8e23537413d3e85143cbdb46126e6dc5f))
 
 ## [1.11.2](https://github.com/SocialGouv/mano/compare/v1.11.1...v1.11.2) (2021-09-27)
 
+
 ### Bug Fixes
 
-- Bump version ([7dca32f](https://github.com/SocialGouv/mano/commit/7dca32f89fa44c1f847f3bc93bc805e481a2d792))
+* Bump version ([7dca32f](https://github.com/SocialGouv/mano/commit/7dca32f89fa44c1f847f3bc93bc805e481a2d792))
 
 ## [1.11.1](https://github.com/SocialGouv/mano/compare/v1.11.0...v1.11.1) (2021-09-22)
 
+
 ### Bug Fixes
 
-- can go back when update multiple actions ([e9a3472](https://github.com/SocialGouv/mano/commit/e9a347269ab3ccdb7fd2ab9f088066291416555b))
+* can go back when update multiple actions ([e9a3472](https://github.com/SocialGouv/mano/commit/e9a347269ab3ccdb7fd2ab9f088066291416555b))
 
 # [1.11.0](https://github.com/SocialGouv/mano/compare/v1.10.3...v1.11.0) (2021-09-22)
 
+
 ### Features
 
-- can create action for multiple persons in app ([#36](https://github.com/SocialGouv/mano/issues/36)) ([e3e3de5](https://github.com/SocialGouv/mano/commit/e3e3de556834b0d5d6e32f9263f1ccfcaa1ad2be)), closes [#44](https://github.com/SocialGouv/mano/issues/44)
+* can create action for multiple persons in app ([#36](https://github.com/SocialGouv/mano/issues/36)) ([e3e3de5](https://github.com/SocialGouv/mano/commit/e3e3de556834b0d5d6e32f9263f1ccfcaa1ad2be)), closes [#44](https://github.com/SocialGouv/mano/issues/44)
 
 ## [1.10.3](https://github.com/SocialGouv/mano/compare/v1.10.2...v1.10.3) (2021-09-21)
 
+
 ### Bug Fixes
 
-- search in app ([#45](https://github.com/SocialGouv/mano/issues/45)) ([b77abdc](https://github.com/SocialGouv/mano/commit/b77abdccb18b9b5360ebc8af8cd98eaa1ef933e5))
+* search in app ([#45](https://github.com/SocialGouv/mano/issues/45)) ([b77abdc](https://github.com/SocialGouv/mano/commit/b77abdccb18b9b5360ebc8af8cd98eaa1ef933e5))
 
 ## [1.10.2](https://github.com/SocialGouv/mano/compare/v1.10.1...v1.10.2) (2021-09-21)
 
+
 ### Bug Fixes
 
-- **ci:** semantic release update package.json ([#37](https://github.com/SocialGouv/mano/issues/37)) ([22b1098](https://github.com/SocialGouv/mano/commit/22b1098264975e31ea7776716926625102f59f2e)), closes [#38](https://github.com/SocialGouv/mano/issues/38)
+* **ci:** semantic release update package.json ([#37](https://github.com/SocialGouv/mano/issues/37)) ([22b1098](https://github.com/SocialGouv/mano/commit/22b1098264975e31ea7776716926625102f59f2e)), closes [#38](https://github.com/SocialGouv/mano/issues/38)
 
 ## [1.10.1](https://github.com/SocialGouv/mano/compare/v1.10.0...v1.10.1) (2021-09-17)
 
+
 ### Bug Fixes
 
-- **dashboard:** increase k8s startup delay ([#41](https://github.com/SocialGouv/mano/issues/41)) ([f7abbff](https://github.com/SocialGouv/mano/commit/f7abbff2ee10993c28f137dc2e38f1358b212178))
+* **dashboard:** increase k8s startup delay ([#41](https://github.com/SocialGouv/mano/issues/41)) ([f7abbff](https://github.com/SocialGouv/mano/commit/f7abbff2ee10993c28f137dc2e38f1358b212178))
 
 # [1.10.0](https://github.com/SocialGouv/mano/compare/v1.9.0...v1.10.0) (2021-09-14)
 
+
 ### Features
 
-- add metabase ([#35](https://github.com/SocialGouv/mano/issues/35)) ([4f58930](https://github.com/SocialGouv/mano/commit/4f58930a8c2bcfed9ffe72ac8441e0f75a0122fb))
+* add metabase ([#35](https://github.com/SocialGouv/mano/issues/35)) ([4f58930](https://github.com/SocialGouv/mano/commit/4f58930a8c2bcfed9ffe72ac8441e0f75a0122fb))
 
 # [1.9.0](https://github.com/SocialGouv/mano/compare/v1.8.2...v1.9.0) (2021-09-14)
 
+
 ### Bug Fixes
 
-- can set status of action while creating ([#28](https://github.com/SocialGouv/mano/issues/28)) ([15b4bb5](https://github.com/SocialGouv/mano/commit/15b4bb555fe1026571808aa7a2dbd5f846eebfcd))
+* can set status of action while creating ([#28](https://github.com/SocialGouv/mano/issues/28)) ([15b4bb5](https://github.com/SocialGouv/mano/commit/15b4bb555fe1026571808aa7a2dbd5f846eebfcd))
+
 
 ### Features
 
-- can show structures in the app ([#34](https://github.com/SocialGouv/mano/issues/34)) ([1a6dd07](https://github.com/SocialGouv/mano/commit/1a6dd07e8e11916bf0024eddd3a48a7b0caa2111))
+* can show structures in the app ([#34](https://github.com/SocialGouv/mano/issues/34)) ([1a6dd07](https://github.com/SocialGouv/mano/commit/1a6dd07e8e11916bf0024eddd3a48a7b0caa2111))
 
 ## [1.8.2](https://github.com/SocialGouv/mano/compare/v1.8.1...v1.8.2) (2021-09-14)
 
+
 ### Bug Fixes
 
-- add night shift for teams ([#25](https://github.com/SocialGouv/mano/issues/25)) ([3cd657a](https://github.com/SocialGouv/mano/commit/3cd657ad7a546f77694cfaae43c218753c09e071))
+* add night shift for teams ([#25](https://github.com/SocialGouv/mano/issues/25)) ([3cd657a](https://github.com/SocialGouv/mano/commit/3cd657ad7a546f77694cfaae43c218753c09e071))
 
 ## [1.8.1](https://github.com/SocialGouv/mano/compare/v1.8.0...v1.8.1) (2021-09-14)
 
+
 ### Bug Fixes
 
-- bug on email sending ([70edbb2](https://github.com/SocialGouv/mano/commit/70edbb26623f97216967685a42997b3e8067c94f))
+* bug on email sending ([70edbb2](https://github.com/SocialGouv/mano/commit/70edbb26623f97216967685a42997b3e8067c94f))
 
 # [1.8.0](https://github.com/SocialGouv/mano/compare/v1.7.4...v1.8.0) (2021-09-13)
 
+
 ### Features
 
-- add mobile app ([#22](https://github.com/SocialGouv/mano/issues/22)) ([8266cfc](https://github.com/SocialGouv/mano/commit/8266cfc8e8de70d1feb64c3d3eefb05ab68abd7d))
+* add mobile app ([#22](https://github.com/SocialGouv/mano/issues/22)) ([8266cfc](https://github.com/SocialGouv/mano/commit/8266cfc8e8de70d1feb64c3d3eefb05ab68abd7d))
 
 ## [1.7.4](https://github.com/SocialGouv/mano/compare/v1.7.3...v1.7.4) (2021-09-13)
 
+
 ### Bug Fixes
 
-- update kosko charts ([978ff4e](https://github.com/SocialGouv/mano/commit/978ff4ebe455452b5fc56a39fc571d804e11f046))
+* update kosko charts ([978ff4e](https://github.com/SocialGouv/mano/commit/978ff4ebe455452b5fc56a39fc571d804e11f046))
 
 ## [1.7.3](https://github.com/SocialGouv/mano/compare/v1.7.2...v1.7.3) (2021-09-13)
 
+
 ### Bug Fixes
 
-- update preprod api secret ([491e2f9](https://github.com/SocialGouv/mano/commit/491e2f9a7d15e3ab043cb9e487406169cbde9eae))
+* update preprod api secret ([491e2f9](https://github.com/SocialGouv/mano/commit/491e2f9a7d15e3ab043cb9e487406169cbde9eae))
 
 ## [1.7.2](https://github.com/SocialGouv/mano/compare/v1.7.1...v1.7.2) (2021-09-13)
 
+
 ### Bug Fixes
 
-- update kostko.toml ([7515e99](https://github.com/SocialGouv/mano/commit/7515e993ad07e447b5e00f952ebdfab8c6735603))
+* update kostko.toml ([7515e99](https://github.com/SocialGouv/mano/commit/7515e993ad07e447b5e00f952ebdfab8c6735603))
 
 ## [1.7.1](https://github.com/SocialGouv/mano/compare/v1.7.0...v1.7.1) (2021-09-13)
 
+
 ### Bug Fixes
 
-- **ci:** add rancher id in env ([4e5b18e](https://github.com/SocialGouv/mano/commit/4e5b18e33b4962d9398ff244b27b443035d1ea20))
-- **ci:** add rancher id in env preproduction ([3f52fa8](https://github.com/SocialGouv/mano/commit/3f52fa8060e27324634f80c12c5efe99a6baa804))
+* **ci:** add rancher id in env ([4e5b18e](https://github.com/SocialGouv/mano/commit/4e5b18e33b4962d9398ff244b27b443035d1ea20))
+* **ci:** add rancher id in env preproduction ([3f52fa8](https://github.com/SocialGouv/mano/commit/3f52fa8060e27324634f80c12c5efe99a6baa804))
 
 # [1.7.0](https://github.com/SocialGouv/mano/compare/v1.6.1...v1.7.0) (2021-09-13)
 
+
 ### Features
 
-- **ci:** deploy api in production ([#21](https://github.com/SocialGouv/mano/issues/21)) ([05c1063](https://github.com/SocialGouv/mano/commit/05c10631904c4e40e77f876ac0b977b2982fd5f0))
+* **ci:** deploy api in production ([#21](https://github.com/SocialGouv/mano/issues/21)) ([05c1063](https://github.com/SocialGouv/mano/commit/05c10631904c4e40e77f876ac0b977b2982fd5f0))
 
 ## [1.6.1](https://github.com/SocialGouv/mano/compare/v1.6.0...v1.6.1) (2021-09-13)
 
+
 ### Bug Fixes
 
-- bump version ([44c6b4c](https://github.com/SocialGouv/mano/commit/44c6b4c4cc489787a37d213e0f010f5788d2d848))
+* bump version ([44c6b4c](https://github.com/SocialGouv/mano/commit/44c6b4c4cc489787a37d213e0f010f5788d2d848))
 
 # [1.6.0](https://github.com/SocialGouv/mano/compare/v1.5.1...v1.6.0) (2021-09-13)
 
+
 ### Features
 
-- add api in review ([#15](https://github.com/SocialGouv/mano/issues/15)) ([e913b5d](https://github.com/SocialGouv/mano/commit/e913b5df488a9b749feea1748a5fd24f9e7aebd4)), closes [#16](https://github.com/SocialGouv/mano/issues/16)
+* add api in review ([#15](https://github.com/SocialGouv/mano/issues/15)) ([e913b5d](https://github.com/SocialGouv/mano/commit/e913b5df488a9b749feea1748a5fd24f9e7aebd4)), closes [#16](https://github.com/SocialGouv/mano/issues/16)
 
 ## [1.5.1](https://github.com/SocialGouv/mano/compare/v1.5.0...v1.5.1) (2021-09-11)
 
+
 ### Bug Fixes
 
-- can view report ([98794f2](https://github.com/SocialGouv/mano/commit/98794f2d958bfcd947630ed57c67bbecdffe3905))
+* can view report ([98794f2](https://github.com/SocialGouv/mano/commit/98794f2d958bfcd947630ed57c67bbecdffe3905))
 
 # [1.5.0](https://github.com/SocialGouv/mano/compare/v1.4.1...v1.5.0) (2021-09-10)
 
+
 ### Features
 
-- add api ([#14](https://github.com/SocialGouv/mano/issues/14)) ([b951367](https://github.com/SocialGouv/mano/commit/b951367bb07e330ebc73dfa8d2dbc7c0132ffd03))
+* add api ([#14](https://github.com/SocialGouv/mano/issues/14)) ([b951367](https://github.com/SocialGouv/mano/commit/b951367bb07e330ebc73dfa8d2dbc7c0132ffd03))
 
 ## [1.4.1](https://github.com/SocialGouv/mano/compare/v1.4.0...v1.4.1) (2021-09-10)
 
+
 ### Bug Fixes
 
-- add another maraud in report ([#12](https://github.com/SocialGouv/mano/issues/12)) ([c543440](https://github.com/SocialGouv/mano/commit/c54344013a89ffe8b8cde0387773941b9f0aefe3))
+* add another maraud in report ([#12](https://github.com/SocialGouv/mano/issues/12)) ([c543440](https://github.com/SocialGouv/mano/commit/c54344013a89ffe8b8cde0387773941b9f0aefe3))
 
 # [1.4.0](https://github.com/SocialGouv/mano/compare/v1.3.0...v1.4.0) (2021-09-10)
 
+
 ### Features
 
-- **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([#11](https://github.com/SocialGouv/mano/issues/11)) ([816a643](https://github.com/SocialGouv/mano/commit/816a6434d22207397aa19c6feeaf5233441783e3))
+* **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([#11](https://github.com/SocialGouv/mano/issues/11)) ([816a643](https://github.com/SocialGouv/mano/commit/816a6434d22207397aa19c6feeaf5233441783e3))
 
 # [1.4.0-alpha.1](https://github.com/SocialGouv/mano/compare/v1.3.0...v1.4.0-alpha.1) (2021-09-10)
 
+
 ### Features
 
-- **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([3ac41bc](https://github.com/SocialGouv/mano/commit/3ac41bc719e507e319b87e88825ec80430759151))
+* **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([3ac41bc](https://github.com/SocialGouv/mano/commit/3ac41bc719e507e319b87e88825ec80430759151))
 
 # [1.3.0](https://github.com/SocialGouv/mano/compare/v1.2.0...v1.3.0) (2021-09-10)
 
+
 ### Features
 
-- **ci:** add component dashboard only for dev env ([#9](https://github.com/SocialGouv/mano/issues/9)) ([36af8db](https://github.com/SocialGouv/mano/commit/36af8db09179341ade62e230cbba204a89469538))
+* **ci:** add component dashboard only for dev env ([#9](https://github.com/SocialGouv/mano/issues/9)) ([36af8db](https://github.com/SocialGouv/mano/commit/36af8db09179341ade62e230cbba204a89469538))
 
 # [1.2.0](https://github.com/SocialGouv/mano/compare/v1.1.0...v1.2.0) (2021-09-03)
 
+
 ### Features
 
-- add dashboard ([#7](https://github.com/SocialGouv/mano/issues/7)) ([988fd16](https://github.com/SocialGouv/mano/commit/988fd16d08945984c8b19834d32f71e84e237f96))
+* add dashboard ([#7](https://github.com/SocialGouv/mano/issues/7)) ([988fd16](https://github.com/SocialGouv/mano/commit/988fd16d08945984c8b19834d32f71e84e237f96))
 
 # [1.1.0](https://github.com/SocialGouv/mano/compare/v1.0.0...v1.1.0) (2021-09-03)
 
+
 ### Features
 
-- deploy to prod ([#6](https://github.com/SocialGouv/mano/issues/6)) ([c8f31a6](https://github.com/SocialGouv/mano/commit/c8f31a64474794e8944657918101244afdd2c525)), closes [#3](https://github.com/SocialGouv/mano/issues/3) [#3](https://github.com/SocialGouv/mano/issues/3) [#5](https://github.com/SocialGouv/mano/issues/5)
+* deploy to prod ([#6](https://github.com/SocialGouv/mano/issues/6)) ([c8f31a6](https://github.com/SocialGouv/mano/commit/c8f31a64474794e8944657918101244afdd2c525)), closes [#3](https://github.com/SocialGouv/mano/issues/3) [#3](https://github.com/SocialGouv/mano/issues/3) [#5](https://github.com/SocialGouv/mano/issues/5)
 
 # [1.1.0-alpha.3](https://github.com/SocialGouv/mano/compare/v1.1.0-alpha.2...v1.1.0-alpha.3) (2021-09-02)
 
+
 ### Bug Fixes
 
-- bump version ([304b705](https://github.com/SocialGouv/mano/commit/304b7055dc03eedf5d0e5ba92d667f028c213285))
+* bump version ([304b705](https://github.com/SocialGouv/mano/commit/304b7055dc03eedf5d0e5ba92d667f028c213285))
 
 # [1.1.0-alpha.2](https://github.com/SocialGouv/mano/compare/v1.1.0-alpha.1...v1.1.0-alpha.2) (2021-09-02)
 
+
 ### Bug Fixes
 
-- **ci:** rename job to deploy-preproduction ([647a280](https://github.com/SocialGouv/mano/commit/647a2808b1eae073dbced3adc35cd9ebb01c118b))
+* **ci:** rename job to deploy-preproduction ([647a280](https://github.com/SocialGouv/mano/commit/647a2808b1eae073dbced3adc35cd9ebb01c118b))
 
 # [1.1.0-alpha.1](https://github.com/SocialGouv/mano/compare/v1.0.0...v1.1.0-alpha.1) (2021-09-02)
 
+
 ### Features
 
-- **ci:** add prod and pre-prod deployment ([#3](https://github.com/SocialGouv/mano/issues/3)) ([2eaf32e](https://github.com/SocialGouv/mano/commit/2eaf32e4b6a8574a4412eb191c02aa2f6ede8a5d))
+* **ci:** add prod and pre-prod deployment ([#3](https://github.com/SocialGouv/mano/issues/3)) ([2eaf32e](https://github.com/SocialGouv/mano/commit/2eaf32e4b6a8574a4412eb191c02aa2f6ede8a5d))
 
 # 1.0.0 (2021-09-02)
 
+
 ### Bug Fixes
 
-- **ci:** remove useless url ([30c5993](https://github.com/SocialGouv/mano/commit/30c5993707ad1226d81e3c3700451f1a638728da))
-- missing releaserc ([e44d777](https://github.com/SocialGouv/mano/commit/e44d77763d8111d20a9c8d6d98207e9c8978bb35))
-- **ci:** branches ([0c00e06](https://github.com/SocialGouv/mano/commit/0c00e06d4684a3ac85d6d31b386917aa095485d5))
+* **ci:** remove useless url ([30c5993](https://github.com/SocialGouv/mano/commit/30c5993707ad1226d81e3c3700451f1a638728da))
+* missing releaserc ([e44d777](https://github.com/SocialGouv/mano/commit/e44d77763d8111d20a9c8d6d98207e9c8978bb35))
+* **ci:** branches ([0c00e06](https://github.com/SocialGouv/mano/commit/0c00e06d4684a3ac85d6d31b386917aa095485d5))
+
 
 ### Features
 
-- add semantic release ([82ad799](https://github.com/SocialGouv/mano/commit/82ad799e36fda1ff2a9cd930eb06b0112697cda1))
+* add semantic release ([82ad799](https://github.com/SocialGouv/mano/commit/82ad799e36fda1ff2a9cd930eb06b0112697cda1))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,2273 +1,1949 @@
 ## [1.83.1](https://github.com/SocialGouv/mano/compare/v1.83.0...v1.83.1) (2022-04-01)
 
-
 ### Bug Fixes
 
-* user should not be able to delete themselves ([#568](https://github.com/SocialGouv/mano/issues/568)) ([1ba98da](https://github.com/SocialGouv/mano/commit/1ba98da11bd89defaadb38c49507f2c07ab549ca))
+- user should not be able to delete themselves ([#568](https://github.com/SocialGouv/mano/issues/568)) ([1ba98da](https://github.com/SocialGouv/mano/commit/1ba98da11bd89defaadb38c49507f2c07ab549ca))
 
 # [1.83.0](https://github.com/SocialGouv/mano/compare/v1.82.0...v1.83.0) (2022-04-01)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix 566 ([3921130](https://github.com/SocialGouv/mano/commit/39211308b98f39612c57c1286d3e2d674eaf9465))
-
+- **dashboard:** fix 566 ([3921130](https://github.com/SocialGouv/mano/commit/39211308b98f39612c57c1286d3e2d674eaf9465))
 
 ### Features
 
-* **app:** update mobile version ([5367191](https://github.com/SocialGouv/mano/commit/53671912a4939829677e8ba17cbbafb9c57f8a78))
+- **app:** update mobile version ([5367191](https://github.com/SocialGouv/mano/commit/53671912a4939829677e8ba17cbbafb9c57f8a78))
 
 # [1.82.0](https://github.com/SocialGouv/mano/compare/v1.81.3...v1.82.0) (2022-04-01)
 
-
 ### Features
 
-* **app:** suggest team association when create person ([#560](https://github.com/SocialGouv/mano/issues/560)) ([67af25e](https://github.com/SocialGouv/mano/commit/67af25ead8cf33d34d843bab83a16fc6db626d27))
+- **app:** suggest team association when create person ([#560](https://github.com/SocialGouv/mano/issues/560)) ([67af25e](https://github.com/SocialGouv/mano/commit/67af25ead8cf33d34d843bab83a16fc6db626d27))
 
 ## [1.81.3](https://github.com/SocialGouv/mano/compare/v1.81.2...v1.81.3) (2022-04-01)
 
-
 ### Bug Fixes
 
-* **app:** loose bottom navigation bar ([#546](https://github.com/SocialGouv/mano/issues/546)) ([97c23cd](https://github.com/SocialGouv/mano/commit/97c23cd91219009c31d30060473633a379a634d1))
+- **app:** loose bottom navigation bar ([#546](https://github.com/SocialGouv/mano/issues/546)) ([97c23cd](https://github.com/SocialGouv/mano/commit/97c23cd91219009c31d30060473633a379a634d1))
 
 ## [1.81.2](https://github.com/SocialGouv/mano/compare/v1.81.1...v1.81.2) (2022-03-30)
 
-
 ### Bug Fixes
 
-* **dash:** sanitize custom field ([#554](https://github.com/SocialGouv/mano/issues/554)) ([21ea43c](https://github.com/SocialGouv/mano/commit/21ea43c1371c7184a55ab2220619c5df42492cfa))
+- **dash:** sanitize custom field ([#554](https://github.com/SocialGouv/mano/issues/554)) ([21ea43c](https://github.com/SocialGouv/mano/commit/21ea43c1371c7184a55ab2220619c5df42492cfa))
 
 ## [1.81.1](https://github.com/SocialGouv/mano/compare/v1.81.0...v1.81.1) (2022-03-30)
 
-
 ### Bug Fixes
 
-* **api:** add onlyHealthcareProfessional to checked fields ([#553](https://github.com/SocialGouv/mano/issues/553)) ([00550b6](https://github.com/SocialGouv/mano/commit/00550b647e2f98d14385cd50879aacd8a26eab58))
+- **api:** add onlyHealthcareProfessional to checked fields ([#553](https://github.com/SocialGouv/mano/issues/553)) ([00550b6](https://github.com/SocialGouv/mano/commit/00550b647e2f98d14385cd50879aacd8a26eab58))
 
 # [1.81.0](https://github.com/SocialGouv/mano/compare/v1.80.1...v1.81.0) (2022-03-28)
 
-
 ### Features
 
-* **dashboard,app:** only healthcare professional ([#543](https://github.com/SocialGouv/mano/issues/543)) ([64ff190](https://github.com/SocialGouv/mano/commit/64ff190c3ca79e2a91716745b7f213e7c03e20f8))
+- **dashboard,app:** only healthcare professional ([#543](https://github.com/SocialGouv/mano/issues/543)) ([64ff190](https://github.com/SocialGouv/mano/commit/64ff190c3ca79e2a91716745b7f213e7c03e20f8))
 
 ## [1.80.1](https://github.com/SocialGouv/mano/compare/v1.80.0...v1.80.1) (2022-03-28)
 
-
 ### Bug Fixes
 
-* **app:** ignore noisy errors for mobile ([#539](https://github.com/SocialGouv/mano/issues/539)) ([156a2c2](https://github.com/SocialGouv/mano/commit/156a2c2c32260ae0a607ca40640e581ec32d9bf1))
+- **app:** ignore noisy errors for mobile ([#539](https://github.com/SocialGouv/mano/issues/539)) ([156a2c2](https://github.com/SocialGouv/mano/commit/156a2c2c32260ae0a607ca40640e581ec32d9bf1))
 
 # [1.80.0](https://github.com/SocialGouv/mano/compare/v1.79.9...v1.80.0) (2022-03-25)
 
-
 ### Features
 
-* **dashboard:** add autre to outOfActiveListReasonOptions ([86ea129](https://github.com/SocialGouv/mano/commit/86ea129d3e2c5ff6b07211122a3c5b6e768728b3))
+- **dashboard:** add autre to outOfActiveListReasonOptions ([86ea129](https://github.com/SocialGouv/mano/commit/86ea129d3e2c5ff6b07211122a3c5b6e768728b3))
 
 ## [1.79.9](https://github.com/SocialGouv/mano/compare/v1.79.8...v1.79.9) (2022-03-25)
 
-
 ### Bug Fixes
 
-* **dashboard:** completedAt was overridden ([83dbd18](https://github.com/SocialGouv/mano/commit/83dbd18ff75dab4e606c898cba5625fe0fe7b281))
+- **dashboard:** completedAt was overridden ([83dbd18](https://github.com/SocialGouv/mano/commit/83dbd18ff75dab4e606c898cba5625fe0fe7b281))
 
 ## [1.79.8](https://github.com/SocialGouv/mano/compare/v1.79.7...v1.79.8) (2022-03-25)
 
-
 ### Bug Fixes
 
-* **dashboard:** sanitize imports ([#530](https://github.com/SocialGouv/mano/issues/530)) ([a4fed0e](https://github.com/SocialGouv/mano/commit/a4fed0ea6b2c5b54cebbe93dba22166499ebcf00))
+- **dashboard:** sanitize imports ([#530](https://github.com/SocialGouv/mano/issues/530)) ([a4fed0e](https://github.com/SocialGouv/mano/commit/a4fed0ea6b2c5b54cebbe93dba22166499ebcf00))
 
 ## [1.79.7](https://github.com/SocialGouv/mano/compare/v1.79.6...v1.79.7) (2022-03-24)
 
-
 ### Bug Fixes
 
-* **api:** trigger api release ([31d35df](https://github.com/SocialGouv/mano/commit/31d35dffc1beffe7dd6f5db29b227c852a898534))
-* **app,dashboard,api:** remove ability to PUT createdAt of comment ([#503](https://github.com/SocialGouv/mano/issues/503)) ([dfde586](https://github.com/SocialGouv/mano/commit/dfde586bb068188cae984714fff2a9443787950a))
-* **dashboard:** editingField may exist but not have options ([15a6dd5](https://github.com/SocialGouv/mano/commit/15a6dd582ed99aa6321875e19511423f4ee78a81))
-* migrations not activated yet in app ([#529](https://github.com/SocialGouv/mano/issues/529)) ([c5cb5bd](https://github.com/SocialGouv/mano/commit/c5cb5bd5f8c28fb196e2e6c357f55c8b59771442))
+- **api:** trigger api release ([31d35df](https://github.com/SocialGouv/mano/commit/31d35dffc1beffe7dd6f5db29b227c852a898534))
+- **app,dashboard,api:** remove ability to PUT createdAt of comment ([#503](https://github.com/SocialGouv/mano/issues/503)) ([dfde586](https://github.com/SocialGouv/mano/commit/dfde586bb068188cae984714fff2a9443787950a))
+- **dashboard:** editingField may exist but not have options ([15a6dd5](https://github.com/SocialGouv/mano/commit/15a6dd582ed99aa6321875e19511423f4ee78a81))
+- migrations not activated yet in app ([#529](https://github.com/SocialGouv/mano/issues/529)) ([c5cb5bd](https://github.com/SocialGouv/mano/commit/c5cb5bd5f8c28fb196e2e6c357f55c8b59771442))
 
 ## [1.79.6](https://github.com/SocialGouv/mano/compare/v1.79.5...v1.79.6) (2022-03-24)
 
-
 ### Bug Fixes
 
-* normal user also can migrate ([d3a14be](https://github.com/SocialGouv/mano/commit/d3a14be71ab8261c1b823161da0c0e80e844df63))
+- normal user also can migrate ([d3a14be](https://github.com/SocialGouv/mano/commit/d3a14be71ab8261c1b823161da0c0e80e844df63))
 
 ## [1.79.5](https://github.com/SocialGouv/mano/compare/v1.79.4...v1.79.5) (2022-03-24)
 
-
 ### Bug Fixes
 
-* **dashboard:** import crashed with team after [#487](https://github.com/SocialGouv/mano/issues/487) refactor ([14a2bae](https://github.com/SocialGouv/mano/commit/14a2baefbae53cafc6d9d13c6c792fa1e7c389e8))
+- **dashboard:** import crashed with team after [#487](https://github.com/SocialGouv/mano/issues/487) refactor ([14a2bae](https://github.com/SocialGouv/mano/commit/14a2baefbae53cafc6d9d13c6c792fa1e7c389e8))
 
 ## [1.79.4](https://github.com/SocialGouv/mano/compare/v1.79.3...v1.79.4) (2022-03-23)
 
-
 ### Bug Fixes
 
-* **dashboard:** prevent reports updating non stop ([#518](https://github.com/SocialGouv/mano/issues/518)) ([19ea779](https://github.com/SocialGouv/mano/commit/19ea779a3170704648d4186bbcc489a93d85aee3))
+- **dashboard:** prevent reports updating non stop ([#518](https://github.com/SocialGouv/mano/issues/518)) ([19ea779](https://github.com/SocialGouv/mano/commit/19ea779a3170704648d4186bbcc489a93d85aee3))
 
 ## [1.79.3](https://github.com/SocialGouv/mano/compare/v1.79.2...v1.79.3) (2022-03-23)
 
-
 ### Bug Fixes
 
-* **dashboard:** number of comments ([#517](https://github.com/SocialGouv/mano/issues/517)) ([f974537](https://github.com/SocialGouv/mano/commit/f974537235e70acc9983f3788ee2e2b6f23fb1d5))
+- **dashboard:** number of comments ([#517](https://github.com/SocialGouv/mano/issues/517)) ([f974537](https://github.com/SocialGouv/mano/commit/f974537235e70acc9983f3788ee2e2b6f23fb1d5))
 
 ## [1.79.2](https://github.com/SocialGouv/mano/compare/v1.79.1...v1.79.2) (2022-03-23)
 
-
 ### Bug Fixes
 
-* **dashboard:**  bugs related to new passage migration ([#516](https://github.com/SocialGouv/mano/issues/516)) ([a05fd7d](https://github.com/SocialGouv/mano/commit/a05fd7d1324d41a3255217329d1fb5fbd14c0ffc))
+- **dashboard:** bugs related to new passage migration ([#516](https://github.com/SocialGouv/mano/issues/516)) ([a05fd7d](https://github.com/SocialGouv/mano/commit/a05fd7d1324d41a3255217329d1fb5fbd14c0ffc))
 
 ## [1.79.1](https://github.com/SocialGouv/mano/compare/v1.79.0...v1.79.1) (2022-03-23)
 
-
 ### Bug Fixes
 
-* cors update to include tauri ([#515](https://github.com/SocialGouv/mano/issues/515)) ([b634df0](https://github.com/SocialGouv/mano/commit/b634df061d455289160ab226d09cb397b9fa581d))
+- cors update to include tauri ([#515](https://github.com/SocialGouv/mano/issues/515)) ([b634df0](https://github.com/SocialGouv/mano/commit/b634df061d455289160ab226d09cb397b9fa581d))
 
 # [1.79.0](https://github.com/SocialGouv/mano/compare/v1.78.2...v1.79.0) (2022-03-22)
 
-
 ### Features
 
-* **api,dashboard:**  passages migration cherry picked ([#493](https://github.com/SocialGouv/mano/issues/493)) ([32b940e](https://github.com/SocialGouv/mano/commit/32b940e7a10261a9cd20b0e05601b66f0970ac49))
+- **api,dashboard:** passages migration cherry picked ([#493](https://github.com/SocialGouv/mano/issues/493)) ([32b940e](https://github.com/SocialGouv/mano/commit/32b940e7a10261a9cd20b0e05601b66f0970ac49))
 
 ## [1.78.2](https://github.com/SocialGouv/mano/compare/v1.78.1...v1.78.2) (2022-03-21)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix am-pm dates ([#513](https://github.com/SocialGouv/mano/issues/513)) ([1cb83d0](https://github.com/SocialGouv/mano/commit/1cb83d034d3e3db638c72d90bb58d24c425007df))
+- **dashboard:** fix am-pm dates ([#513](https://github.com/SocialGouv/mano/issues/513)) ([1cb83d0](https://github.com/SocialGouv/mano/commit/1cb83d034d3e3db638c72d90bb58d24c425007df))
 
 ## [1.78.1](https://github.com/SocialGouv/mano/compare/v1.78.0...v1.78.1) (2022-03-21)
 
-
 ### Bug Fixes
 
-* **app:** delete person confirm in app ([#498](https://github.com/SocialGouv/mano/issues/498)) ([3b206a5](https://github.com/SocialGouv/mano/commit/3b206a5681b9842c538a54f9783e51c19cf6b661))
+- **app:** delete person confirm in app ([#498](https://github.com/SocialGouv/mano/issues/498)) ([3b206a5](https://github.com/SocialGouv/mano/commit/3b206a5681b9842c538a54f9783e51c19cf6b661))
 
 # [1.78.0](https://github.com/SocialGouv/mano/compare/v1.77.0...v1.78.0) (2022-03-21)
 
-
 ### Features
 
-* **dashboard:** improve browser support ([#494](https://github.com/SocialGouv/mano/issues/494)) ([d2c75d5](https://github.com/SocialGouv/mano/commit/d2c75d5e3f6ad7069f5674c7754690115ad1b74e))
+- **dashboard:** improve browser support ([#494](https://github.com/SocialGouv/mano/issues/494)) ([d2c75d5](https://github.com/SocialGouv/mano/commit/d2c75d5e3f6ad7069f5674c7754690115ad1b74e))
 
 # [1.77.0](https://github.com/SocialGouv/mano/compare/v1.76.1...v1.77.0) (2022-03-21)
 
-
 ### Features
 
-* add healthcare professional property on users ([#492](https://github.com/SocialGouv/mano/issues/492)) ([417f65b](https://github.com/SocialGouv/mano/commit/417f65b6d6a42dac5b345b0bc37c40a1898799bd))
+- add healthcare professional property on users ([#492](https://github.com/SocialGouv/mano/issues/492)) ([417f65b](https://github.com/SocialGouv/mano/commit/417f65b6d6a42dac5b345b0bc37c40a1898799bd))
 
 ## [1.76.1](https://github.com/SocialGouv/mano/compare/v1.76.0...v1.76.1) (2022-03-18)
 
-
 ### Bug Fixes
 
-* **app:** can delete territory ([#499](https://github.com/SocialGouv/mano/issues/499)) ([210d623](https://github.com/SocialGouv/mano/commit/210d623289d0aa2fadb1ef3771978a221541fad4))
+- **app:** can delete territory ([#499](https://github.com/SocialGouv/mano/issues/499)) ([210d623](https://github.com/SocialGouv/mano/commit/210d623289d0aa2fadb1ef3771978a221541fad4))
 
 # [1.76.0](https://github.com/SocialGouv/mano/compare/v1.75.0...v1.76.0) (2022-03-17)
 
-
 ### Features
 
-* **dashboard:** warning before delete person ([#491](https://github.com/SocialGouv/mano/issues/491)) ([4617e05](https://github.com/SocialGouv/mano/commit/4617e053211ba7d88647d0dc324c916f95313e72))
+- **dashboard:** warning before delete person ([#491](https://github.com/SocialGouv/mano/issues/491)) ([4617e05](https://github.com/SocialGouv/mano/commit/4617e053211ba7d88647d0dc324c916f95313e72))
 
 # [1.75.0](https://github.com/SocialGouv/mano/compare/v1.74.0...v1.75.0) (2022-03-17)
 
-
 ### Features
 
-* **dashboard:**  remove abstractions ([#487](https://github.com/SocialGouv/mano/issues/487)) ([d4a7566](https://github.com/SocialGouv/mano/commit/d4a75665f0fb37e5445919f2490868225b2469a0))
+- **dashboard:** remove abstractions ([#487](https://github.com/SocialGouv/mano/issues/487)) ([d4a7566](https://github.com/SocialGouv/mano/commit/d4a75665f0fb37e5445919f2490868225b2469a0))
 
 # [1.74.0](https://github.com/SocialGouv/mano/compare/v1.73.1...v1.74.0) (2022-03-16)
 
-
 ### Features
 
-* **dashboard:** outdated version checker ([#485](https://github.com/SocialGouv/mano/issues/485)) ([2a46d17](https://github.com/SocialGouv/mano/commit/2a46d1783948dc254f1551f1adfb03d2e84c01cc))
+- **dashboard:** outdated version checker ([#485](https://github.com/SocialGouv/mano/issues/485)) ([2a46d17](https://github.com/SocialGouv/mano/commit/2a46d1783948dc254f1551f1adfb03d2e84c01cc))
 
 ## [1.73.1](https://github.com/SocialGouv/mano/compare/v1.73.0...v1.73.1) (2022-03-16)
 
-
 ### Bug Fixes
 
-* **api:** password disclosure in sentry ([#486](https://github.com/SocialGouv/mano/issues/486)) ([80827e1](https://github.com/SocialGouv/mano/commit/80827e11948b0d14ef359f9996f1480f276dc4ba))
+- **api:** password disclosure in sentry ([#486](https://github.com/SocialGouv/mano/issues/486)) ([80827e1](https://github.com/SocialGouv/mano/commit/80827e11948b0d14ef359f9996f1480f276dc4ba))
 
 # [1.73.0](https://github.com/SocialGouv/mano/compare/v1.72.2...v1.73.0) (2022-03-15)
 
-
 ### Features
 
-* **dashboard:** show version in drawer ([#484](https://github.com/SocialGouv/mano/issues/484)) ([b8d2ad0](https://github.com/SocialGouv/mano/commit/b8d2ad048ac37f028a9e5069583f36b8281aa6d7))
+- **dashboard:** show version in drawer ([#484](https://github.com/SocialGouv/mano/issues/484)) ([b8d2ad0](https://github.com/SocialGouv/mano/commit/b8d2ad048ac37f028a9e5069583f36b8281aa6d7))
 
 ## [1.72.2](https://github.com/SocialGouv/mano/compare/v1.72.1...v1.72.2) (2022-03-14)
 
-
 ### Bug Fixes
 
-* **dashboard:** boolean custom field display ([#477](https://github.com/SocialGouv/mano/issues/477)) ([c0d35b1](https://github.com/SocialGouv/mano/commit/c0d35b13636b3ad7cca530d2bd0b52c20a2238dd))
+- **dashboard:** boolean custom field display ([#477](https://github.com/SocialGouv/mano/issues/477)) ([c0d35b1](https://github.com/SocialGouv/mano/commit/c0d35b13636b3ad7cca530d2bd0b52c20a2238dd))
 
 ## [1.72.1](https://github.com/SocialGouv/mano/compare/v1.72.0...v1.72.1) (2022-03-14)
 
-
 ### Bug Fixes
 
-* **dashboard:** outOfActiveList message ([76ac7a0](https://github.com/SocialGouv/mano/commit/76ac7a076bbca9ce92430a2e6a7682ea1820345e))
+- **dashboard:** outOfActiveList message ([76ac7a0](https://github.com/SocialGouv/mano/commit/76ac7a076bbca9ce92430a2e6a7682ea1820345e))
 
 # [1.72.0](https://github.com/SocialGouv/mano/compare/v1.71.26...v1.72.0) (2022-03-14)
 
-
 ### Features
 
-* **dashboard:** link to q&a ([#483](https://github.com/SocialGouv/mano/issues/483)) ([5485214](https://github.com/SocialGouv/mano/commit/54852140aa695ecd4b4ac8f23e61bec592c76d71))
+- **dashboard:** link to q&a ([#483](https://github.com/SocialGouv/mano/issues/483)) ([5485214](https://github.com/SocialGouv/mano/commit/54852140aa695ecd4b4ac8f23e61bec592c76d71))
 
 ## [1.71.26](https://github.com/SocialGouv/mano/compare/v1.71.25...v1.71.26) (2022-03-14)
 
-
 ### Bug Fixes
 
-* **dashboard:** enable/disable reception ([#482](https://github.com/SocialGouv/mano/issues/482)) ([ffbce3f](https://github.com/SocialGouv/mano/commit/ffbce3f62c0f53c860daaa9449a76cc5326dbdcb))
+- **dashboard:** enable/disable reception ([#482](https://github.com/SocialGouv/mano/issues/482)) ([ffbce3f](https://github.com/SocialGouv/mano/commit/ffbce3f62c0f53c860daaa9449a76cc5326dbdcb))
 
 ## [1.71.25](https://github.com/SocialGouv/mano/compare/v1.71.24...v1.71.25) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **dashboard:**  reports date team ([#476](https://github.com/SocialGouv/mano/issues/476)) ([0c99d1c](https://github.com/SocialGouv/mano/commit/0c99d1ccd805767b40261e4de58e8d34a3e24496))
+- **dashboard:** reports date team ([#476](https://github.com/SocialGouv/mano/issues/476)) ([0c99d1c](https://github.com/SocialGouv/mano/commit/0c99d1ccd805767b40261e4de58e8d34a3e24496))
 
 ## [1.71.24](https://github.com/SocialGouv/mano/compare/v1.71.23...v1.71.24) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **api:** capture invalid requests ([#478](https://github.com/SocialGouv/mano/issues/478)) ([e580208](https://github.com/SocialGouv/mano/commit/e5802089a8ec36b96556a413af7e5b7373cbafd1))
+- **api:** capture invalid requests ([#478](https://github.com/SocialGouv/mano/issues/478)) ([e580208](https://github.com/SocialGouv/mano/commit/e5802089a8ec36b96556a413af7e5b7373cbafd1))
 
 ## [1.71.23](https://github.com/SocialGouv/mano/compare/v1.71.22...v1.71.23) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix "optimization" ([d9509ac](https://github.com/SocialGouv/mano/commit/d9509ace1cc36bb5c92e8817fb4083dc58af938b))
+- **dashboard:** fix "optimization" ([d9509ac](https://github.com/SocialGouv/mano/commit/d9509ace1cc36bb5c92e8817fb4083dc58af938b))
 
 ## [1.71.22](https://github.com/SocialGouv/mano/compare/v1.71.21...v1.71.22) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **app:** value if null ([#473](https://github.com/SocialGouv/mano/issues/473)) ([0953851](https://github.com/SocialGouv/mano/commit/095385103ab34dcf3ee588c6ef498b484299e487))
+- **app:** value if null ([#473](https://github.com/SocialGouv/mano/issues/473)) ([0953851](https://github.com/SocialGouv/mano/commit/095385103ab34dcf3ee588c6ef498b484299e487))
 
 ## [1.71.21](https://github.com/SocialGouv/mano/compare/v1.71.20...v1.71.21) (2022-03-11)
 
-
 ### Bug Fixes
 
-* **dashboard:** change signin process ([#471](https://github.com/SocialGouv/mano/issues/471)) ([69f5011](https://github.com/SocialGouv/mano/commit/69f50114f12df1f7a5cdd5da7d6f85de21115200))
+- **dashboard:** change signin process ([#471](https://github.com/SocialGouv/mano/issues/471)) ([69f5011](https://github.com/SocialGouv/mano/commit/69f50114f12df1f7a5cdd5da7d6f85de21115200))
 
 ## [1.71.20](https://github.com/SocialGouv/mano/compare/v1.71.19...v1.71.20) (2022-03-10)
 
-
 ### Bug Fixes
 
-* fix table sort ([#458](https://github.com/SocialGouv/mano/issues/458)) ([09dd5f7](https://github.com/SocialGouv/mano/commit/09dd5f769480a612541d520df80c498709ee2505))
+- fix table sort ([#458](https://github.com/SocialGouv/mano/issues/458)) ([09dd5f7](https://github.com/SocialGouv/mano/commit/09dd5f769480a612541d520df80c498709ee2505))
 
 ## [1.71.19](https://github.com/SocialGouv/mano/compare/v1.71.18...v1.71.19) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **api:** validate actual body ([33415cb](https://github.com/SocialGouv/mano/commit/33415cbdb88e5a1ff29976cd768141f0f7244933))
+- **api:** validate actual body ([33415cb](https://github.com/SocialGouv/mano/commit/33415cbdb88e5a1ff29976cd768141f0f7244933))
 
 ## [1.71.18](https://github.com/SocialGouv/mano/compare/v1.71.17...v1.71.18) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** delete custom field ([d97889a](https://github.com/SocialGouv/mano/commit/d97889af5ab9cb4edf2da3d7eb3708f784d4c86e))
+- **dashboard:** delete custom field ([d97889a](https://github.com/SocialGouv/mano/commit/d97889af5ab9cb4edf2da3d7eb3708f784d4c86e))
 
 ## [1.71.17](https://github.com/SocialGouv/mano/compare/v1.71.16...v1.71.17) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **dahsboard:** fix #MANO-64 ([454f396](https://github.com/SocialGouv/mano/commit/454f396ab256a24ac76980caece84a83fab0ebf2)), closes [#MANO-64](https://github.com/SocialGouv/mano/issues/MANO-64)
+- **dahsboard:** fix #MANO-64 ([454f396](https://github.com/SocialGouv/mano/commit/454f396ab256a24ac76980caece84a83fab0ebf2)), closes [#MANO-64](https://github.com/SocialGouv/mano/issues/MANO-64)
 
 ## [1.71.16](https://github.com/SocialGouv/mano/compare/v1.71.15...v1.71.16) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix #MANO-9M ([#456](https://github.com/SocialGouv/mano/issues/456)) ([c88432d](https://github.com/SocialGouv/mano/commit/c88432de6bcaaa4ee1df9fad7c9e50e6482f7394)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+- **dashboard:** fix #MANO-9M ([#456](https://github.com/SocialGouv/mano/issues/456)) ([c88432d](https://github.com/SocialGouv/mano/commit/c88432de6bcaaa4ee1df9fad7c9e50e6482f7394)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.15](https://github.com/SocialGouv/mano/compare/v1.71.14...v1.71.15) (2022-03-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix #MANO-9K ([b10ab24](https://github.com/SocialGouv/mano/commit/b10ab24f1a189fa4c0c13eba9c805d4c5b0d583f)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+- **dashboard:** fix #MANO-9K ([b10ab24](https://github.com/SocialGouv/mano/commit/b10ab24f1a189fa4c0c13eba9c805d4c5b0d583f)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.14](https://github.com/SocialGouv/mano/compare/v1.71.13...v1.71.14) (2022-03-10)
 
-
 ### Bug Fixes
 
-* super admin connexion ([6397210](https://github.com/SocialGouv/mano/commit/63972106d7d32007b1c82b667a4a8e1a3aeb94ad))
+- super admin connexion ([6397210](https://github.com/SocialGouv/mano/commit/63972106d7d32007b1c82b667a4a8e1a3aeb94ad))
 
 ## [1.71.13](https://github.com/SocialGouv/mano/compare/v1.71.12...v1.71.13) (2022-03-08)
 
-
 ### Bug Fixes
 
-* **security:** remove injection in structure search ([332c722](https://github.com/SocialGouv/mano/commit/332c72263e4d27910cd4d0d81a6caa1f32aa7566))
+- **security:** remove injection in structure search ([332c722](https://github.com/SocialGouv/mano/commit/332c72263e4d27910cd4d0d81a6caa1f32aa7566))
 
 ## [1.71.12](https://github.com/SocialGouv/mano/compare/v1.71.11...v1.71.12) (2022-03-08)
 
-
 ### Bug Fixes
 
-* **app:** release version ([195f5a9](https://github.com/SocialGouv/mano/commit/195f5a9a5233a773822aec5a6ea2bd868b5d0862))
+- **app:** release version ([195f5a9](https://github.com/SocialGouv/mano/commit/195f5a9a5233a773822aec5a6ea2bd868b5d0862))
 
 ## [1.71.11](https://github.com/SocialGouv/mano/compare/v1.71.10...v1.71.11) (2022-03-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix #MANO-9J ([a68255b](https://github.com/SocialGouv/mano/commit/a68255bf7adf7cc6754bd759f10982ae2bc80f02)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+- **dashboard:** fix #MANO-9J ([a68255b](https://github.com/SocialGouv/mano/commit/a68255bf7adf7cc6754bd759f10982ae2bc80f02)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.10](https://github.com/SocialGouv/mano/compare/v1.71.9...v1.71.10) (2022-03-08)
 
-
 ### Bug Fixes
 
-* **app:** fix #MANO-9F ([7f66699](https://github.com/SocialGouv/mano/commit/7f666993707422c0c8277b93c77663ca77133428)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
+- **app:** fix #MANO-9F ([7f66699](https://github.com/SocialGouv/mano/commit/7f666993707422c0c8277b93c77663ca77133428)), closes [#MANO-9](https://github.com/SocialGouv/mano/issues/MANO-9)
 
 ## [1.71.9](https://github.com/SocialGouv/mano/compare/v1.71.8...v1.71.9) (2022-03-08)
 
-
 ### Bug Fixes
 
-* fix optional date ([fc21424](https://github.com/SocialGouv/mano/commit/fc21424ca681b4d733f1a73b04a99cf16ed06685))
+- fix optional date ([fc21424](https://github.com/SocialGouv/mano/commit/fc21424ca681b4d733f1a73b04a99cf16ed06685))
 
 ## [1.71.8](https://github.com/SocialGouv/mano/compare/v1.71.7...v1.71.8) (2022-03-07)
 
-
 ### Bug Fixes
 
-* **dashboard:** limit actions 1000 ([f19fcfd](https://github.com/SocialGouv/mano/commit/f19fcfd6a9d2ee48c18baad4326097379137d8b0))
+- **dashboard:** limit actions 1000 ([f19fcfd](https://github.com/SocialGouv/mano/commit/f19fcfd6a9d2ee48c18baad4326097379137d8b0))
 
 ## [1.71.7](https://github.com/SocialGouv/mano/compare/v1.71.6...v1.71.7) (2022-03-07)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix not found on comment from reports ([435b2b0](https://github.com/SocialGouv/mano/commit/435b2b0f6029ac9c78f3bb88e2c510c41c1ad1be))
+- **dashboard:** fix not found on comment from reports ([435b2b0](https://github.com/SocialGouv/mano/commit/435b2b0f6029ac9c78f3bb88e2c510c41c1ad1be))
 
 ## [1.71.6](https://github.com/SocialGouv/mano/compare/v1.71.5...v1.71.6) (2022-03-07)
 
-
 ### Bug Fixes
 
-* **api:** add security on actions ([#448](https://github.com/SocialGouv/mano/issues/448)) ([4e34c4c](https://github.com/SocialGouv/mano/commit/4e34c4cf5b0a8b5c4ed999885f171888509bad69))
+- **api:** add security on actions ([#448](https://github.com/SocialGouv/mano/issues/448)) ([4e34c4c](https://github.com/SocialGouv/mano/commit/4e34c4cf5b0a8b5c4ed999885f171888509bad69))
 
 ## [1.71.5](https://github.com/SocialGouv/mano/compare/v1.71.4...v1.71.5) (2022-03-07)
 
-
 ### Bug Fixes
 
-* **app:** release app with person fix ([69ae276](https://github.com/SocialGouv/mano/commit/69ae27661089ec1f4e510ecb2eb03bd24e4bb2c6))
+- **app:** release app with person fix ([69ae276](https://github.com/SocialGouv/mano/commit/69ae27661089ec1f4e510ecb2eb03bd24e4bb2c6))
 
 ## [1.71.4](https://github.com/SocialGouv/mano/compare/v1.71.3...v1.71.4) (2022-03-07)
 
-
 ### Bug Fixes
 
-* **app:** person name ([4465d86](https://github.com/SocialGouv/mano/commit/4465d86b4d8d315a46db5ee655a6d701bc7a11e3))
+- **app:** person name ([4465d86](https://github.com/SocialGouv/mano/commit/4465d86b4d8d315a46db5ee655a6d701bc7a11e3))
 
 ## [1.71.3](https://github.com/SocialGouv/mano/compare/v1.71.2...v1.71.3) (2022-03-07)
 
-
 ### Bug Fixes
 
-* categories empty ([781dac9](https://github.com/SocialGouv/mano/commit/781dac97fcb70815266f6e62b607be35f8280f12))
+- categories empty ([781dac9](https://github.com/SocialGouv/mano/commit/781dac97fcb70815266f6e62b607be35f8280f12))
 
 ## [1.71.2](https://github.com/SocialGouv/mano/compare/v1.71.1...v1.71.2) (2022-03-07)
 
-
 ### Bug Fixes
 
-* up ([b7a7376](https://github.com/SocialGouv/mano/commit/b7a7376b6ec9a464f6d0128d375a34612ef07e94))
+- up ([b7a7376](https://github.com/SocialGouv/mano/commit/b7a7376b6ec9a464f6d0128d375a34612ef07e94))
 
 ## [1.71.1](https://github.com/SocialGouv/mano/compare/v1.71.0...v1.71.1) (2022-03-07)
 
-
 ### Bug Fixes
 
-* cat value must be set ([0c37f60](https://github.com/SocialGouv/mano/commit/0c37f6069a85e43add4dae1ec22f5220126e95f7))
+- cat value must be set ([0c37f60](https://github.com/SocialGouv/mano/commit/0c37f6069a85e43add4dae1ec22f5220126e95f7))
 
 # [1.71.0](https://github.com/SocialGouv/mano/compare/v1.70.4...v1.71.0) (2022-03-07)
 
-
 ### Features
 
-* **dashboard:** can rename services categories ([#447](https://github.com/SocialGouv/mano/issues/447)) ([99f7424](https://github.com/SocialGouv/mano/commit/99f742406f2fbbf2db4cf5dc339ef6116a09246f))
+- **dashboard:** can rename services categories ([#447](https://github.com/SocialGouv/mano/issues/447)) ([99f7424](https://github.com/SocialGouv/mano/commit/99f742406f2fbbf2db4cf5dc339ef6116a09246f))
 
 ## [1.70.4](https://github.com/SocialGouv/mano/compare/v1.70.3...v1.70.4) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **app:** action empty #MANO-99 ([#446](https://github.com/SocialGouv/mano/issues/446)) ([d65a9b9](https://github.com/SocialGouv/mano/commit/d65a9b99dd7ff9d21c1d720242ffe876bb708b0f)), closes [#MANO-99](https://github.com/SocialGouv/mano/issues/MANO-99)
+- **app:** action empty #MANO-99 ([#446](https://github.com/SocialGouv/mano/issues/446)) ([d65a9b9](https://github.com/SocialGouv/mano/commit/d65a9b99dd7ff9d21c1d720242ffe876bb708b0f)), closes [#MANO-99](https://github.com/SocialGouv/mano/issues/MANO-99)
 
 ## [1.70.3](https://github.com/SocialGouv/mano/compare/v1.70.2...v1.70.3) (2022-03-04)
 
-
 ### Bug Fixes
 
-* remove unsecure password generation ([#442](https://github.com/SocialGouv/mano/issues/442)) ([512a7c3](https://github.com/SocialGouv/mano/commit/512a7c363eb65b2e1b35533e8a021aff3dffcc75))
+- remove unsecure password generation ([#442](https://github.com/SocialGouv/mano/issues/442)) ([512a7c3](https://github.com/SocialGouv/mano/commit/512a7c363eb65b2e1b35533e8a021aff3dffcc75))
 
 ## [1.70.2](https://github.com/SocialGouv/mano/compare/v1.70.1...v1.70.2) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **api:** fix uuid ([4e4ac67](https://github.com/SocialGouv/mano/commit/4e4ac674cf76b97155b62cbdc9b5f2852c1b5629))
+- **api:** fix uuid ([4e4ac67](https://github.com/SocialGouv/mano/commit/4e4ac674cf76b97155b62cbdc9b5f2852c1b5629))
 
 ## [1.70.1](https://github.com/SocialGouv/mano/compare/v1.70.0...v1.70.1) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **dashboard:** loader message ([#445](https://github.com/SocialGouv/mano/issues/445)) ([dc12a25](https://github.com/SocialGouv/mano/commit/dc12a25959a19f9601d6e47c559c0b503fe7b64a))
+- **dashboard:** loader message ([#445](https://github.com/SocialGouv/mano/issues/445)) ([dc12a25](https://github.com/SocialGouv/mano/commit/dc12a25959a19f9601d6e47c559c0b503fe7b64a))
 
 # [1.70.0](https://github.com/SocialGouv/mano/compare/v1.69.0...v1.70.0) (2022-03-04)
 
-
 ### Features
 
-* **dashboard:** show comments on superadmin ([#443](https://github.com/SocialGouv/mano/issues/443)) ([b0ac051](https://github.com/SocialGouv/mano/commit/b0ac0519acc6df98ba265315be8f6affc87b53de))
+- **dashboard:** show comments on superadmin ([#443](https://github.com/SocialGouv/mano/issues/443)) ([b0ac051](https://github.com/SocialGouv/mano/commit/b0ac0519acc6df98ba265315be8f6affc87b53de))
 
 # [1.69.0](https://github.com/SocialGouv/mano/compare/v1.68.4...v1.69.0) (2022-03-04)
 
-
 ### Features
 
-* **app:** ask permissions before accessing to stuff + can change nam… ([#435](https://github.com/SocialGouv/mano/issues/435)) ([5fa6167](https://github.com/SocialGouv/mano/commit/5fa61674bb433e1ca7a2ebe4afc954976e89117e))
+- **app:** ask permissions before accessing to stuff + can change nam… ([#435](https://github.com/SocialGouv/mano/issues/435)) ([5fa6167](https://github.com/SocialGouv/mano/commit/5fa61674bb433e1ca7a2ebe4afc954976e89117e))
 
 ## [1.68.4](https://github.com/SocialGouv/mano/compare/v1.68.3...v1.68.4) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **app:** duplicate comments on duplicate action ([#433](https://github.com/SocialGouv/mano/issues/433)) ([0949a71](https://github.com/SocialGouv/mano/commit/0949a71ae908aead47b34239424dfb000c56b69c))
+- **app:** duplicate comments on duplicate action ([#433](https://github.com/SocialGouv/mano/issues/433)) ([0949a71](https://github.com/SocialGouv/mano/commit/0949a71ae908aead47b34239424dfb000c56b69c))
 
 ## [1.68.3](https://github.com/SocialGouv/mano/compare/v1.68.2...v1.68.3) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **app:** show only a few actions ([#439](https://github.com/SocialGouv/mano/issues/439)) ([3b82473](https://github.com/SocialGouv/mano/commit/3b82473353f7b9e3d621787d52a2f783727024fe))
+- **app:** show only a few actions ([#439](https://github.com/SocialGouv/mano/issues/439)) ([3b82473](https://github.com/SocialGouv/mano/commit/3b82473353f7b9e3d621787d52a2f783727024fe))
 
 ## [1.68.2](https://github.com/SocialGouv/mano/compare/v1.68.1...v1.68.2) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **dashboard:** stop throw error on fail api request ([#441](https://github.com/SocialGouv/mano/issues/441)) ([2d06ded](https://github.com/SocialGouv/mano/commit/2d06ded8b587707849daab4420df253a4c146ab3))
+- **dashboard:** stop throw error on fail api request ([#441](https://github.com/SocialGouv/mano/issues/441)) ([2d06ded](https://github.com/SocialGouv/mano/commit/2d06ded8b587707849daab4420df253a4c146ab3))
 
 ## [1.68.1](https://github.com/SocialGouv/mano/compare/v1.68.0...v1.68.1) (2022-03-04)
 
-
 ### Bug Fixes
 
-* noisy error ([65e12c8](https://github.com/SocialGouv/mano/commit/65e12c8ab03109648fa0a4f5eb0232bc5fbba4ea))
+- noisy error ([65e12c8](https://github.com/SocialGouv/mano/commit/65e12c8ab03109648fa0a4f5eb0232bc5fbba4ea))
 
 # [1.68.0](https://github.com/SocialGouv/mano/compare/v1.67.6...v1.68.0) (2022-03-04)
 
-
 ### Features
 
-* **dashboard:** reorder services categories and custom fields ([#423](https://github.com/SocialGouv/mano/issues/423)) ([5022f9c](https://github.com/SocialGouv/mano/commit/5022f9c5fabe6a28460b6b743133cbca8ca28d96))
+- **dashboard:** reorder services categories and custom fields ([#423](https://github.com/SocialGouv/mano/issues/423)) ([5022f9c](https://github.com/SocialGouv/mano/commit/5022f9c5fabe6a28460b6b743133cbca8ca28d96))
 
 ## [1.67.6](https://github.com/SocialGouv/mano/compare/v1.67.5...v1.67.6) (2022-03-04)
 
-
 ### Bug Fixes
 
-* **app:**  app perfs ([#428](https://github.com/SocialGouv/mano/issues/428)) ([92857fd](https://github.com/SocialGouv/mano/commit/92857fd18d303cfa00827d6e5797fb0be7961755))
+- **app:** app perfs ([#428](https://github.com/SocialGouv/mano/issues/428)) ([92857fd](https://github.com/SocialGouv/mano/commit/92857fd18d303cfa00827d6e5797fb0be7961755))
 
 ## [1.67.5](https://github.com/SocialGouv/mano/compare/v1.67.4...v1.67.5) (2022-03-03)
 
-
 ### Bug Fixes
 
-* data validation ([#427](https://github.com/SocialGouv/mano/issues/427)) ([017ece4](https://github.com/SocialGouv/mano/commit/017ece4cf40c745bb00eaaaa09adfe005fb541ff))
+- data validation ([#427](https://github.com/SocialGouv/mano/issues/427)) ([017ece4](https://github.com/SocialGouv/mano/commit/017ece4cf40c745bb00eaaaa09adfe005fb541ff))
 
 ## [1.67.4](https://github.com/SocialGouv/mano/compare/v1.67.3...v1.67.4) (2022-03-03)
 
-
 ### Bug Fixes
 
-* **dashboard,app:** addressDetails as enum not text filter ([#432](https://github.com/SocialGouv/mano/issues/432)) ([416fcbf](https://github.com/SocialGouv/mano/commit/416fcbf27e7880823ea3536301ad8134b08a8bd7))
+- **dashboard,app:** addressDetails as enum not text filter ([#432](https://github.com/SocialGouv/mano/issues/432)) ([416fcbf](https://github.com/SocialGouv/mano/commit/416fcbf27e7880823ea3536301ad8134b08a8bd7))
 
 ## [1.67.3](https://github.com/SocialGouv/mano/compare/v1.67.2...v1.67.3) (2022-03-03)
 
-
 ### Bug Fixes
 
-* **dashboard:** celan ([#431](https://github.com/SocialGouv/mano/issues/431)) ([43ac42c](https://github.com/SocialGouv/mano/commit/43ac42ceb2ec1cb6b36c57e46412610e4c9c6635))
+- **dashboard:** celan ([#431](https://github.com/SocialGouv/mano/issues/431)) ([43ac42c](https://github.com/SocialGouv/mano/commit/43ac42ceb2ec1cb6b36c57e46412610e4c9c6635))
 
 ## [1.67.2](https://github.com/SocialGouv/mano/compare/v1.67.1...v1.67.2) (2022-03-03)
 
-
 ### Bug Fixes
 
-* **dashboard:** datepicker on small screens ([#429](https://github.com/SocialGouv/mano/issues/429)) ([c81138e](https://github.com/SocialGouv/mano/commit/c81138e2f85a9630941a11eb631e5b18788af481))
+- **dashboard:** datepicker on small screens ([#429](https://github.com/SocialGouv/mano/issues/429)) ([c81138e](https://github.com/SocialGouv/mano/commit/c81138e2f85a9630941a11eb631e5b18788af481))
 
 ## [1.67.1](https://github.com/SocialGouv/mano/compare/v1.67.0...v1.67.1) (2022-03-03)
 
-
 ### Bug Fixes
 
-* **app:** expired session ([#426](https://github.com/SocialGouv/mano/issues/426)) ([a954e73](https://github.com/SocialGouv/mano/commit/a954e73079b6c995d5a5c9c26b8d9f50973cd150))
+- **app:** expired session ([#426](https://github.com/SocialGouv/mano/issues/426)) ([a954e73](https://github.com/SocialGouv/mano/commit/a954e73079b6c995d5a5c9c26b8d9f50973cd150))
 
 # [1.67.0](https://github.com/SocialGouv/mano/compare/v1.66.2...v1.67.0) (2022-03-03)
 
-
 ### Features
 
-* **app,api:** app v2.12.0 ([#411](https://github.com/SocialGouv/mano/issues/411)) ([de02f60](https://github.com/SocialGouv/mano/commit/de02f60a48778a91b6df2ad1a6e2ddf2d360c2f4))
+- **app,api:** app v2.12.0 ([#411](https://github.com/SocialGouv/mano/issues/411)) ([de02f60](https://github.com/SocialGouv/mano/commit/de02f60a48778a91b6df2ad1a6e2ddf2d360c2f4))
 
 ## [1.66.2](https://github.com/SocialGouv/mano/compare/v1.66.1...v1.66.2) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **api:** authorize normal user to add collaboration ([#422](https://github.com/SocialGouv/mano/issues/422)) ([629b07a](https://github.com/SocialGouv/mano/commit/629b07a07ce2f0851a202afbcb89d4718b5f7063))
+- **api:** authorize normal user to add collaboration ([#422](https://github.com/SocialGouv/mano/issues/422)) ([629b07a](https://github.com/SocialGouv/mano/commit/629b07a07ce2f0851a202afbcb89d4718b5f7063))
 
 ## [1.66.1](https://github.com/SocialGouv/mano/compare/v1.66.0...v1.66.1) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** onboarding show encryption ([#421](https://github.com/SocialGouv/mano/issues/421)) ([3bddfd5](https://github.com/SocialGouv/mano/commit/3bddfd50b9dd1bf7a2adf7e9aead93fbeb69ea0a))
+- **dashboard:** onboarding show encryption ([#421](https://github.com/SocialGouv/mano/issues/421)) ([3bddfd5](https://github.com/SocialGouv/mano/commit/3bddfd50b9dd1bf7a2adf7e9aead93fbeb69ea0a))
 
 # [1.66.0](https://github.com/SocialGouv/mano/compare/v1.65.2...v1.66.0) (2022-03-02)
 
-
 ### Features
 
-* **dashboard:** reorganize organisation setup ([#408](https://github.com/SocialGouv/mano/issues/408)) ([e5f0450](https://github.com/SocialGouv/mano/commit/e5f0450dd3cb9448b5f359be91a18cd786f3addf))
+- **dashboard:** reorganize organisation setup ([#408](https://github.com/SocialGouv/mano/issues/408)) ([e5f0450](https://github.com/SocialGouv/mano/commit/e5f0450dd3cb9448b5f359be91a18cd786f3addf))
 
 ## [1.65.2](https://github.com/SocialGouv/mano/compare/v1.65.1...v1.65.2) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** sort reports on creation ([#420](https://github.com/SocialGouv/mano/issues/420)) ([cb8b8ab](https://github.com/SocialGouv/mano/commit/cb8b8abe99b8ded03e7f3ea2152d4dfbcd6b92b8))
+- **dashboard:** sort reports on creation ([#420](https://github.com/SocialGouv/mano/issues/420)) ([cb8b8ab](https://github.com/SocialGouv/mano/commit/cb8b8abe99b8ded03e7f3ea2152d4dfbcd6b92b8))
 
 ## [1.65.1](https://github.com/SocialGouv/mano/compare/v1.65.0...v1.65.1) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** prev next report ([#419](https://github.com/SocialGouv/mano/issues/419)) ([3c4f2cb](https://github.com/SocialGouv/mano/commit/3c4f2cbb846b519f76d9c35b82cf9c994cedbd03))
+- **dashboard:** prev next report ([#419](https://github.com/SocialGouv/mano/issues/419)) ([3c4f2cb](https://github.com/SocialGouv/mano/commit/3c4f2cbb846b519f76d9c35b82cf9c994cedbd03))
 
 # [1.65.0](https://github.com/SocialGouv/mano/compare/v1.64.5...v1.65.0) (2022-03-02)
 
-
 ### Features
 
-* **api:** send platform and version to sentry ([#418](https://github.com/SocialGouv/mano/issues/418)) ([e51d63e](https://github.com/SocialGouv/mano/commit/e51d63e1a600b2c2e2e474d8203068a1b0be18d3))
+- **api:** send platform and version to sentry ([#418](https://github.com/SocialGouv/mano/issues/418)) ([e51d63e](https://github.com/SocialGouv/mano/commit/e51d63e1a600b2c2e2e474d8203068a1b0be18d3))
 
 ## [1.64.5](https://github.com/SocialGouv/mano/compare/v1.64.4...v1.64.5) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **app,dashboard:**  check date before showing ([#417](https://github.com/SocialGouv/mano/issues/417)) ([87d63ba](https://github.com/SocialGouv/mano/commit/87d63baf28397247ba1d09b122d58b79dd7296a0))
+- **app,dashboard:** check date before showing ([#417](https://github.com/SocialGouv/mano/issues/417)) ([87d63ba](https://github.com/SocialGouv/mano/commit/87d63baf28397247ba1d09b122d58b79dd7296a0))
 
 ## [1.64.4](https://github.com/SocialGouv/mano/compare/v1.64.3...v1.64.4) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **api:** add orinigal url to sentry ([#416](https://github.com/SocialGouv/mano/issues/416)) ([3090a12](https://github.com/SocialGouv/mano/commit/3090a12bbfb09fe1adb2327e80ad62ea6d505355))
+- **api:** add orinigal url to sentry ([#416](https://github.com/SocialGouv/mano/issues/416)) ([3090a12](https://github.com/SocialGouv/mano/commit/3090a12bbfb09fe1adb2327e80ad62ea6d505355))
 
 ## [1.64.3](https://github.com/SocialGouv/mano/compare/v1.64.2...v1.64.3) (2022-03-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** auto report create in reception ([#415](https://github.com/SocialGouv/mano/issues/415)) ([8a04b22](https://github.com/SocialGouv/mano/commit/8a04b2241526289c139dfee4219baa4e36cc5dec))
+- **dashboard:** auto report create in reception ([#415](https://github.com/SocialGouv/mano/issues/415)) ([8a04b22](https://github.com/SocialGouv/mano/commit/8a04b2241526289c139dfee4219baa4e36cc5dec))
 
 ## [1.64.2](https://github.com/SocialGouv/mano/compare/v1.64.1...v1.64.2) (2022-03-01)
 
-
 ### Bug Fixes
 
-* **dashboard:** loader on comments ([#412](https://github.com/SocialGouv/mano/issues/412)) ([abc3786](https://github.com/SocialGouv/mano/commit/abc3786d01266009a3a0a452a429bbad02956475))
+- **dashboard:** loader on comments ([#412](https://github.com/SocialGouv/mano/issues/412)) ([abc3786](https://github.com/SocialGouv/mano/commit/abc3786d01266009a3a0a452a429bbad02956475))
 
 ## [1.64.1](https://github.com/SocialGouv/mano/compare/v1.64.0...v1.64.1) (2022-03-01)
 
-
 ### Bug Fixes
 
-* **dashboard:** better loader ([#407](https://github.com/SocialGouv/mano/issues/407)) ([c56fbb0](https://github.com/SocialGouv/mano/commit/c56fbb0765020634277d51ab011de83401362006))
+- **dashboard:** better loader ([#407](https://github.com/SocialGouv/mano/issues/407)) ([c56fbb0](https://github.com/SocialGouv/mano/commit/c56fbb0765020634277d51ab011de83401362006))
 
 # [1.64.0](https://github.com/SocialGouv/mano/compare/v1.63.0...v1.64.0) (2022-03-01)
 
-
 ### Features
 
-* **dashboard:** improve filters for persons ([#405](https://github.com/SocialGouv/mano/issues/405)) ([0eb73db](https://github.com/SocialGouv/mano/commit/0eb73dbd6ac79106b5f709858a6bb64bd1838f04))
+- **dashboard:** improve filters for persons ([#405](https://github.com/SocialGouv/mano/issues/405)) ([0eb73db](https://github.com/SocialGouv/mano/commit/0eb73dbd6ac79106b5f709858a6bb64bd1838f04))
 
 # [1.63.0](https://github.com/SocialGouv/mano/compare/v1.62.0...v1.63.0) (2022-03-01)
 
-
 ### Features
 
-* **app,api:** update documents from mobile ([#400](https://github.com/SocialGouv/mano/issues/400)) ([ad096f1](https://github.com/SocialGouv/mano/commit/ad096f1ba6ca6425873232478514c71000556ae1))
+- **app,api:** update documents from mobile ([#400](https://github.com/SocialGouv/mano/issues/400)) ([ad096f1](https://github.com/SocialGouv/mano/commit/ad096f1ba6ca6425873232478514c71000556ae1))
 
 # [1.62.0](https://github.com/SocialGouv/mano/compare/v1.61.0...v1.62.0) (2022-02-28)
 
-
 ### Features
 
-* **dashboard:** remove organisation stats button when only one team ([#402](https://github.com/SocialGouv/mano/issues/402)) ([3f3b9b3](https://github.com/SocialGouv/mano/commit/3f3b9b33384bc88cc61eeb24172adffc24895f3f))
+- **dashboard:** remove organisation stats button when only one team ([#402](https://github.com/SocialGouv/mano/issues/402)) ([3f3b9b3](https://github.com/SocialGouv/mano/commit/3f3b9b33384bc88cc61eeb24172adffc24895f3f))
 
 # [1.61.0](https://github.com/SocialGouv/mano/compare/v1.60.0...v1.61.0) (2022-02-28)
 
-
 ### Features
 
-* validate organisation encryption ([#383](https://github.com/SocialGouv/mano/issues/383)) ([ff82af7](https://github.com/SocialGouv/mano/commit/ff82af760f30a9f01f0d15d8b2a5ee90c83a6aa1))
+- validate organisation encryption ([#383](https://github.com/SocialGouv/mano/issues/383)) ([ff82af7](https://github.com/SocialGouv/mano/commit/ff82af760f30a9f01f0d15d8b2a5ee90c83a6aa1))
 
 # [1.60.0](https://github.com/SocialGouv/mano/compare/v1.59.0...v1.60.0) (2022-02-28)
 
-
 ### Features
 
-* **dashboard:** refresh button everywhere ([#404](https://github.com/SocialGouv/mano/issues/404)) ([a3ac762](https://github.com/SocialGouv/mano/commit/a3ac76226eef3d9d63e6740391bc751b8a265175))
+- **dashboard:** refresh button everywhere ([#404](https://github.com/SocialGouv/mano/issues/404)) ([a3ac762](https://github.com/SocialGouv/mano/commit/a3ac76226eef3d9d63e6740391bc751b8a265175))
 
 # [1.59.0](https://github.com/SocialGouv/mano/compare/v1.58.4...v1.59.0) (2022-02-28)
 
-
 ### Features
 
-* **dashboard:** show date also in comment research ([#403](https://github.com/SocialGouv/mano/issues/403)) ([270283a](https://github.com/SocialGouv/mano/commit/270283a639d1c9ef004575071391e1e75b699421))
+- **dashboard:** show date also in comment research ([#403](https://github.com/SocialGouv/mano/issues/403)) ([270283a](https://github.com/SocialGouv/mano/commit/270283a639d1c9ef004575071391e1e75b699421))
 
 ## [1.58.4](https://github.com/SocialGouv/mano/compare/v1.58.3...v1.58.4) (2022-02-28)
 
-
 ### Bug Fixes
 
-* **dashboard:** create collaboration ([#401](https://github.com/SocialGouv/mano/issues/401)) ([7db8abd](https://github.com/SocialGouv/mano/commit/7db8abd5063f88cbba1d3d80dec2714f5ffbc5be))
+- **dashboard:** create collaboration ([#401](https://github.com/SocialGouv/mano/issues/401)) ([7db8abd](https://github.com/SocialGouv/mano/commit/7db8abd5063f88cbba1d3d80dec2714f5ffbc5be))
 
 ## [1.58.3](https://github.com/SocialGouv/mano/compare/v1.58.2...v1.58.3) (2022-02-25)
 
-
 ### Bug Fixes
 
-* **api:** remove orgEncryptionKeyCacheForDebug ([244d406](https://github.com/SocialGouv/mano/commit/244d406f87bd62431ddfefa3d012ae8f35c46980))
+- **api:** remove orgEncryptionKeyCacheForDebug ([244d406](https://github.com/SocialGouv/mano/commit/244d406f87bd62431ddfefa3d012ae8f35c46980))
 
 ## [1.58.2](https://github.com/SocialGouv/mano/compare/v1.58.1...v1.58.2) (2022-02-25)
 
-
 ### Bug Fixes
 
-* **api:** remove capture ([379c7fe](https://github.com/SocialGouv/mano/commit/379c7fe0bdc38d6a14dd880d048df174c8ad57a7))
+- **api:** remove capture ([379c7fe](https://github.com/SocialGouv/mano/commit/379c7fe0bdc38d6a14dd880d048df174c8ad57a7))
 
 ## [1.58.1](https://github.com/SocialGouv/mano/compare/v1.58.0...v1.58.1) (2022-02-25)
 
-
 ### Bug Fixes
 
-* bump ([5752399](https://github.com/SocialGouv/mano/commit/5752399ef0f267e7bffe2828ffa557309b814247))
-* up ([1c6bdd0](https://github.com/SocialGouv/mano/commit/1c6bdd01b8d7c2bbe0b65b5bbb7f52c35bf5f4f7))
-* **api:** action update ([a0e9b56](https://github.com/SocialGouv/mano/commit/a0e9b56fdbbf089ff911f879739906f6c7889958))
-* **api:** only admin can update org ([c3bce83](https://github.com/SocialGouv/mano/commit/c3bce83a47577d28a4270c1deadfd1c78d3cd0fb))
-* **api:** remove team check since it does not exist anymore on tables ([f147dff](https://github.com/SocialGouv/mano/commit/f147dff82d7a782caf0d6a9586a14d99de10493f))
-* **app:** text color on dark mode ([#395](https://github.com/SocialGouv/mano/issues/395)) ([8c0038c](https://github.com/SocialGouv/mano/commit/8c0038c5d999af1340863779a816048d025e7a01))
+- bump ([5752399](https://github.com/SocialGouv/mano/commit/5752399ef0f267e7bffe2828ffa557309b814247))
+- up ([1c6bdd0](https://github.com/SocialGouv/mano/commit/1c6bdd01b8d7c2bbe0b65b5bbb7f52c35bf5f4f7))
+- **api:** action update ([a0e9b56](https://github.com/SocialGouv/mano/commit/a0e9b56fdbbf089ff911f879739906f6c7889958))
+- **api:** only admin can update org ([c3bce83](https://github.com/SocialGouv/mano/commit/c3bce83a47577d28a4270c1deadfd1c78d3cd0fb))
+- **api:** remove team check since it does not exist anymore on tables ([f147dff](https://github.com/SocialGouv/mano/commit/f147dff82d7a782caf0d6a9586a14d99de10493f))
+- **app:** text color on dark mode ([#395](https://github.com/SocialGouv/mano/issues/395)) ([8c0038c](https://github.com/SocialGouv/mano/commit/8c0038c5d999af1340863779a816048d025e7a01))
 
 # [1.58.0](https://github.com/SocialGouv/mano/compare/v1.57.2...v1.58.0) (2022-02-25)
 
-
 ### Features
 
-* remove encrypted field from columns ([#364](https://github.com/SocialGouv/mano/issues/364)) ([d76fcc3](https://github.com/SocialGouv/mano/commit/d76fcc3502ef7a21e3f9ea67e7fdab25c0a96825))
+- remove encrypted field from columns ([#364](https://github.com/SocialGouv/mano/issues/364)) ([d76fcc3](https://github.com/SocialGouv/mano/commit/d76fcc3502ef7a21e3f9ea67e7fdab25c0a96825))
 
 ## [1.57.2](https://github.com/SocialGouv/mano/compare/v1.57.1...v1.57.2) (2022-02-25)
 
-
 ### Bug Fixes
 
-* **app:** refactor refresher + fix clear cache when change organisation ([#394](https://github.com/SocialGouv/mano/issues/394)) ([4a1b151](https://github.com/SocialGouv/mano/commit/4a1b151cf069821f1fc45d1e28c47295a853f962))
+- **app:** refactor refresher + fix clear cache when change organisation ([#394](https://github.com/SocialGouv/mano/issues/394)) ([4a1b151](https://github.com/SocialGouv/mano/commit/4a1b151cf069821f1fc45d1e28c47295a853f962))
 
 ## [1.57.1](https://github.com/SocialGouv/mano/compare/v1.57.0...v1.57.1) (2022-02-25)
 
-
 ### Bug Fixes
 
-* update yarn.lock ([fae2114](https://github.com/SocialGouv/mano/commit/fae21142614c7d757894b2456e08e7a9656657e0))
+- update yarn.lock ([fae2114](https://github.com/SocialGouv/mano/commit/fae21142614c7d757894b2456e08e7a9656657e0))
 
 # [1.57.0](https://github.com/SocialGouv/mano/compare/v1.56.3...v1.57.0) (2022-02-24)
 
-
 ### Features
 
-* **app,api:** new version ([#393](https://github.com/SocialGouv/mano/issues/393)) ([df9dd0d](https://github.com/SocialGouv/mano/commit/df9dd0d7e6dad91a223d203c15b506ec4864753a))
+- **app,api:** new version ([#393](https://github.com/SocialGouv/mano/issues/393)) ([df9dd0d](https://github.com/SocialGouv/mano/commit/df9dd0d7e6dad91a223d203c15b506ec4864753a))
 
 ## [1.56.3](https://github.com/SocialGouv/mano/compare/v1.56.2...v1.56.3) (2022-02-24)
 
-
 ### Bug Fixes
 
-* **app:** cannot update aciton with no name ([#392](https://github.com/SocialGouv/mano/issues/392)) ([a01b2dc](https://github.com/SocialGouv/mano/commit/a01b2dcc7b512f49cc313a3eb77b41109b1d87f9))
+- **app:** cannot update aciton with no name ([#392](https://github.com/SocialGouv/mano/issues/392)) ([a01b2dc](https://github.com/SocialGouv/mano/commit/a01b2dcc7b512f49cc313a3eb77b41109b1d87f9))
 
 ## [1.56.2](https://github.com/SocialGouv/mano/compare/v1.56.1...v1.56.2) (2022-02-24)
 
-
 ### Bug Fixes
 
-* **app,dashboard:**  last fixes before encryption ([#391](https://github.com/SocialGouv/mano/issues/391)) ([06a3a8a](https://github.com/SocialGouv/mano/commit/06a3a8a286e1922c1d8e7f04eec924323e509543))
+- **app,dashboard:** last fixes before encryption ([#391](https://github.com/SocialGouv/mano/issues/391)) ([06a3a8a](https://github.com/SocialGouv/mano/commit/06a3a8a286e1922c1d8e7f04eec924323e509543))
 
 ## [1.56.1](https://github.com/SocialGouv/mano/compare/v1.56.0...v1.56.1) (2022-02-24)
 
-
 ### Bug Fixes
 
-* **app:** remove mano-tests from dependencies ([#388](https://github.com/SocialGouv/mano/issues/388)) ([d26373d](https://github.com/SocialGouv/mano/commit/d26373db8a3b127ac77f367ee354b58efd99dd5f))
+- **app:** remove mano-tests from dependencies ([#388](https://github.com/SocialGouv/mano/issues/388)) ([d26373d](https://github.com/SocialGouv/mano/commit/d26373db8a3b127ac77f367ee354b58efd99dd5f))
 
 # [1.56.0](https://github.com/SocialGouv/mano/compare/v1.55.0...v1.56.0) (2022-02-24)
 
-
 ### Features
 
-* **app:** test with detox ([#387](https://github.com/SocialGouv/mano/issues/387)) ([be86e19](https://github.com/SocialGouv/mano/commit/be86e19939407b4ebcb90c9126bd824bf307ca7b))
+- **app:** test with detox ([#387](https://github.com/SocialGouv/mano/issues/387)) ([be86e19](https://github.com/SocialGouv/mano/commit/be86e19939407b4ebcb90c9126bd824bf307ca7b))
 
 # [1.55.0](https://github.com/SocialGouv/mano/compare/v1.54.3...v1.55.0) (2022-02-23)
 
-
 ### Features
 
-* **dashboard:** tests persons/actions/territories ([#382](https://github.com/SocialGouv/mano/issues/382)) ([08b1857](https://github.com/SocialGouv/mano/commit/08b1857f95f76cabc5211a8a70f0c62231f5191c))
+- **dashboard:** tests persons/actions/territories ([#382](https://github.com/SocialGouv/mano/issues/382)) ([08b1857](https://github.com/SocialGouv/mano/commit/08b1857f95f76cabc5211a8a70f0c62231f5191c))
 
 ## [1.54.3](https://github.com/SocialGouv/mano/compare/v1.54.2...v1.54.3) (2022-02-22)
 
-
 ### Bug Fixes
 
-* **dashboard:** can go to prev/next report + can change services in report ([#379](https://github.com/SocialGouv/mano/issues/379)) ([2765a47](https://github.com/SocialGouv/mano/commit/2765a47eac0bb3a79b73ac0ce1229f626e75ab56))
+- **dashboard:** can go to prev/next report + can change services in report ([#379](https://github.com/SocialGouv/mano/issues/379)) ([2765a47](https://github.com/SocialGouv/mano/commit/2765a47eac0bb3a79b73ac0ce1229f626e75ab56))
 
 ## [1.54.2](https://github.com/SocialGouv/mano/compare/v1.54.1...v1.54.2) (2022-02-21)
 
-
 ### Bug Fixes
 
-* **api:** use transaction in find ([046714f](https://github.com/SocialGouv/mano/commit/046714fde43c9b2ae209ed470ecf1f2c724cf1fb))
+- **api:** use transaction in find ([046714f](https://github.com/SocialGouv/mano/commit/046714fde43c9b2ae209ed470ecf1f2c724cf1fb))
 
 ## [1.54.1](https://github.com/SocialGouv/mano/compare/v1.54.0...v1.54.1) (2022-02-21)
 
-
 ### Bug Fixes
 
-* **app:** findIndex fail ([4549038](https://github.com/SocialGouv/mano/commit/4549038cd5a547b4d9e01a1349ca58beaaf9e58b))
+- **app:** findIndex fail ([4549038](https://github.com/SocialGouv/mano/commit/4549038cd5a547b4d9e01a1349ca58beaaf9e58b))
 
 # [1.54.0](https://github.com/SocialGouv/mano/compare/v1.53.17...v1.54.0) (2022-02-21)
 
-
 ### Features
 
-* **dashboard:** remove cancel encryption ([1b047d3](https://github.com/SocialGouv/mano/commit/1b047d3e68d6a2b40c04c84e71d33f661b32bbd6))
+- **dashboard:** remove cancel encryption ([1b047d3](https://github.com/SocialGouv/mano/commit/1b047d3e68d6a2b40c04c84e71d33f661b32bbd6))
 
 ## [1.53.17](https://github.com/SocialGouv/mano/compare/v1.53.16...v1.53.17) (2022-02-21)
 
-
 ### Bug Fixes
 
-* **dashboard:** google translation ([15406a6](https://github.com/SocialGouv/mano/commit/15406a658ec3987210277e642d550e5b01dfddf3))
+- **dashboard:** google translation ([15406a6](https://github.com/SocialGouv/mano/commit/15406a658ec3987210277e642d550e5b01dfddf3))
 
 ## [1.53.16](https://github.com/SocialGouv/mano/compare/v1.53.15...v1.53.16) (2022-02-21)
 
-
 ### Bug Fixes
 
-* **dashboard:** message and capture when upload doc fails ([#378](https://github.com/SocialGouv/mano/issues/378)) ([aa39dc5](https://github.com/SocialGouv/mano/commit/aa39dc5b4bbbda30ff12138e0abd5e1a39142eea))
+- **dashboard:** message and capture when upload doc fails ([#378](https://github.com/SocialGouv/mano/issues/378)) ([aa39dc5](https://github.com/SocialGouv/mano/commit/aa39dc5b4bbbda30ff12138e0abd5e1a39142eea))
 
 ## [1.53.15](https://github.com/SocialGouv/mano/compare/v1.53.14...v1.53.15) (2022-02-21)
 
-
 ### Bug Fixes
 
-* **api:** minimum mobile version ([a713b13](https://github.com/SocialGouv/mano/commit/a713b131f107f316d9df4796c292309952f7ab82))
+- **api:** minimum mobile version ([a713b13](https://github.com/SocialGouv/mano/commit/a713b131f107f316d9df4796c292309952f7ab82))
 
 ## [1.53.14](https://github.com/SocialGouv/mano/compare/v1.53.13...v1.53.14) (2022-02-17)
 
-
 ### Bug Fixes
 
-* **app:** comment edit / person delete / action delete / popup on duplicate ([#374](https://github.com/SocialGouv/mano/issues/374)) ([9c65334](https://github.com/SocialGouv/mano/commit/9c65334bca9c89ecd7ccc4a6e8f53d6ef99ee58c))
+- **app:** comment edit / person delete / action delete / popup on duplicate ([#374](https://github.com/SocialGouv/mano/issues/374)) ([9c65334](https://github.com/SocialGouv/mano/commit/9c65334bca9c89ecd7ccc4a6e8f53d6ef99ee58c))
 
 ## [1.53.13](https://github.com/SocialGouv/mano/compare/v1.53.12...v1.53.13) (2022-02-17)
 
-
 ### Bug Fixes
 
-* **app:** button done/cancel for action ([#373](https://github.com/SocialGouv/mano/issues/373)) ([6213681](https://github.com/SocialGouv/mano/commit/6213681bcf9174edc3a8b1c5763f2b09792c9079))
+- **app:** button done/cancel for action ([#373](https://github.com/SocialGouv/mano/issues/373)) ([6213681](https://github.com/SocialGouv/mano/commit/6213681bcf9174edc3a8b1c5763f2b09792c9079))
 
 ## [1.53.12](https://github.com/SocialGouv/mano/compare/v1.53.11...v1.53.12) (2022-02-15)
 
-
 ### Bug Fixes
 
-* **api:** try to relaunch ([#372](https://github.com/SocialGouv/mano/issues/372)) ([17017cc](https://github.com/SocialGouv/mano/commit/17017cc55f4a09aa1d90fade8f61c4d2f6fbd357))
+- **api:** try to relaunch ([#372](https://github.com/SocialGouv/mano/issues/372)) ([17017cc](https://github.com/SocialGouv/mano/commit/17017cc55f4a09aa1d90fade8f61c4d2f6fbd357))
 
 ## [1.53.11](https://github.com/SocialGouv/mano/compare/v1.53.10...v1.53.11) (2022-02-14)
 
-
 ### Bug Fixes
 
-* get args in errors ([40e2b74](https://github.com/SocialGouv/mano/commit/40e2b74f394a530dafa4ec709deee6c3d0f6ee02))
+- get args in errors ([40e2b74](https://github.com/SocialGouv/mano/commit/40e2b74f394a530dafa4ec709deee6c3d0f6ee02))
 
 ## [1.53.10](https://github.com/SocialGouv/mano/compare/v1.53.9...v1.53.10) (2022-02-14)
 
-
 ### Bug Fixes
 
-* up ([e2dcc4c](https://github.com/SocialGouv/mano/commit/e2dcc4ca6bd99eaf0a9242b44b0d63a64e02023e))
+- up ([e2dcc4c](https://github.com/SocialGouv/mano/commit/e2dcc4ca6bd99eaf0a9242b44b0d63a64e02023e))
 
 ## [1.53.9](https://github.com/SocialGouv/mano/compare/v1.53.8...v1.53.9) (2022-02-14)
 
-
 ### Bug Fixes
 
-* fix recoil ([e60417f](https://github.com/SocialGouv/mano/commit/e60417f7ec4220fe973855d72a6db5ad4cdecf03))
+- fix recoil ([e60417f](https://github.com/SocialGouv/mano/commit/e60417f7ec4220fe973855d72a6db5ad4cdecf03))
 
 ## [1.53.8](https://github.com/SocialGouv/mano/compare/v1.53.7...v1.53.8) (2022-02-11)
 
-
 ### Bug Fixes
 
-* upgrade oauth2 ([#363](https://github.com/SocialGouv/mano/issues/363)) ([94fa8ec](https://github.com/SocialGouv/mano/commit/94fa8ec8bfd458d4f86ab0bbb98cca41b8cdad85))
+- upgrade oauth2 ([#363](https://github.com/SocialGouv/mano/issues/363)) ([94fa8ec](https://github.com/SocialGouv/mano/commit/94fa8ec8bfd458d4f86ab0bbb98cca41b8cdad85))
 
 ## [1.53.7](https://github.com/SocialGouv/mano/compare/v1.53.6...v1.53.7) (2022-02-11)
 
-
 ### Bug Fixes
 
-* **api:** update sentry ([#361](https://github.com/SocialGouv/mano/issues/361)) ([a1ffbec](https://github.com/SocialGouv/mano/commit/a1ffbec47afda63ec30ab14727de2ac1d7471ca2))
+- **api:** update sentry ([#361](https://github.com/SocialGouv/mano/issues/361)) ([a1ffbec](https://github.com/SocialGouv/mano/commit/a1ffbec47afda63ec30ab14727de2ac1d7471ca2))
 
 ## [1.53.6](https://github.com/SocialGouv/mano/compare/v1.53.5...v1.53.6) (2022-02-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** actions on connection ([3d58eee](https://github.com/SocialGouv/mano/commit/3d58eee5ec3a1e1cfcb75255beb08e2e5258f290))
+- **dashboard:** actions on connection ([3d58eee](https://github.com/SocialGouv/mano/commit/3d58eee5ec3a1e1cfcb75255beb08e2e5258f290))
 
 ## [1.53.5](https://github.com/SocialGouv/mano/compare/v1.53.4...v1.53.5) (2022-02-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** again ([c09ca24](https://github.com/SocialGouv/mano/commit/c09ca240bd3dd03f4bba10168154f6b34addedf7))
+- **dashboard:** again ([c09ca24](https://github.com/SocialGouv/mano/commit/c09ca240bd3dd03f4bba10168154f6b34addedf7))
 
 ## [1.53.4](https://github.com/SocialGouv/mano/compare/v1.53.3...v1.53.4) (2022-02-09)
 
-
 ### Bug Fixes
 
-* **dashboard:** create action ([6ba2af8](https://github.com/SocialGouv/mano/commit/6ba2af8e6bc1dcaa3e705f20fb009e7de3f799f7))
+- **dashboard:** create action ([6ba2af8](https://github.com/SocialGouv/mano/commit/6ba2af8e6bc1dcaa3e705f20fb009e7de3f799f7))
 
 ## [1.53.3](https://github.com/SocialGouv/mano/compare/v1.53.2...v1.53.3) (2022-02-09)
 
-
 ### Bug Fixes
 
-* **dashboard:** selectedPersons length ([103db71](https://github.com/SocialGouv/mano/commit/103db711fd8e72aecf2d2c19cfd36ea500a11aa1))
+- **dashboard:** selectedPersons length ([103db71](https://github.com/SocialGouv/mano/commit/103db711fd8e72aecf2d2c19cfd36ea500a11aa1))
 
 ## [1.53.2](https://github.com/SocialGouv/mano/compare/v1.53.1...v1.53.2) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **api:** remove sentry in non-production env ([438f632](https://github.com/SocialGouv/mano/commit/438f632ebf0de61f2043df76d534bc4f21cfaa1b))
+- **api:** remove sentry in non-production env ([438f632](https://github.com/SocialGouv/mano/commit/438f632ebf0de61f2043df76d534bc4f21cfaa1b))
 
 ## [1.53.1](https://github.com/SocialGouv/mano/compare/v1.53.0...v1.53.1) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix dates for date range picker ([98394bd](https://github.com/SocialGouv/mano/commit/98394bd1d3f6c9c5dbabbdb6ac4078881ce387b6))
+- **dashboard:** fix dates for date range picker ([98394bd](https://github.com/SocialGouv/mano/commit/98394bd1d3f6c9c5dbabbdb6ac4078881ce387b6))
 
 # [1.53.0](https://github.com/SocialGouv/mano/compare/v1.52.0...v1.53.0) (2022-02-08)
 
-
 ### Features
 
-* **k8s:** add configmap for api production ([#355](https://github.com/SocialGouv/mano/issues/355)) ([8ce916c](https://github.com/SocialGouv/mano/commit/8ce916c4fcc6e566114549f0191fe2bc2c4095cd))
+- **k8s:** add configmap for api production ([#355](https://github.com/SocialGouv/mano/issues/355)) ([8ce916c](https://github.com/SocialGouv/mano/commit/8ce916c4fcc6e566114549f0191fe2bc2c4095cd))
 
 # [1.52.0](https://github.com/SocialGouv/mano/compare/v1.51.0...v1.52.0) (2022-02-08)
 
-
 ### Features
 
-* **app:** release app ([4dde5bb](https://github.com/SocialGouv/mano/commit/4dde5bbf919302b514d0898846c7cd65ac2e1dbb))
+- **app:** release app ([4dde5bb](https://github.com/SocialGouv/mano/commit/4dde5bbf919302b514d0898846c7cd65ac2e1dbb))
 
 # [1.51.0](https://github.com/SocialGouv/mano/compare/v1.50.4...v1.51.0) (2022-02-08)
 
-
 ### Features
 
-* **api:** do not return encrypted fields ([#326](https://github.com/SocialGouv/mano/issues/326)) ([ef6e275](https://github.com/SocialGouv/mano/commit/ef6e2751ce02f6f34933cf2472492b1d5cd028d6))
+- **api:** do not return encrypted fields ([#326](https://github.com/SocialGouv/mano/issues/326)) ([ef6e275](https://github.com/SocialGouv/mano/commit/ef6e2751ce02f6f34933cf2472492b1d5cd028d6))
 
 ## [1.50.4](https://github.com/SocialGouv/mano/compare/v1.50.3...v1.50.4) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** add user in territory ([d0411d7](https://github.com/SocialGouv/mano/commit/d0411d7d7a1e0d6def5e263131c489379dcf2547))
+- **dashboard:** add user in territory ([d0411d7](https://github.com/SocialGouv/mano/commit/d0411d7d7a1e0d6def5e263131c489379dcf2547))
 
 ## [1.50.3](https://github.com/SocialGouv/mano/compare/v1.50.2...v1.50.3) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **app:** add user in new action form ([0743443](https://github.com/SocialGouv/mano/commit/074344372eb444bfdc0e54cc3b513098957fb8ea))
+- **app:** add user in new action form ([0743443](https://github.com/SocialGouv/mano/commit/074344372eb444bfdc0e54cc3b513098957fb8ea))
 
 ## [1.50.2](https://github.com/SocialGouv/mano/compare/v1.50.1...v1.50.2) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** action needs a user ([0dca670](https://github.com/SocialGouv/mano/commit/0dca67055fe96561676377ded4682e3a589ee863))
+- **dashboard:** action needs a user ([0dca670](https://github.com/SocialGouv/mano/commit/0dca67055fe96561676377ded4682e3a589ee863))
 
 ## [1.50.1](https://github.com/SocialGouv/mano/compare/v1.50.0...v1.50.1) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix key issue ([7e5c893](https://github.com/SocialGouv/mano/commit/7e5c893c7d0e3eabef959b60c94733eeac28be6f))
+- **dashboard:** fix key issue ([7e5c893](https://github.com/SocialGouv/mano/commit/7e5c893c7d0e3eabef959b60c94733eeac28be6f))
 
 # [1.50.0](https://github.com/SocialGouv/mano/compare/v1.49.8...v1.50.0) (2022-02-08)
 
-
 ### Features
 
-* **app:** update mobile version ([4e46264](https://github.com/SocialGouv/mano/commit/4e462640c17aaae2c58e7d0211f6b4f3c9de2c4d))
+- **app:** update mobile version ([4e46264](https://github.com/SocialGouv/mano/commit/4e462640c17aaae2c58e7d0211f6b4f3c9de2c4d))
 
 ## [1.49.8](https://github.com/SocialGouv/mano/compare/v1.49.7...v1.49.8) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix iedge error for scroll ([6345382](https://github.com/SocialGouv/mano/commit/63453823b7f915398e44a118c4aa7731f21f11d4))
+- **dashboard:** fix iedge error for scroll ([6345382](https://github.com/SocialGouv/mano/commit/63453823b7f915398e44a118c4aa7731f21f11d4))
 
 ## [1.49.7](https://github.com/SocialGouv/mano/compare/v1.49.6...v1.49.7) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix refresher bugs ([#353](https://github.com/SocialGouv/mano/issues/353)) ([5831d61](https://github.com/SocialGouv/mano/commit/5831d614fb45379f42d988ecbc447472aabd1ef2))
+- **dashboard:** fix refresher bugs ([#353](https://github.com/SocialGouv/mano/issues/353)) ([5831d61](https://github.com/SocialGouv/mano/commit/5831d614fb45379f42d988ecbc447472aabd1ef2))
 
 ## [1.49.6](https://github.com/SocialGouv/mano/compare/v1.49.5...v1.49.6) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **app:** remove cache when changing organisation ([#354](https://github.com/SocialGouv/mano/issues/354)) ([4d37cbe](https://github.com/SocialGouv/mano/commit/4d37cbee461c90d988ddebdeb83d6552cc3c5190))
+- **app:** remove cache when changing organisation ([#354](https://github.com/SocialGouv/mano/issues/354)) ([4d37cbe](https://github.com/SocialGouv/mano/commit/4d37cbee461c90d988ddebdeb83d6552cc3c5190))
 
 ## [1.49.5](https://github.com/SocialGouv/mano/compare/v1.49.4...v1.49.5) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** categories can be empty ([a8ecbb1](https://github.com/SocialGouv/mano/commit/a8ecbb1d283f2e35f097272ba35803bfef94eaa6))
+- **dashboard:** categories can be empty ([a8ecbb1](https://github.com/SocialGouv/mano/commit/a8ecbb1d283f2e35f097272ba35803bfef94eaa6))
 
 ## [1.49.4](https://github.com/SocialGouv/mano/compare/v1.49.3...v1.49.4) (2022-02-08)
 
-
 ### Bug Fixes
 
-* **app:** fix action on save ([2f32f25](https://github.com/SocialGouv/mano/commit/2f32f251a769674aa7384abd60785aab51e3bb1a))
+- **app:** fix action on save ([2f32f25](https://github.com/SocialGouv/mano/commit/2f32f251a769674aa7384abd60785aab51e3bb1a))
 
 ## [1.49.3](https://github.com/SocialGouv/mano/compare/v1.49.2...v1.49.3) (2022-02-07)
 
-
 ### Bug Fixes
 
-* bump release ([8d0a49a](https://github.com/SocialGouv/mano/commit/8d0a49a6c3cc30f355a77e5d92fb139113961002))
+- bump release ([8d0a49a](https://github.com/SocialGouv/mano/commit/8d0a49a6c3cc30f355a77e5d92fb139113961002))
 
 ## [1.49.2](https://github.com/SocialGouv/mano/compare/v1.49.1...v1.49.2) (2022-02-07)
 
-
 ### Bug Fixes
 
-* **dashboard:** display teams ([24a7ae1](https://github.com/SocialGouv/mano/commit/24a7ae14770a1c0a32a58ac1dca1a01d549e545a))
+- **dashboard:** display teams ([24a7ae1](https://github.com/SocialGouv/mano/commit/24a7ae14770a1c0a32a58ac1dca1a01d549e545a))
 
 ## [1.49.1](https://github.com/SocialGouv/mano/compare/v1.49.0...v1.49.1) (2022-02-07)
 
-
 ### Bug Fixes
 
-* **dashboard:** error deleting person due to casade ([#347](https://github.com/SocialGouv/mano/issues/347)) ([0e808a1](https://github.com/SocialGouv/mano/commit/0e808a1e228e0ee9145ea985302a09633ca72da5))
-* **dashboard:** old dates in import aka 1940 bug ([#345](https://github.com/SocialGouv/mano/issues/345)) ([0051651](https://github.com/SocialGouv/mano/commit/00516516a019c601287e5ba61270b43dbd96e9c9))
+- **dashboard:** error deleting person due to casade ([#347](https://github.com/SocialGouv/mano/issues/347)) ([0e808a1](https://github.com/SocialGouv/mano/commit/0e808a1e228e0ee9145ea985302a09633ca72da5))
+- **dashboard:** old dates in import aka 1940 bug ([#345](https://github.com/SocialGouv/mano/issues/345)) ([0051651](https://github.com/SocialGouv/mano/commit/00516516a019c601287e5ba61270b43dbd96e9c9))
 
 # [1.49.0](https://github.com/SocialGouv/mano/compare/v1.48.5...v1.49.0) (2022-02-07)
 
-
 ### Bug Fixes
 
-* **dashboard:** import boolean ([#344](https://github.com/SocialGouv/mano/issues/344)) ([cf2e5b9](https://github.com/SocialGouv/mano/commit/cf2e5b9b2202e573132f3c40145ff16956709015))
-
+- **dashboard:** import boolean ([#344](https://github.com/SocialGouv/mano/issues/344)) ([cf2e5b9](https://github.com/SocialGouv/mano/commit/cf2e5b9b2202e573132f3c40145ff16956709015))
 
 ### Features
 
-* **dashboard:** more info in download example ([#343](https://github.com/SocialGouv/mano/issues/343)) ([8bd7f21](https://github.com/SocialGouv/mano/commit/8bd7f2144e11967a7c1d2100df89534e567ccc65))
-* **import:** improve description in import ([#342](https://github.com/SocialGouv/mano/issues/342)) ([065fc52](https://github.com/SocialGouv/mano/commit/065fc528c81546aad088b1db77004eabc13e3d63))
+- **dashboard:** more info in download example ([#343](https://github.com/SocialGouv/mano/issues/343)) ([8bd7f21](https://github.com/SocialGouv/mano/commit/8bd7f2144e11967a7c1d2100df89534e567ccc65))
+- **import:** improve description in import ([#342](https://github.com/SocialGouv/mano/issues/342)) ([065fc52](https://github.com/SocialGouv/mano/commit/065fc528c81546aad088b1db77004eabc13e3d63))
 
 ## [1.48.5](https://github.com/SocialGouv/mano/compare/v1.48.4...v1.48.5) (2022-02-07)
 
-
 ### Bug Fixes
 
-* typo fr ([#348](https://github.com/SocialGouv/mano/issues/348)) ([6875c97](https://github.com/SocialGouv/mano/commit/6875c97feb01ea6af54e66d900ffe068015ace00))
-* **typo:** and mise a jour ([#349](https://github.com/SocialGouv/mano/issues/349)) ([29497aa](https://github.com/SocialGouv/mano/commit/29497aab2c228e86ba11b9e378317037a433bbd3))
+- typo fr ([#348](https://github.com/SocialGouv/mano/issues/348)) ([6875c97](https://github.com/SocialGouv/mano/commit/6875c97feb01ea6af54e66d900ffe068015ace00))
+- **typo:** and mise a jour ([#349](https://github.com/SocialGouv/mano/issues/349)) ([29497aa](https://github.com/SocialGouv/mano/commit/29497aab2c228e86ba11b9e378317037a433bbd3))
 
 ## [1.48.4](https://github.com/SocialGouv/mano/compare/v1.48.3...v1.48.4) (2022-02-07)
 
-
 ### Bug Fixes
 
-* fix error ([b82a482](https://github.com/SocialGouv/mano/commit/b82a4828ecd2804f1e81e17fe4f333657fe6777e))
+- fix error ([b82a482](https://github.com/SocialGouv/mano/commit/b82a4828ecd2804f1e81e17fe4f333657fe6777e))
 
 ## [1.48.3](https://github.com/SocialGouv/mano/compare/v1.48.2...v1.48.3) (2022-02-04)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency xlsx to ^0.18.0 ([#336](https://github.com/SocialGouv/mano/issues/336)) ([2e02a18](https://github.com/SocialGouv/mano/commit/2e02a18cdb38cacd99aebe85758c21043dd81172))
+- **deps:** update dependency xlsx to ^0.18.0 ([#336](https://github.com/SocialGouv/mano/issues/336)) ([2e02a18](https://github.com/SocialGouv/mano/commit/2e02a18cdb38cacd99aebe85758c21043dd81172))
 
 ## [1.48.2](https://github.com/SocialGouv/mano/compare/v1.48.1...v1.48.2) (2022-02-03)
 
-
 ### Bug Fixes
 
-* **dashboard:** dates with dayjs ([#334](https://github.com/SocialGouv/mano/issues/334)) ([4a4bfa4](https://github.com/SocialGouv/mano/commit/4a4bfa4aedbbd17a514455a84935e27c9148a465))
+- **dashboard:** dates with dayjs ([#334](https://github.com/SocialGouv/mano/issues/334)) ([4a4bfa4](https://github.com/SocialGouv/mano/commit/4a4bfa4aedbbd17a514455a84935e27c9148a465))
 
 ## [1.48.1](https://github.com/SocialGouv/mano/compare/v1.48.0...v1.48.1) (2022-02-03)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency dotenv to v16 ([#340](https://github.com/SocialGouv/mano/issues/340)) ([5009147](https://github.com/SocialGouv/mano/commit/5009147266fbd8ad95f742a29b275e0b6c1257f2))
+- **deps:** update dependency dotenv to v16 ([#340](https://github.com/SocialGouv/mano/issues/340)) ([5009147](https://github.com/SocialGouv/mano/commit/5009147266fbd8ad95f742a29b275e0b6c1257f2))
 
 # [1.48.0](https://github.com/SocialGouv/mano/compare/v1.47.0...v1.48.0) (2022-02-03)
 
-
 ### Features
 
-* **api,dashboard,app:** remove relPersonTeam usage ([#327](https://github.com/SocialGouv/mano/issues/327)) ([b34607d](https://github.com/SocialGouv/mano/commit/b34607d11a21bdfce4a6f11c9f07dfc1bd6c0fc8))
+- **api,dashboard,app:** remove relPersonTeam usage ([#327](https://github.com/SocialGouv/mano/issues/327)) ([b34607d](https://github.com/SocialGouv/mano/commit/b34607d11a21bdfce4a6f11c9f07dfc1bd6c0fc8))
 
 # [1.47.0](https://github.com/SocialGouv/mano/compare/v1.46.6...v1.47.0) (2022-02-03)
 
-
 ### Features
 
-* **dahsboard,app:** add hotel ([fb41665](https://github.com/SocialGouv/mano/commit/fb41665984ef8ed3d46521ce3c0c4934b755ef41))
+- **dahsboard,app:** add hotel ([fb41665](https://github.com/SocialGouv/mano/commit/fb41665984ef8ed3d46521ce3c0c4934b755ef41))
 
 ## [1.46.6](https://github.com/SocialGouv/mano/compare/v1.46.5...v1.46.6) (2022-02-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** rollback reactselect and reactstrap ([#338](https://github.com/SocialGouv/mano/issues/338)) ([3152b65](https://github.com/SocialGouv/mano/commit/3152b65a0a5310d41c3a6075402e1786988a83fe))
+- **dashboard:** rollback reactselect and reactstrap ([#338](https://github.com/SocialGouv/mano/issues/338)) ([3152b65](https://github.com/SocialGouv/mano/commit/3152b65a0a5310d41c3a6075402e1786988a83fe))
 
 ## [1.46.5](https://github.com/SocialGouv/mano/compare/v1.46.4...v1.46.5) (2022-02-02)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency reactstrap to v9 ([#321](https://github.com/SocialGouv/mano/issues/321)) ([c647abe](https://github.com/SocialGouv/mano/commit/c647abe350e12594baf828a5907327080fa63285))
+- **deps:** update dependency reactstrap to v9 ([#321](https://github.com/SocialGouv/mano/issues/321)) ([c647abe](https://github.com/SocialGouv/mano/commit/c647abe350e12594baf828a5907327080fa63285))
 
 ## [1.46.4](https://github.com/SocialGouv/mano/compare/v1.46.3...v1.46.4) (2022-02-02)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency dotenv to v15 ([#319](https://github.com/SocialGouv/mano/issues/319)) ([f1d9470](https://github.com/SocialGouv/mano/commit/f1d9470f1966a5853a864e073e054c80dda2c891))
+- **deps:** update dependency dotenv to v15 ([#319](https://github.com/SocialGouv/mano/issues/319)) ([f1d9470](https://github.com/SocialGouv/mano/commit/f1d9470f1966a5853a864e073e054c80dda2c891))
 
 ## [1.46.3](https://github.com/SocialGouv/mano/compare/v1.46.2...v1.46.3) (2022-02-02)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency react-select to v5 ([#320](https://github.com/SocialGouv/mano/issues/320)) ([ce6722b](https://github.com/SocialGouv/mano/commit/ce6722bdb167971ca3c40c3f023fba94bc47c085))
+- **deps:** update dependency react-select to v5 ([#320](https://github.com/SocialGouv/mano/issues/320)) ([ce6722b](https://github.com/SocialGouv/mano/commit/ce6722bdb167971ca3c40c3f023fba94bc47c085))
 
 ## [1.46.2](https://github.com/SocialGouv/mano/compare/v1.46.1...v1.46.2) (2022-02-01)
 
-
 ### Bug Fixes
 
-* **ci:** fix proxy secrets ([#332](https://github.com/SocialGouv/mano/issues/332)) ([6df6793](https://github.com/SocialGouv/mano/commit/6df67937330b78684f78e40a431ab948ff279090))
+- **ci:** fix proxy secrets ([#332](https://github.com/SocialGouv/mano/issues/332)) ([6df6793](https://github.com/SocialGouv/mano/commit/6df67937330b78684f78e40a431ab948ff279090))
 
 ## [1.46.1](https://github.com/SocialGouv/mano/compare/v1.46.0...v1.46.1) (2022-02-01)
 
-
 ### Bug Fixes
 
-* **dashboard:** debug false ([ebf3f29](https://github.com/SocialGouv/mano/commit/ebf3f29594fad4021b5214eef06ee96d602731aa))
+- **dashboard:** debug false ([ebf3f29](https://github.com/SocialGouv/mano/commit/ebf3f29594fad4021b5214eef06ee96d602731aa))
 
 # [1.46.0](https://github.com/SocialGouv/mano/compare/v1.45.3...v1.46.0) (2022-02-01)
 
-
 ### Features
 
-* **metabase:** add github auth proxy ([#293](https://github.com/SocialGouv/mano/issues/293)) ([87e9edb](https://github.com/SocialGouv/mano/commit/87e9edbce2891dd481c17190637b693908032906))
+- **metabase:** add github auth proxy ([#293](https://github.com/SocialGouv/mano/issues/293)) ([87e9edb](https://github.com/SocialGouv/mano/commit/87e9edbce2891dd481c17190637b693908032906))
 
 ## [1.45.3](https://github.com/SocialGouv/mano/compare/v1.45.2...v1.45.3) (2022-01-31)
 
-
 ### Bug Fixes
 
-* **dashboard:** fix stats for passages ([d49ef27](https://github.com/SocialGouv/mano/commit/d49ef27d2e589dabddd5ca52122418bf7977c839))
+- **dashboard:** fix stats for passages ([d49ef27](https://github.com/SocialGouv/mano/commit/d49ef27d2e589dabddd5ca52122418bf7977c839))
 
 ## [1.45.2](https://github.com/SocialGouv/mano/compare/v1.45.1...v1.45.2) (2022-01-31)
 
-
 ### Bug Fixes
 
-* fix passages count in stat ([#314](https://github.com/SocialGouv/mano/issues/314)) ([8a31646](https://github.com/SocialGouv/mano/commit/8a31646d25b7955d9a3745d22686b2216b5bbdd1))
+- fix passages count in stat ([#314](https://github.com/SocialGouv/mano/issues/314)) ([8a31646](https://github.com/SocialGouv/mano/commit/8a31646d25b7955d9a3745d22686b2216b5bbdd1))
 
 ## [1.45.1](https://github.com/SocialGouv/mano/compare/v1.45.0...v1.45.1) (2022-01-31)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency recoil to ^0.6.0 ([#318](https://github.com/SocialGouv/mano/issues/318)) ([3afbc08](https://github.com/SocialGouv/mano/commit/3afbc089723452edefa1d25f664493ced021d530))
+- **deps:** update dependency recoil to ^0.6.0 ([#318](https://github.com/SocialGouv/mano/issues/318)) ([3afbc08](https://github.com/SocialGouv/mano/commit/3afbc089723452edefa1d25f664493ced021d530))
 
 # [1.45.0](https://github.com/SocialGouv/mano/compare/v1.44.3...v1.45.0) (2022-01-31)
 
-
 ### Features
 
-* **dashboard:** import teams ([#312](https://github.com/SocialGouv/mano/issues/312)) ([f6d195d](https://github.com/SocialGouv/mano/commit/f6d195d44c8eae5a44500a77b9366b8676a90cfe))
+- **dashboard:** import teams ([#312](https://github.com/SocialGouv/mano/issues/312)) ([f6d195d](https://github.com/SocialGouv/mano/commit/f6d195d44c8eae5a44500a77b9366b8676a90cfe))
 
 ## [1.44.3](https://github.com/SocialGouv/mano/compare/v1.44.2...v1.44.3) (2022-01-29)
 
-
 ### Bug Fixes
 
-* **deps:** update nivo monorepo ([#304](https://github.com/SocialGouv/mano/issues/304)) ([7ae10d9](https://github.com/SocialGouv/mano/commit/7ae10d99376fb3a1b5e13e069810597b1fa6f2eb))
+- **deps:** update nivo monorepo ([#304](https://github.com/SocialGouv/mano/issues/304)) ([7ae10d9](https://github.com/SocialGouv/mano/commit/7ae10d99376fb3a1b5e13e069810597b1fa6f2eb))
 
 ## [1.44.2](https://github.com/SocialGouv/mano/compare/v1.44.1...v1.44.2) (2022-01-28)
 
-
 ### Bug Fixes
 
-* **app:** remove classes ([#308](https://github.com/SocialGouv/mano/issues/308)) ([bca118f](https://github.com/SocialGouv/mano/commit/bca118fd72f23d59abd4506ab51f5429ecc66bfb))
+- **app:** remove classes ([#308](https://github.com/SocialGouv/mano/issues/308)) ([bca118f](https://github.com/SocialGouv/mano/commit/bca118fd72f23d59abd4506ab51f5429ecc66bfb))
 
 ## [1.44.1](https://github.com/SocialGouv/mano/compare/v1.44.0...v1.44.1) (2022-01-27)
 
-
 ### Bug Fixes
 
-* **dashboard:** import custom fields ([#311](https://github.com/SocialGouv/mano/issues/311)) ([9a2e88f](https://github.com/SocialGouv/mano/commit/9a2e88f2988e9ee7872f0243b20fe30f5d9951c2))
+- **dashboard:** import custom fields ([#311](https://github.com/SocialGouv/mano/issues/311)) ([9a2e88f](https://github.com/SocialGouv/mano/commit/9a2e88f2988e9ee7872f0243b20fe30f5d9951c2))
 
 # [1.44.0](https://github.com/SocialGouv/mano/compare/v1.43.4...v1.44.0) (2022-01-27)
 
-
 ### Features
 
-* **dashboard:** scroll to top on page change ([#287](https://github.com/SocialGouv/mano/issues/287)) ([f062519](https://github.com/SocialGouv/mano/commit/f062519b647c19943a59beedb5a89953db81c8e3))
+- **dashboard:** scroll to top on page change ([#287](https://github.com/SocialGouv/mano/issues/287)) ([f062519](https://github.com/SocialGouv/mano/commit/f062519b647c19943a59beedb5a89953db81c8e3))
 
 ## [1.43.4](https://github.com/SocialGouv/mano/compare/v1.43.3...v1.43.4) (2022-01-27)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency node-fetch to v2.6.7 [security] ([#296](https://github.com/SocialGouv/mano/issues/296)) ([bbf66e7](https://github.com/SocialGouv/mano/commit/bbf66e702bdc9010e12dd0cbfe057f608bbc1e0b))
+- **deps:** update dependency node-fetch to v2.6.7 [security] ([#296](https://github.com/SocialGouv/mano/issues/296)) ([bbf66e7](https://github.com/SocialGouv/mano/commit/bbf66e702bdc9010e12dd0cbfe057f608bbc1e0b))
 
 ## [1.43.3](https://github.com/SocialGouv/mano/compare/v1.43.2...v1.43.3) (2022-01-26)
 
-
 ### Bug Fixes
 
-* **dashboard:** import data ([#298](https://github.com/SocialGouv/mano/issues/298)) ([8ef6e12](https://github.com/SocialGouv/mano/commit/8ef6e12fe7cf9080f56b30701d0489da74714fec))
+- **dashboard:** import data ([#298](https://github.com/SocialGouv/mano/issues/298)) ([8ef6e12](https://github.com/SocialGouv/mano/commit/8ef6e12fe7cf9080f56b30701d0489da74714fec))
 
 ## [1.43.2](https://github.com/SocialGouv/mano/compare/v1.43.1...v1.43.2) (2022-01-26)
 
-
 ### Bug Fixes
 
-* **api:** no need password ([#297](https://github.com/SocialGouv/mano/issues/297)) ([e40b1ea](https://github.com/SocialGouv/mano/commit/e40b1ea13581f4180322b08cb9bf76e5e3348afd))
+- **api:** no need password ([#297](https://github.com/SocialGouv/mano/issues/297)) ([e40b1ea](https://github.com/SocialGouv/mano/commit/e40b1ea13581f4180322b08cb9bf76e5e3348afd))
 
 ## [1.43.1](https://github.com/SocialGouv/mano/compare/v1.43.0...v1.43.1) (2022-01-26)
 
-
 ### Bug Fixes
 
-* **app:** dont show undefined in terrotiry observations ([#288](https://github.com/SocialGouv/mano/issues/288)) ([0d2aade](https://github.com/SocialGouv/mano/commit/0d2aade7b2f7cbb41738f383360065aead392b97))
+- **app:** dont show undefined in terrotiry observations ([#288](https://github.com/SocialGouv/mano/issues/288)) ([0d2aade](https://github.com/SocialGouv/mano/commit/0d2aade7b2f7cbb41738f383360065aead392b97))
 
 # [1.43.0](https://github.com/SocialGouv/mano/compare/v1.42.2...v1.43.0) (2022-01-26)
 
-
 ### Features
 
-* **dash:** onboarding with encryption ([#285](https://github.com/SocialGouv/mano/issues/285)) ([7e25424](https://github.com/SocialGouv/mano/commit/7e25424e579272b99f39d466703db784391f7bbe))
+- **dash:** onboarding with encryption ([#285](https://github.com/SocialGouv/mano/issues/285)) ([7e25424](https://github.com/SocialGouv/mano/commit/7e25424e579272b99f39d466703db784391f7bbe))
 
 ## [1.42.2](https://github.com/SocialGouv/mano/compare/v1.42.1...v1.42.2) (2022-01-25)
 
-
 ### Bug Fixes
 
-* **dashboad:** fix import custom fields ([5b1422b](https://github.com/SocialGouv/mano/commit/5b1422be960dd2f0244c485fdec69a0353c914a6))
+- **dashboad:** fix import custom fields ([5b1422b](https://github.com/SocialGouv/mano/commit/5b1422be960dd2f0244c485fdec69a0353c914a6))
 
 ## [1.42.1](https://github.com/SocialGouv/mano/compare/v1.42.0...v1.42.1) (2022-01-07)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency react-datepicker to v4 ([#271](https://github.com/SocialGouv/mano/issues/271)) ([2e70b96](https://github.com/SocialGouv/mano/commit/2e70b96c8262a292a8ae4a396f51331bf8b4d4d4))
+- **deps:** update dependency react-datepicker to v4 ([#271](https://github.com/SocialGouv/mano/issues/271)) ([2e70b96](https://github.com/SocialGouv/mano/commit/2e70b96c8262a292a8ae4a396f51331bf8b4d4d4))
 
 # [1.42.0](https://github.com/SocialGouv/mano/compare/v1.41.9...v1.42.0) (2022-01-07)
 
-
 ### Features
 
-* **dashboard:** upload docs ([#276](https://github.com/SocialGouv/mano/issues/276)) ([9f5d7b7](https://github.com/SocialGouv/mano/commit/9f5d7b7dd1e8d8202fdfeea793d8ea2a5606352f))
+- **dashboard:** upload docs ([#276](https://github.com/SocialGouv/mano/issues/276)) ([9f5d7b7](https://github.com/SocialGouv/mano/commit/9f5d7b7dd1e8d8202fdfeea793d8ea2a5606352f))
 
 ## [1.41.9](https://github.com/SocialGouv/mano/compare/v1.41.8...v1.41.9) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency urijs to v1.19.7 [security] ([#274](https://github.com/SocialGouv/mano/issues/274)) ([72a3e85](https://github.com/SocialGouv/mano/commit/72a3e85c89ae33b83f1194fdbbfd556013b14974))
+- **deps:** update dependency urijs to v1.19.7 [security] ([#274](https://github.com/SocialGouv/mano/issues/274)) ([72a3e85](https://github.com/SocialGouv/mano/commit/72a3e85c89ae33b83f1194fdbbfd556013b14974))
 
 ## [1.41.8](https://github.com/SocialGouv/mano/compare/v1.41.7...v1.41.8) (2021-12-21)
 
-
 ### Bug Fixes
 
-* bump release ([8361d04](https://github.com/SocialGouv/mano/commit/8361d04965b538e2f2ee9d9d9951edd22664c29e))
+- bump release ([8361d04](https://github.com/SocialGouv/mano/commit/8361d04965b538e2f2ee9d9d9951edd22664c29e))
 
 ## [1.41.7](https://github.com/SocialGouv/mano/compare/v1.41.6...v1.41.7) (2021-12-21)
 
-
 ### Bug Fixes
 
-* bump release ([9215a49](https://github.com/SocialGouv/mano/commit/9215a4910a0cae0efcd1503fb35f73579b293412))
+- bump release ([9215a49](https://github.com/SocialGouv/mano/commit/9215a4910a0cae0efcd1503fb35f73579b293412))
 
 ## [1.41.6](https://github.com/SocialGouv/mano/compare/v1.41.5...v1.41.6) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency dotenv to v10 ([#260](https://github.com/SocialGouv/mano/issues/260)) ([8e5f90e](https://github.com/SocialGouv/mano/commit/8e5f90edf9d9b50618a4c4e2a98b2014f3d1bfe7))
+- **deps:** update dependency dotenv to v10 ([#260](https://github.com/SocialGouv/mano/issues/260)) ([8e5f90e](https://github.com/SocialGouv/mano/commit/8e5f90edf9d9b50618a4c4e2a98b2014f3d1bfe7))
 
 ## [1.41.5](https://github.com/SocialGouv/mano/compare/v1.41.4...v1.41.5) (2021-12-21)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency npm to v8 ([#269](https://github.com/SocialGouv/mano/issues/269)) ([11c532f](https://github.com/SocialGouv/mano/commit/11c532fc2178182f2bd1ad2e7088229e785da518))
+- **deps:** update dependency npm to v8 ([#269](https://github.com/SocialGouv/mano/issues/269)) ([11c532f](https://github.com/SocialGouv/mano/commit/11c532fc2178182f2bd1ad2e7088229e785da518))
 
 ## [1.41.4](https://github.com/SocialGouv/mano/compare/v1.41.3...v1.41.4) (2021-12-20)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency helmet to v4 ([#263](https://github.com/SocialGouv/mano/issues/263)) ([71e214c](https://github.com/SocialGouv/mano/commit/71e214c154fcd7b630e4912cc48c7a5b25eb6fe6))
+- **deps:** update dependency helmet to v4 ([#263](https://github.com/SocialGouv/mano/issues/263)) ([71e214c](https://github.com/SocialGouv/mano/commit/71e214c154fcd7b630e4912cc48c7a5b25eb6fe6))
 
 ## [1.41.3](https://github.com/SocialGouv/mano/compare/v1.41.2...v1.41.3) (2021-12-20)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency next to v12 ([#264](https://github.com/SocialGouv/mano/issues/264)) ([521ae70](https://github.com/SocialGouv/mano/commit/521ae70183f64062d4bacbb6c817a744ddda9ec7))
+- **deps:** update dependency next to v12 ([#264](https://github.com/SocialGouv/mano/issues/264)) ([521ae70](https://github.com/SocialGouv/mano/commit/521ae70183f64062d4bacbb6c817a744ddda9ec7))
 
 ## [1.41.2](https://github.com/SocialGouv/mano/compare/v1.41.1...v1.41.2) (2021-12-20)
 
-
 ### Bug Fixes
 
-* **dashboard:** comment.person can be empty ([9feb344](https://github.com/SocialGouv/mano/commit/9feb344fccc16d6be1c551fc868800fe865352a0))
+- **dashboard:** comment.person can be empty ([9feb344](https://github.com/SocialGouv/mano/commit/9feb344fccc16d6be1c551fc868800fe865352a0))
 
 ## [1.41.1](https://github.com/SocialGouv/mano/compare/v1.41.0...v1.41.1) (2021-12-20)
 
-
 ### Bug Fixes
 
-* **dashboard:** at least one team for user ([#252](https://github.com/SocialGouv/mano/issues/252)) ([bd7e205](https://github.com/SocialGouv/mano/commit/bd7e205f401e0ae515071a37b6526a413b600a7e))
+- **dashboard:** at least one team for user ([#252](https://github.com/SocialGouv/mano/issues/252)) ([bd7e205](https://github.com/SocialGouv/mano/commit/bd7e205f401e0ae515071a37b6526a413b600a7e))
 
 # [1.41.0](https://github.com/SocialGouv/mano/compare/v1.40.6...v1.41.0) (2021-12-17)
 
-
 ### Features
 
-* **dashboard:** all fields in create action modal ([#247](https://github.com/SocialGouv/mano/issues/247)) ([18766ea](https://github.com/SocialGouv/mano/commit/18766ea596cfcab712fd6a8f8c45877225a0a2a1))
+- **dashboard:** all fields in create action modal ([#247](https://github.com/SocialGouv/mano/issues/247)) ([18766ea](https://github.com/SocialGouv/mano/commit/18766ea596cfcab712fd6a8f8c45877225a0a2a1))
 
 ## [1.40.6](https://github.com/SocialGouv/mano/compare/v1.40.5...v1.40.6) (2021-12-17)
 
-
 ### Bug Fixes
 
-* **deps:** update react monorepo ([#244](https://github.com/SocialGouv/mano/issues/244)) ([11aea86](https://github.com/SocialGouv/mano/commit/11aea8673e1beafb5ad6240bc1c1bb1d29f8c9f2))
+- **deps:** update react monorepo ([#244](https://github.com/SocialGouv/mano/issues/244)) ([11aea86](https://github.com/SocialGouv/mano/commit/11aea8673e1beafb5ad6240bc1c1bb1d29f8c9f2))
 
 ## [1.40.5](https://github.com/SocialGouv/mano/compare/v1.40.4...v1.40.5) (2021-12-17)
 
-
 ### Bug Fixes
 
-* **deps:** update nivo monorepo to ^0.75.0 ([#243](https://github.com/SocialGouv/mano/issues/243)) ([a389f7e](https://github.com/SocialGouv/mano/commit/a389f7ead8f87f1f0fb1eaff2ad98491cf63c609))
+- **deps:** update nivo monorepo to ^0.75.0 ([#243](https://github.com/SocialGouv/mano/issues/243)) ([a389f7e](https://github.com/SocialGouv/mano/commit/a389f7ead8f87f1f0fb1eaff2ad98491cf63c609))
 
 ## [1.40.4](https://github.com/SocialGouv/mano/compare/v1.40.3...v1.40.4) (2021-12-17)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @socialgouv/kosko-charts to ^9.8.21 ([#232](https://github.com/SocialGouv/mano/issues/232)) ([e15a270](https://github.com/SocialGouv/mano/commit/e15a270cdb12db03c994011d0b2e8b2099b1ba61))
-* **deps:** update dependency react-select to ^4.3.1 ([#229](https://github.com/SocialGouv/mano/issues/229)) ([457c60c](https://github.com/SocialGouv/mano/commit/457c60ce808d1793cffc52e4584d2371a013344c))
-* **deps:** update dependency recoil to ^0.5.2 ([#230](https://github.com/SocialGouv/mano/issues/230)) ([9dc91e8](https://github.com/SocialGouv/mano/commit/9dc91e8084bd510677217a05b5900414119be737))
+- **deps:** update dependency @socialgouv/kosko-charts to ^9.8.21 ([#232](https://github.com/SocialGouv/mano/issues/232)) ([e15a270](https://github.com/SocialGouv/mano/commit/e15a270cdb12db03c994011d0b2e8b2099b1ba61))
+- **deps:** update dependency react-select to ^4.3.1 ([#229](https://github.com/SocialGouv/mano/issues/229)) ([457c60c](https://github.com/SocialGouv/mano/commit/457c60ce808d1793cffc52e4584d2371a013344c))
+- **deps:** update dependency recoil to ^0.5.2 ([#230](https://github.com/SocialGouv/mano/issues/230)) ([9dc91e8](https://github.com/SocialGouv/mano/commit/9dc91e8084bd510677217a05b5900414119be737))
 
 ## [1.40.3](https://github.com/SocialGouv/mano/compare/v1.40.2...v1.40.3) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency react-native-config to ^1.4.5 ([#224](https://github.com/SocialGouv/mano/issues/224)) ([15102ee](https://github.com/SocialGouv/mano/commit/15102ee6e13eadca925b6de6071c40dfc1292d29))
-* **deps:** update dependency react-native-svg to ^12.1.1 ([#225](https://github.com/SocialGouv/mano/issues/225)) ([e08266a](https://github.com/SocialGouv/mano/commit/e08266a21522650796dc9902ff5163310556e821))
+- **deps:** update dependency react-native-config to ^1.4.5 ([#224](https://github.com/SocialGouv/mano/issues/224)) ([15102ee](https://github.com/SocialGouv/mano/commit/15102ee6e13eadca925b6de6071c40dfc1292d29))
+- **deps:** update dependency react-native-svg to ^12.1.1 ([#225](https://github.com/SocialGouv/mano/issues/225)) ([e08266a](https://github.com/SocialGouv/mano/commit/e08266a21522650796dc9902ff5163310556e821))
 
 ## [1.40.2](https://github.com/SocialGouv/mano/compare/v1.40.1...v1.40.2) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency react-redux to ^7.2.6 ([#226](https://github.com/SocialGouv/mano/issues/226)) ([ef29390](https://github.com/SocialGouv/mano/commit/ef2939059ce1a5537e159c104079070d9b7f483d))
+- **deps:** update dependency react-redux to ^7.2.6 ([#226](https://github.com/SocialGouv/mano/issues/226)) ([ef29390](https://github.com/SocialGouv/mano/commit/ef2939059ce1a5537e159c104079070d9b7f483d))
 
 ## [1.40.1](https://github.com/SocialGouv/mano/compare/v1.40.0...v1.40.1) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency helmet to ^3.23.3 ([#219](https://github.com/SocialGouv/mano/issues/219)) ([ad75b75](https://github.com/SocialGouv/mano/commit/ad75b75eb47f80601f441c48bbaba130476f3310))
+- **deps:** update dependency helmet to ^3.23.3 ([#219](https://github.com/SocialGouv/mano/issues/219)) ([ad75b75](https://github.com/SocialGouv/mano/commit/ad75b75eb47f80601f441c48bbaba130476f3310))
 
 # [1.40.0](https://github.com/SocialGouv/mano/compare/v1.39.4...v1.40.0) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency react-icons to ^4.3.1 ([#222](https://github.com/SocialGouv/mano/issues/222)) ([0d64687](https://github.com/SocialGouv/mano/commit/0d646874c331bb13f1f8e4985734755bbd9bd34f))
-
+- **deps:** update dependency react-icons to ^4.3.1 ([#222](https://github.com/SocialGouv/mano/issues/222)) ([0d64687](https://github.com/SocialGouv/mano/commit/0d646874c331bb13f1f8e4985734755bbd9bd34f))
 
 ### Features
 
-* **dashboard:** filter by territory on stats ([#208](https://github.com/SocialGouv/mano/issues/208)) ([6d58054](https://github.com/SocialGouv/mano/commit/6d58054269b2085f2db43ccd0db1ba62d87a4f2d))
+- **dashboard:** filter by territory on stats ([#208](https://github.com/SocialGouv/mano/issues/208)) ([6d58054](https://github.com/SocialGouv/mano/commit/6d58054269b2085f2db43ccd0db1ba62d87a4f2d))
 
 ## [1.39.4](https://github.com/SocialGouv/mano/compare/v1.39.3...v1.39.4) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency react-datepicker to ^3.8.0 ([#221](https://github.com/SocialGouv/mano/issues/221)) ([310cda4](https://github.com/SocialGouv/mano/commit/310cda4ab777155cdc06af5a5121646978047aec))
+- **deps:** update dependency react-datepicker to ^3.8.0 ([#221](https://github.com/SocialGouv/mano/issues/221)) ([310cda4](https://github.com/SocialGouv/mano/commit/310cda4ab777155cdc06af5a5121646978047aec))
 
 ## [1.39.3](https://github.com/SocialGouv/mano/compare/v1.39.2...v1.39.3) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency formik to ^2.2.9 ([#211](https://github.com/SocialGouv/mano/issues/211)) ([f46152e](https://github.com/SocialGouv/mano/commit/f46152e716d726526e26cf28958ccf286f295955))
+- **deps:** update dependency formik to ^2.2.9 ([#211](https://github.com/SocialGouv/mano/issues/211)) ([f46152e](https://github.com/SocialGouv/mano/commit/f46152e716d726526e26cf28958ccf286f295955))
 
 ## [1.39.2](https://github.com/SocialGouv/mano/compare/v1.39.1...v1.39.2) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency dotenv to ^8.6.0 ([#218](https://github.com/SocialGouv/mano/issues/218)) ([12172ae](https://github.com/SocialGouv/mano/commit/12172ae878d14983d6394af648c0c9fed8916f9f))
+- **deps:** update dependency dotenv to ^8.6.0 ([#218](https://github.com/SocialGouv/mano/issues/218)) ([12172ae](https://github.com/SocialGouv/mano/commit/12172ae878d14983d6394af648c0c9fed8916f9f))
 
 ## [1.39.1](https://github.com/SocialGouv/mano/compare/v1.39.0...v1.39.1) (2021-12-16)
 
-
 ### Bug Fixes
 
-* **deps:** update dependency @headlessui/react to ^1.4.2 ([#206](https://github.com/SocialGouv/mano/issues/206)) ([235b054](https://github.com/SocialGouv/mano/commit/235b0549822f235efcebd26f84f7226363dec5d2))
-* **deps:** update dependency bootstrap to ^4.6.1 ([#207](https://github.com/SocialGouv/mano/issues/207)) ([d465daf](https://github.com/SocialGouv/mano/commit/d465daf08726a9b31ae7f70129187f5b7f5df9b1))
+- **deps:** update dependency @headlessui/react to ^1.4.2 ([#206](https://github.com/SocialGouv/mano/issues/206)) ([235b054](https://github.com/SocialGouv/mano/commit/235b0549822f235efcebd26f84f7226363dec5d2))
+- **deps:** update dependency bootstrap to ^4.6.1 ([#207](https://github.com/SocialGouv/mano/issues/207)) ([d465daf](https://github.com/SocialGouv/mano/commit/d465daf08726a9b31ae7f70129187f5b7f5df9b1))
 
 # [1.39.0](https://github.com/SocialGouv/mano/compare/v1.38.1...v1.39.0) (2021-12-16)
 
-
 ### Features
 
-* **dashboard:** delete orga for superadmin ([#203](https://github.com/SocialGouv/mano/issues/203)) ([8327791](https://github.com/SocialGouv/mano/commit/832779191e1ae63e83ff08646837b7238b28a7ff))
+- **dashboard:** delete orga for superadmin ([#203](https://github.com/SocialGouv/mano/issues/203)) ([8327791](https://github.com/SocialGouv/mano/commit/832779191e1ae63e83ff08646837b7238b28a7ff))
 
 ## [1.38.1](https://github.com/SocialGouv/mano/compare/v1.38.0...v1.38.1) (2021-12-16)
 
-
 ### Bug Fixes
 
-* select territory from search tab ([d6e4de1](https://github.com/SocialGouv/mano/commit/d6e4de124ff132e2af06fab6f0dccedc908dfe09))
+- select territory from search tab ([d6e4de1](https://github.com/SocialGouv/mano/commit/d6e4de124ff132e2af06fab6f0dccedc908dfe09))
 
 # [1.38.0](https://github.com/SocialGouv/mano/compare/v1.37.1...v1.38.0) (2021-12-16)
 
-
 ### Features
 
-* **dashboard:** add custom fields in filters ([#202](https://github.com/SocialGouv/mano/issues/202)) ([7d83a3f](https://github.com/SocialGouv/mano/commit/7d83a3f18ab9284d1a0138c27e2242f57051dff3))
+- **dashboard:** add custom fields in filters ([#202](https://github.com/SocialGouv/mano/issues/202)) ([7d83a3f](https://github.com/SocialGouv/mano/commit/7d83a3f18ab9284d1a0138c27e2242f57051dff3))
 
 ## [1.37.1](https://github.com/SocialGouv/mano/compare/v1.37.0...v1.37.1) (2021-12-14)
 
-
 ### Bug Fixes
 
-* **dashboard:** 2 stats repeated twice ([#201](https://github.com/SocialGouv/mano/issues/201)) ([7bcc3fd](https://github.com/SocialGouv/mano/commit/7bcc3fd6b7c908b1d49c172f813cffa6c872bf8c))
+- **dashboard:** 2 stats repeated twice ([#201](https://github.com/SocialGouv/mano/issues/201)) ([7bcc3fd](https://github.com/SocialGouv/mano/commit/7bcc3fd6b7c908b1d49c172f813cffa6c872bf8c))
 
 # [1.37.0](https://github.com/SocialGouv/mano/compare/v1.36.7...v1.37.0) (2021-12-14)
 
-
 ### Bug Fixes
 
-* **api:** fix logout in production ([#200](https://github.com/SocialGouv/mano/issues/200)) ([fde016e](https://github.com/SocialGouv/mano/commit/fde016e094e8bf9e6e18a50b8708927ace818ac4))
-* **dashboard:** filterable fields person ([#199](https://github.com/SocialGouv/mano/issues/199)) ([f8116f1](https://github.com/SocialGouv/mano/commit/f8116f1224a2f2e2fdf0c4717cc6f519b0d3f2dc))
-
+- **api:** fix logout in production ([#200](https://github.com/SocialGouv/mano/issues/200)) ([fde016e](https://github.com/SocialGouv/mano/commit/fde016e094e8bf9e6e18a50b8708927ace818ac4))
+- **dashboard:** filterable fields person ([#199](https://github.com/SocialGouv/mano/issues/199)) ([f8116f1](https://github.com/SocialGouv/mano/commit/f8116f1224a2f2e2fdf0c4717cc6f519b0d3f2dc))
 
 ### Features
 
-* **dashboard:** stats orga and team ([#198](https://github.com/SocialGouv/mano/issues/198)) ([cea0d1c](https://github.com/SocialGouv/mano/commit/cea0d1c571450d803f0f9fbfbd2777acd0581170))
+- **dashboard:** stats orga and team ([#198](https://github.com/SocialGouv/mano/issues/198)) ([cea0d1c](https://github.com/SocialGouv/mano/commit/cea0d1c571450d803f0f9fbfbd2777acd0581170))
 
 ## [1.36.7](https://github.com/SocialGouv/mano/compare/v1.36.6...v1.36.7) (2021-12-13)
 
-
 ### Bug Fixes
 
-* **secu:** add k8s network policies and update snaps ([#188](https://github.com/SocialGouv/mano/issues/188)) ([413e043](https://github.com/SocialGouv/mano/commit/413e0431ae948c0eabb1e392df3ad5fc03652471))
+- **secu:** add k8s network policies and update snaps ([#188](https://github.com/SocialGouv/mano/issues/188)) ([413e043](https://github.com/SocialGouv/mano/commit/413e0431ae948c0eabb1e392df3ad5fc03652471))
 
 ## [1.36.6](https://github.com/SocialGouv/mano/compare/v1.36.5...v1.36.6) (2021-12-13)
 
-
 ### Bug Fixes
 
-* **api,dashboard:** setting encryptedVerificationKey for non admin ([#197](https://github.com/SocialGouv/mano/issues/197)) ([6406ada](https://github.com/SocialGouv/mano/commit/6406ada735983caf0c5c849914258426ef0ea77f))
+- **api,dashboard:** setting encryptedVerificationKey for non admin ([#197](https://github.com/SocialGouv/mano/issues/197)) ([6406ada](https://github.com/SocialGouv/mano/commit/6406ada735983caf0c5c849914258426ef0ea77f))
 
 ## [1.36.5](https://github.com/SocialGouv/mano/compare/v1.36.4...v1.36.5) (2021-12-13)
 
-
 ### Bug Fixes
 
-* upgrade metabase ([#196](https://github.com/SocialGouv/mano/issues/196)) ([677fb6a](https://github.com/SocialGouv/mano/commit/677fb6acf3d5f4b108a39a0d20dd1bc1f89ee8aa))
+- upgrade metabase ([#196](https://github.com/SocialGouv/mano/issues/196)) ([677fb6a](https://github.com/SocialGouv/mano/commit/677fb6acf3d5f4b108a39a0d20dd1bc1f89ee8aa))
 
 ## [1.36.4](https://github.com/SocialGouv/mano/compare/v1.36.3...v1.36.4) (2021-12-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** clean api in dashboard ([#173](https://github.com/SocialGouv/mano/issues/173)) ([fb724e6](https://github.com/SocialGouv/mano/commit/fb724e61b8afc5f23d9b6af6a02fa7ff8fe783ca))
+- **dashboard:** clean api in dashboard ([#173](https://github.com/SocialGouv/mano/issues/173)) ([fb724e6](https://github.com/SocialGouv/mano/commit/fb724e61b8afc5f23d9b6af6a02fa7ff8fe783ca))
 
 ## [1.36.3](https://github.com/SocialGouv/mano/compare/v1.36.2...v1.36.3) (2021-12-10)
 
-
 ### Bug Fixes
 
-* **api:** remove migration script for passages ([#195](https://github.com/SocialGouv/mano/issues/195)) ([c346215](https://github.com/SocialGouv/mano/commit/c346215bd08c5a7860de22141a2b28c4baad1101))
+- **api:** remove migration script for passages ([#195](https://github.com/SocialGouv/mano/issues/195)) ([c346215](https://github.com/SocialGouv/mano/commit/c346215bd08c5a7860de22141a2b28c4baad1101))
 
 ## [1.36.2](https://github.com/SocialGouv/mano/compare/v1.36.1...v1.36.2) (2021-12-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** passages ([#177](https://github.com/SocialGouv/mano/issues/177)) ([c0bb89d](https://github.com/SocialGouv/mano/commit/c0bb89dccc25edce2b05e8d60c73627437612653))
+- **dashboard:** passages ([#177](https://github.com/SocialGouv/mano/issues/177)) ([c0bb89d](https://github.com/SocialGouv/mano/commit/c0bb89dccc25edce2b05e8d60c73627437612653))
 
 ## [1.36.1](https://github.com/SocialGouv/mano/compare/v1.36.0...v1.36.1) (2021-12-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** organisationEncryptionKey can also be setup by non-admin ([#191](https://github.com/SocialGouv/mano/issues/191)) ([e71cfec](https://github.com/SocialGouv/mano/commit/e71cfece5d57068d1b0e052088fd9b971a76d763))
+- **dashboard:** organisationEncryptionKey can also be setup by non-admin ([#191](https://github.com/SocialGouv/mano/issues/191)) ([e71cfec](https://github.com/SocialGouv/mano/commit/e71cfece5d57068d1b0e052088fd9b971a76d763))
 
 # [1.36.0](https://github.com/SocialGouv/mano/compare/v1.35.0...v1.36.0) (2021-12-10)
 
-
 ### Features
 
-* **dashboard:** reset recoil on organisation change ([#194](https://github.com/SocialGouv/mano/issues/194)) ([507549d](https://github.com/SocialGouv/mano/commit/507549df8a9b15a5b24b85fa5d121d387d02dfe6))
+- **dashboard:** reset recoil on organisation change ([#194](https://github.com/SocialGouv/mano/issues/194)) ([507549d](https://github.com/SocialGouv/mano/commit/507549df8a9b15a5b24b85fa5d121d387d02dfe6))
 
 # [1.35.0](https://github.com/SocialGouv/mano/compare/v1.34.2...v1.35.0) (2021-12-10)
 
-
 ### Features
 
-* **dashboard:** import custom fields ([#187](https://github.com/SocialGouv/mano/issues/187)) ([cbaccc6](https://github.com/SocialGouv/mano/commit/cbaccc6d8d0a6738001d748ccecdc3bfb60a9a23))
+- **dashboard:** import custom fields ([#187](https://github.com/SocialGouv/mano/issues/187)) ([cbaccc6](https://github.com/SocialGouv/mano/commit/cbaccc6d8d0a6738001d748ccecdc3bfb60a9a23))
 
 ## [1.34.2](https://github.com/SocialGouv/mano/compare/v1.34.1...v1.34.2) (2021-12-10)
 
-
 ### Bug Fixes
 
-* **dashboard:** on chart click do nothing when nothing to do ([#192](https://github.com/SocialGouv/mano/issues/192)) ([9ef8d0f](https://github.com/SocialGouv/mano/commit/9ef8d0f28551f3b0ecac497ddf4ddb944e9bf579))
+- **dashboard:** on chart click do nothing when nothing to do ([#192](https://github.com/SocialGouv/mano/issues/192)) ([9ef8d0f](https://github.com/SocialGouv/mano/commit/9ef8d0f28551f3b0ecac497ddf4ddb944e9bf579))
 
 ## [1.34.1](https://github.com/SocialGouv/mano/compare/v1.34.0...v1.34.1) (2021-12-10)
 
-
 ### Bug Fixes
 
-* **api:** remove migration script for reports ([#190](https://github.com/SocialGouv/mano/issues/190)) ([300f58c](https://github.com/SocialGouv/mano/commit/300f58c08c6808e71c82d94cb47a107bad17fe35))
+- **api:** remove migration script for reports ([#190](https://github.com/SocialGouv/mano/issues/190)) ([300f58c](https://github.com/SocialGouv/mano/commit/300f58c08c6808e71c82d94cb47a107bad17fe35))
 
 # [1.34.0](https://github.com/SocialGouv/mano/compare/v1.33.1...v1.34.0) (2021-12-07)
 
-
 ### Features
 
-* add new medical default fields ([#186](https://github.com/SocialGouv/mano/issues/186)) ([ffac343](https://github.com/SocialGouv/mano/commit/ffac34324557ff1336f4119245815f0bf99711e5))
+- add new medical default fields ([#186](https://github.com/SocialGouv/mano/issues/186)) ([ffac343](https://github.com/SocialGouv/mano/commit/ffac34324557ff1336f4119245815f0bf99711e5))
 
 ## [1.33.1](https://github.com/SocialGouv/mano/compare/v1.33.0...v1.33.1) (2021-12-07)
 
-
 ### Bug Fixes
 
-* **dashboard:** invalid attempt to spread non-iterable instance ([eb983b0](https://github.com/SocialGouv/mano/commit/eb983b056f152a1e70487c3ece0f0dd2d0f3609b))
+- **dashboard:** invalid attempt to spread non-iterable instance ([eb983b0](https://github.com/SocialGouv/mano/commit/eb983b056f152a1e70487c3ece0f0dd2d0f3609b))
 
 # [1.33.0](https://github.com/SocialGouv/mano/compare/v1.32.2...v1.33.0) (2021-12-06)
 
-
 ### Features
 
-* **dashboard,api:** import xlsx ([#178](https://github.com/SocialGouv/mano/issues/178)) ([0c8cb4a](https://github.com/SocialGouv/mano/commit/0c8cb4a9911b68517b8f76fbfa2e708010080a78))
+- **dashboard,api:** import xlsx ([#178](https://github.com/SocialGouv/mano/issues/178)) ([0c8cb4a](https://github.com/SocialGouv/mano/commit/0c8cb4a9911b68517b8f76fbfa2e708010080a78))
 
 ## [1.32.2](https://github.com/SocialGouv/mano/compare/v1.32.1...v1.32.2) (2021-12-03)
 
-
 ### Bug Fixes
 
-* **api:** migration on reports ([#184](https://github.com/SocialGouv/mano/issues/184)) ([f32db49](https://github.com/SocialGouv/mano/commit/f32db494f5119739079cadbd1fd95e0ddfa13dee))
+- **api:** migration on reports ([#184](https://github.com/SocialGouv/mano/issues/184)) ([f32db49](https://github.com/SocialGouv/mano/commit/f32db494f5119739079cadbd1fd95e0ddfa13dee))
 
 ## [1.32.1](https://github.com/SocialGouv/mano/compare/v1.32.0...v1.32.1) (2021-12-03)
 
-
 ### Bug Fixes
 
-* **api:** stop creating multiple reports ([#183](https://github.com/SocialGouv/mano/issues/183)) ([da6d27a](https://github.com/SocialGouv/mano/commit/da6d27aae2382508c4d0dda54a733c0da9eb297c))
+- **api:** stop creating multiple reports ([#183](https://github.com/SocialGouv/mano/issues/183)) ([da6d27a](https://github.com/SocialGouv/mano/commit/da6d27aae2382508c4d0dda54a733c0da9eb297c))
 
 # [1.32.0](https://github.com/SocialGouv/mano/compare/v1.31.0...v1.32.0) (2021-12-03)
 
-
 ### Features
 
-* release mobile app version ([9bc3c8d](https://github.com/SocialGouv/mano/commit/9bc3c8d2e32d516d7ca1ca82d604bfd982bbe5aa))
+- release mobile app version ([9bc3c8d](https://github.com/SocialGouv/mano/commit/9bc3c8d2e32d516d7ca1ca82d604bfd982bbe5aa))
 
 # [1.31.0](https://github.com/SocialGouv/mano/compare/v1.30.1...v1.31.0) (2021-12-03)
 
-
 ### Features
 
-* custom fields on persons ([#171](https://github.com/SocialGouv/mano/issues/171)) ([71c06d4](https://github.com/SocialGouv/mano/commit/71c06d4204cd45c99a5d51d1a6a0725a43cb77bb))
+- custom fields on persons ([#171](https://github.com/SocialGouv/mano/issues/171)) ([71c06d4](https://github.com/SocialGouv/mano/commit/71c06d4204cd45c99a5d51d1a6a0725a43cb77bb))
 
 ## [1.30.1](https://github.com/SocialGouv/mano/compare/v1.30.0...v1.30.1) (2021-12-03)
 
-
 ### Bug Fixes
 
-* **dashboard:** debug encryption ([#182](https://github.com/SocialGouv/mano/issues/182)) ([a999891](https://github.com/SocialGouv/mano/commit/a999891b416f798d2fed5c45694fca46270a8125))
+- **dashboard:** debug encryption ([#182](https://github.com/SocialGouv/mano/issues/182)) ([a999891](https://github.com/SocialGouv/mano/commit/a999891b416f798d2fed5c45694fca46270a8125))
 
 # [1.30.0](https://github.com/SocialGouv/mano/compare/v1.29.7...v1.30.0) (2021-12-03)
 
-
 ### Features
 
-* **dashboard:** debug encryption ([#181](https://github.com/SocialGouv/mano/issues/181)) ([acef89c](https://github.com/SocialGouv/mano/commit/acef89cbc61f6d5a895e46d0caac5262d45fed5a))
+- **dashboard:** debug encryption ([#181](https://github.com/SocialGouv/mano/issues/181)) ([acef89c](https://github.com/SocialGouv/mano/commit/acef89cbc61f6d5a895e46d0caac5262d45fed5a))
 
 ## [1.29.7](https://github.com/SocialGouv/mano/compare/v1.29.6...v1.29.7) (2021-12-03)
 
-
 ### Bug Fixes
 
-* **api,dashboard:** change sentry url ([#180](https://github.com/SocialGouv/mano/issues/180)) ([41dce39](https://github.com/SocialGouv/mano/commit/41dce39d3cb4cf0b295a34b82cec72f18b694d38))
+- **api,dashboard:** change sentry url ([#180](https://github.com/SocialGouv/mano/issues/180)) ([41dce39](https://github.com/SocialGouv/mano/commit/41dce39d3cb4cf0b295a34b82cec72f18b694d38))
 
 ## [1.29.6](https://github.com/SocialGouv/mano/compare/v1.29.5...v1.29.6) (2021-12-01)
 
-
 ### Bug Fixes
 
-* **dashboard:** can edit choices in multi-choices field ([#175](https://github.com/SocialGouv/mano/issues/175)) ([136e65a](https://github.com/SocialGouv/mano/commit/136e65a9431a84b21c9b386b00ed9079dc089cd0))
+- **dashboard:** can edit choices in multi-choices field ([#175](https://github.com/SocialGouv/mano/issues/175)) ([136e65a](https://github.com/SocialGouv/mano/commit/136e65a9431a84b21c9b386b00ed9079dc089cd0))
 
 ## [1.29.5](https://github.com/SocialGouv/mano/compare/v1.29.4...v1.29.5) (2021-11-29)
 
-
 ### Bug Fixes
 
-* **dashboard:** actions in reception ([#172](https://github.com/SocialGouv/mano/issues/172)) ([038575f](https://github.com/SocialGouv/mano/commit/038575f90be5cec31e5b369d5e2f01ec750586ac))
+- **dashboard:** actions in reception ([#172](https://github.com/SocialGouv/mano/issues/172)) ([038575f](https://github.com/SocialGouv/mano/commit/038575f90be5cec31e5b369d5e2f01ec750586ac))
 
 ## [1.29.4](https://github.com/SocialGouv/mano/compare/v1.29.3...v1.29.4) (2021-11-26)
 
-
 ### Bug Fixes
 
-* remove retrocompatibility for json observation custom fields ([725bc73](https://github.com/SocialGouv/mano/commit/725bc7314846ec2fc4f1f16220ad233d72307dff))
+- remove retrocompatibility for json observation custom fields ([725bc73](https://github.com/SocialGouv/mano/commit/725bc7314846ec2fc4f1f16220ad233d72307dff))
 
 ## [1.29.3](https://github.com/SocialGouv/mano/compare/v1.29.2...v1.29.3) (2021-11-25)
 
-
 ### Bug Fixes
 
-* **dashboard:** structure modification ([#170](https://github.com/SocialGouv/mano/issues/170)) ([1521127](https://github.com/SocialGouv/mano/commit/1521127edc734daa53a66577f791190aaf549782))
-* **dashboard:** team selector for action ([#169](https://github.com/SocialGouv/mano/issues/169)) ([09f0f0a](https://github.com/SocialGouv/mano/commit/09f0f0a9934c3a1f05130d25268fbd23555746c4))
+- **dashboard:** structure modification ([#170](https://github.com/SocialGouv/mano/issues/170)) ([1521127](https://github.com/SocialGouv/mano/commit/1521127edc734daa53a66577f791190aaf549782))
+- **dashboard:** team selector for action ([#169](https://github.com/SocialGouv/mano/issues/169)) ([09f0f0a](https://github.com/SocialGouv/mano/commit/09f0f0a9934c3a1f05130d25268fbd23555746c4))
 
 ## [1.29.2](https://github.com/SocialGouv/mano/compare/v1.29.1...v1.29.2) (2021-11-25)
 
-
 ### Bug Fixes
 
-* end 2 end timeout ([b2a9a9f](https://github.com/SocialGouv/mano/commit/b2a9a9fb1e384b6c0abd2607454a720f27dc6ce8))
+- end 2 end timeout ([b2a9a9f](https://github.com/SocialGouv/mano/commit/b2a9a9fb1e384b6c0abd2607454a720f27dc6ce8))
 
 ## [1.29.1](https://github.com/SocialGouv/mano/compare/v1.29.0...v1.29.1) (2021-11-25)
 
-
 ### Bug Fixes
 
-* **dashboard:** try more fetch if fail ([#166](https://github.com/SocialGouv/mano/issues/166)) ([cada9d4](https://github.com/SocialGouv/mano/commit/cada9d422f337ecdfab22032d744cb1cfc77d468))
+- **dashboard:** try more fetch if fail ([#166](https://github.com/SocialGouv/mano/issues/166)) ([cada9d4](https://github.com/SocialGouv/mano/commit/cada9d422f337ecdfab22032d744cb1cfc77d468))
 
 # [1.29.0](https://github.com/SocialGouv/mano/compare/v1.28.12...v1.29.0) (2021-11-23)
 
-
 ### Features
 
-* end to end tests ([#164](https://github.com/SocialGouv/mano/issues/164)) ([7de5040](https://github.com/SocialGouv/mano/commit/7de50405ebb06d9f0f3bf8b8fdd7c3673e6cbf8d))
+- end to end tests ([#164](https://github.com/SocialGouv/mano/issues/164)) ([7de5040](https://github.com/SocialGouv/mano/commit/7de50405ebb06d9f0f3bf8b8fdd7c3673e6cbf8d))
 
 ## [1.28.12](https://github.com/SocialGouv/mano/compare/v1.28.11...v1.28.12) (2021-11-23)
 
-
 ### Bug Fixes
 
-* **dashboard:** error when no options in list ([bed207e](https://github.com/SocialGouv/mano/commit/bed207edce2ef2c5ebd5be90ebd981f1204e0cc7))
+- **dashboard:** error when no options in list ([bed207e](https://github.com/SocialGouv/mano/commit/bed207edce2ef2c5ebd5be90ebd981f1204e0cc7))
 
 ## [1.28.11](https://github.com/SocialGouv/mano/compare/v1.28.10...v1.28.11) (2021-11-19)
 
-
 ### Bug Fixes
 
-* **dashboard:** login with no encryptionValidationKey ([#167](https://github.com/SocialGouv/mano/issues/167)) ([14cfad1](https://github.com/SocialGouv/mano/commit/14cfad18d868551b4f4fd751e75ffca4ef0402e4))
+- **dashboard:** login with no encryptionValidationKey ([#167](https://github.com/SocialGouv/mano/issues/167)) ([14cfad1](https://github.com/SocialGouv/mano/commit/14cfad18d868551b4f4fd751e75ffca4ef0402e4))
 
 ## [1.28.10](https://github.com/SocialGouv/mano/compare/v1.28.9...v1.28.10) (2021-11-19)
 
-
 ### Bug Fixes
 
-* **dashboard:** hashedOrgEncryptionKey === null even after setting good key ([#165](https://github.com/SocialGouv/mano/issues/165)) ([dac4e6c](https://github.com/SocialGouv/mano/commit/dac4e6c452502d4ed908cf0b4b67c292bd4ab931))
+- **dashboard:** hashedOrgEncryptionKey === null even after setting good key ([#165](https://github.com/SocialGouv/mano/issues/165)) ([dac4e6c](https://github.com/SocialGouv/mano/commit/dac4e6c452502d4ed908cf0b4b67c292bd4ab931))
 
 ## [1.28.9](https://github.com/SocialGouv/mano/compare/v1.28.8...v1.28.9) (2021-11-18)
 
-
 ### Bug Fixes
 
-* **dashboard:** encryption verification ([#163](https://github.com/SocialGouv/mano/issues/163)) ([8049741](https://github.com/SocialGouv/mano/commit/8049741bb0b899db70c983e5b6f4df76d58fc567))
+- **dashboard:** encryption verification ([#163](https://github.com/SocialGouv/mano/issues/163)) ([8049741](https://github.com/SocialGouv/mano/commit/8049741bb0b899db70c983e5b6f4df76d58fc567))
 
 ## [1.28.8](https://github.com/SocialGouv/mano/compare/v1.28.7...v1.28.8) (2021-11-16)
 
-
 ### Bug Fixes
 
-* **dashboard:** encryption ([#162](https://github.com/SocialGouv/mano/issues/162)) ([762b597](https://github.com/SocialGouv/mano/commit/762b5973e88efdab0575a358b349d3579b545b6c))
+- **dashboard:** encryption ([#162](https://github.com/SocialGouv/mano/issues/162)) ([762b597](https://github.com/SocialGouv/mano/commit/762b5973e88efdab0575a358b349d3579b545b6c))
 
 ## [1.28.7](https://github.com/SocialGouv/mano/compare/v1.28.6...v1.28.7) (2021-11-16)
 
-
 ### Bug Fixes
 
-* fix observation as JSON ([#161](https://github.com/SocialGouv/mano/issues/161)) ([412948c](https://github.com/SocialGouv/mano/commit/412948c16260581bcb50bc07520bbc48a0aaa597))
+- fix observation as JSON ([#161](https://github.com/SocialGouv/mano/issues/161)) ([412948c](https://github.com/SocialGouv/mano/commit/412948c16260581bcb50bc07520bbc48a0aaa597))
 
 ## [1.28.6](https://github.com/SocialGouv/mano/compare/v1.28.5...v1.28.6) (2021-11-16)
 
-
 ### Bug Fixes
 
-* customFields as object not string ([#158](https://github.com/SocialGouv/mano/issues/158)) ([55db0aa](https://github.com/SocialGouv/mano/commit/55db0aaa7aebf99a1fbc15563918ead97239e124))
+- customFields as object not string ([#158](https://github.com/SocialGouv/mano/issues/158)) ([55db0aa](https://github.com/SocialGouv/mano/commit/55db0aaa7aebf99a1fbc15563918ead97239e124))
 
 ## [1.28.5](https://github.com/SocialGouv/mano/compare/v1.28.4...v1.28.5) (2021-11-16)
 
-
 ### Bug Fixes
 
-* **dashboard:** action list filtered ([#160](https://github.com/SocialGouv/mano/issues/160)) ([6883fed](https://github.com/SocialGouv/mano/commit/6883fedd0a6c4040d7b6f1c713773daa0c429a33))
+- **dashboard:** action list filtered ([#160](https://github.com/SocialGouv/mano/issues/160)) ([6883fed](https://github.com/SocialGouv/mano/commit/6883fedd0a6c4040d7b6f1c713773daa0c429a33))
 
 ## [1.28.4](https://github.com/SocialGouv/mano/compare/v1.28.3...v1.28.4) (2021-11-16)
 
-
 ### Bug Fixes
 
-* trigger release ([d063ee2](https://github.com/SocialGouv/mano/commit/d063ee2a8428ce46020fa6e9fa7c9a08a5e1af1d))
+- trigger release ([d063ee2](https://github.com/SocialGouv/mano/commit/d063ee2a8428ce46020fa6e9fa7c9a08a5e1af1d))
 
 ## [1.28.3](https://github.com/SocialGouv/mano/compare/v1.28.2...v1.28.3) (2021-11-15)
 
-
 ### Bug Fixes
 
-* fix org key ([#159](https://github.com/SocialGouv/mano/issues/159)) ([e6de84f](https://github.com/SocialGouv/mano/commit/e6de84fd51ff5b55e376d323f797c54e57fca7d3))
+- fix org key ([#159](https://github.com/SocialGouv/mano/issues/159)) ([e6de84f](https://github.com/SocialGouv/mano/commit/e6de84fd51ff5b55e376d323f797c54e57fca7d3))
 
 ## [1.28.2](https://github.com/SocialGouv/mano/compare/v1.28.1...v1.28.2) (2021-11-12)
 
-
 ### Bug Fixes
 
-* **api:** send default error to user ([#146](https://github.com/SocialGouv/mano/issues/146)) ([f06d450](https://github.com/SocialGouv/mano/commit/f06d4502e2b77cdabac17b1c37453edcef8f8dbf))
+- **api:** send default error to user ([#146](https://github.com/SocialGouv/mano/issues/146)) ([f06d450](https://github.com/SocialGouv/mano/commit/f06d4502e2b77cdabac17b1c37453edcef8f8dbf))
 
 ## [1.28.1](https://github.com/SocialGouv/mano/compare/v1.28.0...v1.28.1) (2021-11-12)
 
-
 ### Bug Fixes
 
-* **dashboard:** slow search ([#157](https://github.com/SocialGouv/mano/issues/157)) ([b07912c](https://github.com/SocialGouv/mano/commit/b07912c1e41b3be6c3a76fa5d37d55c9c6c3a37c))
+- **dashboard:** slow search ([#157](https://github.com/SocialGouv/mano/issues/157)) ([b07912c](https://github.com/SocialGouv/mano/commit/b07912c1e41b3be6c3a76fa5d37d55c9c6c3a37c))
 
 # [1.28.0](https://github.com/SocialGouv/mano/compare/v1.27.6...v1.28.0) (2021-11-12)
 
-
 ### Features
 
-* **dashboard:** select team on action update ([#155](https://github.com/SocialGouv/mano/issues/155)) ([e621450](https://github.com/SocialGouv/mano/commit/e6214508d78b7b1eb32ac1a9201e0e42b0ff48b5))
+- **dashboard:** select team on action update ([#155](https://github.com/SocialGouv/mano/issues/155)) ([e621450](https://github.com/SocialGouv/mano/commit/e6214508d78b7b1eb32ac1a9201e0e42b0ff48b5))
 
 ## [1.27.6](https://github.com/SocialGouv/mano/compare/v1.27.5...v1.27.6) (2021-11-12)
 
-
 ### Bug Fixes
 
-* **dashboard:** state management with recoil ([#150](https://github.com/SocialGouv/mano/issues/150)) ([967a66a](https://github.com/SocialGouv/mano/commit/967a66acfdac8b53050542690ffb74cda3276b27))
+- **dashboard:** state management with recoil ([#150](https://github.com/SocialGouv/mano/issues/150)) ([967a66a](https://github.com/SocialGouv/mano/commit/967a66acfdac8b53050542690ffb74cda3276b27))
 
 ## [1.27.5](https://github.com/SocialGouv/mano/compare/v1.27.4...v1.27.5) (2021-11-12)
 
-
 ### Bug Fixes
 
-* **api:** fixes passwords flow (reset, change, etc.) ([#156](https://github.com/SocialGouv/mano/issues/156)) ([09666ef](https://github.com/SocialGouv/mano/commit/09666efcfaa2b2a2cdd529d6361bd49cecda6785))
+- **api:** fixes passwords flow (reset, change, etc.) ([#156](https://github.com/SocialGouv/mano/issues/156)) ([09666ef](https://github.com/SocialGouv/mano/commit/09666efcfaa2b2a2cdd529d6361bd49cecda6785))
 
 ## [1.27.4](https://github.com/SocialGouv/mano/compare/v1.27.3...v1.27.4) (2021-11-11)
 
-
 ### Bug Fixes
 
-* **api:** exclude sensitive data from user response ([#147](https://github.com/SocialGouv/mano/issues/147)) ([f7b8295](https://github.com/SocialGouv/mano/commit/f7b8295bd6378ab858fd83c3d4fefb192a320c6e))
+- **api:** exclude sensitive data from user response ([#147](https://github.com/SocialGouv/mano/issues/147)) ([f7b8295](https://github.com/SocialGouv/mano/commit/f7b8295bd6378ab858fd83c3d4fefb192a320c6e))
 
 ## [1.27.3](https://github.com/SocialGouv/mano/compare/v1.27.2...v1.27.3) (2021-11-11)
 
-
 ### Bug Fixes
 
-* **dashboard:** description linebreaks + prevent XSS ([#152](https://github.com/SocialGouv/mano/issues/152)) ([e247d57](https://github.com/SocialGouv/mano/commit/e247d577e17bbf8f3a9d17a3fb4fa49f5ddda9f2))
+- **dashboard:** description linebreaks + prevent XSS ([#152](https://github.com/SocialGouv/mano/issues/152)) ([e247d57](https://github.com/SocialGouv/mano/commit/e247d577e17bbf8f3a9d17a3fb4fa49f5ddda9f2))
 
 ## [1.27.2](https://github.com/SocialGouv/mano/compare/v1.27.1...v1.27.2) (2021-11-11)
 
-
 ### Bug Fixes
 
-* **dashboard:** e is not defined in createaction ([#154](https://github.com/SocialGouv/mano/issues/154)) ([e60b1c7](https://github.com/SocialGouv/mano/commit/e60b1c7fd0d034356d1d6eb985f6337497bef74f))
+- **dashboard:** e is not defined in createaction ([#154](https://github.com/SocialGouv/mano/issues/154)) ([e60b1c7](https://github.com/SocialGouv/mano/commit/e60b1c7fd0d034356d1d6eb985f6337497bef74f))
 
 ## [1.27.1](https://github.com/SocialGouv/mano/compare/v1.27.0...v1.27.1) (2021-11-10)
 
-
 ### Bug Fixes
 
-* **api:** clean ([#151](https://github.com/SocialGouv/mano/issues/151)) ([3a58997](https://github.com/SocialGouv/mano/commit/3a5899734d7b1e12f230613d2c901c1349ce867e))
+- **api:** clean ([#151](https://github.com/SocialGouv/mano/issues/151)) ([3a58997](https://github.com/SocialGouv/mano/commit/3a5899734d7b1e12f230613d2c901c1349ce867e))
 
 # [1.27.0](https://github.com/SocialGouv/mano/compare/v1.26.1...v1.27.0) (2021-11-08)
 
-
 ### Features
 
-* **dashboard:** stats for passages + services ([#149](https://github.com/SocialGouv/mano/issues/149)) ([c408764](https://github.com/SocialGouv/mano/commit/c408764432e612c6fdc06a427c2d517d90b144df))
+- **dashboard:** stats for passages + services ([#149](https://github.com/SocialGouv/mano/issues/149)) ([c408764](https://github.com/SocialGouv/mano/commit/c408764432e612c6fdc06a427c2d517d90b144df))
 
 ## [1.26.1](https://github.com/SocialGouv/mano/compare/v1.26.0...v1.26.1) (2021-11-08)
 
-
 ### Bug Fixes
 
-* **api:** current user in person when no user registered ([#145](https://github.com/SocialGouv/mano/issues/145)) ([14f3146](https://github.com/SocialGouv/mano/commit/14f3146adc71a546d5ba25079c0401a2a4bf4253))
+- **api:** current user in person when no user registered ([#145](https://github.com/SocialGouv/mano/issues/145)) ([14f3146](https://github.com/SocialGouv/mano/commit/14f3146adc71a546d5ba25079c0401a2a4bf4253))
 
 # [1.26.0](https://github.com/SocialGouv/mano/compare/v1.25.0...v1.26.0) (2021-11-08)
 
-
 ### Features
 
-* **dashboard:** enhance stats - new filters - click on pie to filter ([#140](https://github.com/SocialGouv/mano/issues/140)) ([c8be85a](https://github.com/SocialGouv/mano/commit/c8be85a7bed5f679ea09ced428254731608826f5))
+- **dashboard:** enhance stats - new filters - click on pie to filter ([#140](https://github.com/SocialGouv/mano/issues/140)) ([c8be85a](https://github.com/SocialGouv/mano/commit/c8be85a7bed5f679ea09ced428254731608826f5))
 
 # [1.25.0](https://github.com/SocialGouv/mano/compare/v1.24.6...v1.25.0) (2021-11-08)
 
-
 ### Features
 
-* **app,dashboard:** fetch-retry to prevent network error ([#144](https://github.com/SocialGouv/mano/issues/144)) ([06f8ff1](https://github.com/SocialGouv/mano/commit/06f8ff176ad97a85485695eeb203b79c4398c086))
+- **app,dashboard:** fetch-retry to prevent network error ([#144](https://github.com/SocialGouv/mano/issues/144)) ([06f8ff1](https://github.com/SocialGouv/mano/commit/06f8ff176ad97a85485695eeb203b79c4398c086))
 
 ## [1.24.6](https://github.com/SocialGouv/mano/compare/v1.24.5...v1.24.6) (2021-11-08)
 
-
 ### Bug Fixes
 
-* **website:** nathan instead of maxime ([#143](https://github.com/SocialGouv/mano/issues/143)) ([6408ab8](https://github.com/SocialGouv/mano/commit/6408ab86d74a563b69e622272a31a457019ce228))
+- **website:** nathan instead of maxime ([#143](https://github.com/SocialGouv/mano/issues/143)) ([6408ab8](https://github.com/SocialGouv/mano/commit/6408ab86d74a563b69e622272a31a457019ce228))
 
 ## [1.24.5](https://github.com/SocialGouv/mano/compare/v1.24.4...v1.24.5) (2021-11-08)
 
-
 ### Bug Fixes
 
-* **dashboard:** set encryption verification key only for encrypted organisations ([#142](https://github.com/SocialGouv/mano/issues/142)) ([05c886e](https://github.com/SocialGouv/mano/commit/05c886e2ab7a2aee3ef1d2e7261f563b6070f945))
+- **dashboard:** set encryption verification key only for encrypted organisations ([#142](https://github.com/SocialGouv/mano/issues/142)) ([05c886e](https://github.com/SocialGouv/mano/commit/05c886e2ab7a2aee3ef1d2e7261f563b6070f945))
 
 ## [1.24.4](https://github.com/SocialGouv/mano/compare/v1.24.3...v1.24.4) (2021-11-05)
 
-
 ### Bug Fixes
 
-* **app,api:** upgrade app version ([#139](https://github.com/SocialGouv/mano/issues/139)) ([61858ea](https://github.com/SocialGouv/mano/commit/61858ea54a07e99dd743b2a570e467756c6f5b4d))
+- **app,api:** upgrade app version ([#139](https://github.com/SocialGouv/mano/issues/139)) ([61858ea](https://github.com/SocialGouv/mano/commit/61858ea54a07e99dd743b2a570e467756c6f5b4d))
 
 ## [1.24.3](https://github.com/SocialGouv/mano/compare/v1.24.2...v1.24.3) (2021-11-05)
 
-
 ### Bug Fixes
 
-* **website:** email nathan ([#141](https://github.com/SocialGouv/mano/issues/141)) ([77b4c8e](https://github.com/SocialGouv/mano/commit/77b4c8e83914d5c0bddf111a4d502bbeb4189d80))
+- **website:** email nathan ([#141](https://github.com/SocialGouv/mano/issues/141)) ([77b4c8e](https://github.com/SocialGouv/mano/commit/77b4c8e83914d5c0bddf111a4d502bbeb4189d80))
 
 ## [1.24.2](https://github.com/SocialGouv/mano/compare/v1.24.1...v1.24.2) (2021-11-05)
 
-
 ### Bug Fixes
 
-* **dashboard:** encrypted field at the end of the file ([#138](https://github.com/SocialGouv/mano/issues/138)) ([1491a29](https://github.com/SocialGouv/mano/commit/1491a292b8ae2680f9703352903efd48057f3938))
-* **dashboard:** fix utc problem for display date ([#133](https://github.com/SocialGouv/mano/issues/133)) ([b2d108a](https://github.com/SocialGouv/mano/commit/b2d108a766e6d9c57e1fc09f1e3ba92c3edae747))
+- **dashboard:** encrypted field at the end of the file ([#138](https://github.com/SocialGouv/mano/issues/138)) ([1491a29](https://github.com/SocialGouv/mano/commit/1491a292b8ae2680f9703352903efd48057f3938))
+- **dashboard:** fix utc problem for display date ([#133](https://github.com/SocialGouv/mano/issues/133)) ([b2d108a](https://github.com/SocialGouv/mano/commit/b2d108a766e6d9c57e1fc09f1e3ba92c3edae747))
 
 ## [1.24.1](https://github.com/SocialGouv/mano/compare/v1.24.0...v1.24.1) (2021-11-05)
 
-
 ### Bug Fixes
 
-* **api,dashboard:** multiple collaborations ([#135](https://github.com/SocialGouv/mano/issues/135)) ([66f6946](https://github.com/SocialGouv/mano/commit/66f69469211046a68a706de20f4346c9c1fe0fe9))
-* **dashboard:** button for description ([#137](https://github.com/SocialGouv/mano/issues/137)) ([7c80e79](https://github.com/SocialGouv/mano/commit/7c80e7972a385edbb84667b06c34549a98192aa4))
+- **api,dashboard:** multiple collaborations ([#135](https://github.com/SocialGouv/mano/issues/135)) ([66f6946](https://github.com/SocialGouv/mano/commit/66f69469211046a68a706de20f4346c9c1fe0fe9))
+- **dashboard:** button for description ([#137](https://github.com/SocialGouv/mano/issues/137)) ([7c80e79](https://github.com/SocialGouv/mano/commit/7c80e7972a385edbb84667b06c34549a98192aa4))
 
 # [1.24.0](https://github.com/SocialGouv/mano/compare/v1.23.0...v1.24.0) (2021-11-05)
 
-
 ### Features
 
-* set encryption verification key ([#124](https://github.com/SocialGouv/mano/issues/124)) ([b283625](https://github.com/SocialGouv/mano/commit/b2836258d0fcd4e71dbbd617b0158265e127c414))
+- set encryption verification key ([#124](https://github.com/SocialGouv/mano/issues/124)) ([b283625](https://github.com/SocialGouv/mano/commit/b2836258d0fcd4e71dbbd617b0158265e127c414))
 
 # [1.23.0](https://github.com/SocialGouv/mano/compare/v1.22.0...v1.23.0) (2021-11-04)
 
-
 ### Features
 
-* **all:** deploy on node 16 ([#129](https://github.com/SocialGouv/mano/issues/129)) ([d65ffdd](https://github.com/SocialGouv/mano/commit/d65ffdd0227a1583dc1e9bc7a75bedba9c234201))
+- **all:** deploy on node 16 ([#129](https://github.com/SocialGouv/mano/issues/129)) ([d65ffdd](https://github.com/SocialGouv/mano/commit/d65ffdd0227a1583dc1e9bc7a75bedba9c234201))
 
 # [1.22.0](https://github.com/SocialGouv/mano/compare/v1.21.1...v1.22.0) (2021-11-04)
 
-
 ### Features
 
-* **dashboard:** onboarding for admin redirects to first team creation ([#128](https://github.com/SocialGouv/mano/issues/128)) ([0fc04ed](https://github.com/SocialGouv/mano/commit/0fc04eda3f621b594970cbdd11ce2494801ae755))
+- **dashboard:** onboarding for admin redirects to first team creation ([#128](https://github.com/SocialGouv/mano/issues/128)) ([0fc04ed](https://github.com/SocialGouv/mano/commit/0fc04eda3f621b594970cbdd11ce2494801ae755))
 
 ## [1.21.1](https://github.com/SocialGouv/mano/compare/v1.21.0...v1.21.1) (2021-11-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** wording on comments ([1c1f5ee](https://github.com/SocialGouv/mano/commit/1c1f5ee43fdcff0d0ee596c44cbb5ded1caa9056))
+- **dashboard:** wording on comments ([1c1f5ee](https://github.com/SocialGouv/mano/commit/1c1f5ee43fdcff0d0ee596c44cbb5ded1caa9056))
 
 # [1.21.0](https://github.com/SocialGouv/mano/compare/v1.20.1...v1.21.0) (2021-11-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** show message for custom fields when organisation not encrypted ([#126](https://github.com/SocialGouv/mano/issues/126)) ([de16299](https://github.com/SocialGouv/mano/commit/de16299b8d9fe5acd82fed1ff82692559e9003da))
-
+- **dashboard:** show message for custom fields when organisation not encrypted ([#126](https://github.com/SocialGouv/mano/issues/126)) ([de16299](https://github.com/SocialGouv/mano/commit/de16299b8d9fe5acd82fed1ff82692559e9003da))
 
 ### Features
 
-* **dashboard:** show more stuff in organisations for superadmin to better pilot ([#127](https://github.com/SocialGouv/mano/issues/127)) ([204703c](https://github.com/SocialGouv/mano/commit/204703cacb462e14d5634108ea948f4739325c9f))
+- **dashboard:** show more stuff in organisations for superadmin to better pilot ([#127](https://github.com/SocialGouv/mano/issues/127)) ([204703c](https://github.com/SocialGouv/mano/commit/204703cacb462e14d5634108ea948f4739325c9f))
 
 ## [1.20.1](https://github.com/SocialGouv/mano/compare/v1.20.0...v1.20.1) (2021-11-02)
 
-
 ### Bug Fixes
 
-* **dashboard:** wrong "connect again" behavior on dashboard ([#125](https://github.com/SocialGouv/mano/issues/125)) ([6a5b1ea](https://github.com/SocialGouv/mano/commit/6a5b1ea6ad2b907aa587cbc220ab277944836c23))
+- **dashboard:** wrong "connect again" behavior on dashboard ([#125](https://github.com/SocialGouv/mano/issues/125)) ([6a5b1ea](https://github.com/SocialGouv/mano/commit/6a5b1ea6ad2b907aa587cbc220ab277944836c23))
 
 # [1.20.0](https://github.com/SocialGouv/mano/compare/v1.19.0...v1.20.0) (2021-10-27)
 
-
 ### Features
 
-* model observations customizable ([#106](https://github.com/SocialGouv/mano/issues/106)) ([48701c8](https://github.com/SocialGouv/mano/commit/48701c89c5f49641b0b6066cdf700ed35d421f2a))
+- model observations customizable ([#106](https://github.com/SocialGouv/mano/issues/106)) ([48701c8](https://github.com/SocialGouv/mano/commit/48701c89c5f49641b0b6066cdf700ed35d421f2a))
 
 # [1.19.0](https://github.com/SocialGouv/mano/compare/v1.18.4...v1.19.0) (2021-10-27)
 
-
 ### Features
 
-* **app:** out of active list ([#113](https://github.com/SocialGouv/mano/issues/113)) ([6814421](https://github.com/SocialGouv/mano/commit/6814421ec0a51d3dcee4c0568a6ab81de9940376))
+- **app:** out of active list ([#113](https://github.com/SocialGouv/mano/issues/113)) ([6814421](https://github.com/SocialGouv/mano/commit/6814421ec0a51d3dcee4c0568a6ab81de9940376))
 
 ## [1.18.4](https://github.com/SocialGouv/mano/compare/v1.18.3...v1.18.4) (2021-10-26)
 
-
 ### Bug Fixes
 
-* **dashboard,app:** sort actions by dueDate desc ([#117](https://github.com/SocialGouv/mano/issues/117)) ([99d657e](https://github.com/SocialGouv/mano/commit/99d657e49be138a59ed6a112cebc8b0bebf5311c))
+- **dashboard,app:** sort actions by dueDate desc ([#117](https://github.com/SocialGouv/mano/issues/117)) ([99d657e](https://github.com/SocialGouv/mano/commit/99d657e49be138a59ed6a112cebc8b0bebf5311c))
 
 ## [1.18.3](https://github.com/SocialGouv/mano/compare/v1.18.2...v1.18.3) (2021-10-26)
 
-
 ### Bug Fixes
 
-* **website:** src root for img ([ae57f88](https://github.com/SocialGouv/mano/commit/ae57f8856dfafb73aad9c9b2ebf37ba516e12c28))
+- **website:** src root for img ([ae57f88](https://github.com/SocialGouv/mano/commit/ae57f8856dfafb73aad9c9b2ebf37ba516e12c28))
 
 ## [1.18.2](https://github.com/SocialGouv/mano/compare/v1.18.1...v1.18.2) (2021-10-26)
 
-
 ### Bug Fixes
 
-* static website ([#114](https://github.com/SocialGouv/mano/issues/114)) ([8ab9550](https://github.com/SocialGouv/mano/commit/8ab9550fdf281c3996d68685dc476b783901821c))
+- static website ([#114](https://github.com/SocialGouv/mano/issues/114)) ([8ab9550](https://github.com/SocialGouv/mano/commit/8ab9550fdf281c3996d68685dc476b783901821c))
 
 ## [1.18.1](https://github.com/SocialGouv/mano/compare/v1.18.0...v1.18.1) (2021-10-22)
 
-
 ### Bug Fixes
 
-* compulsory person in creating action from CreateAction ([#104](https://github.com/SocialGouv/mano/issues/104)) ([1f319bc](https://github.com/SocialGouv/mano/commit/1f319bcec2d9fe5c37d1f89f5f19d52ab76fcf82))
+- compulsory person in creating action from CreateAction ([#104](https://github.com/SocialGouv/mano/issues/104)) ([1f319bc](https://github.com/SocialGouv/mano/commit/1f319bcec2d9fe5c37d1f89f5f19d52ab76fcf82))
 
 # [1.18.0](https://github.com/SocialGouv/mano/compare/v1.17.0...v1.18.0) (2021-10-22)
 
-
 ### Features
 
-* **app:** local cache ([#107](https://github.com/SocialGouv/mano/issues/107)) ([b143d53](https://github.com/SocialGouv/mano/commit/b143d53404f40d37a1dfe1787b3af9353acecea2))
+- **app:** local cache ([#107](https://github.com/SocialGouv/mano/issues/107)) ([b143d53](https://github.com/SocialGouv/mano/commit/b143d53404f40d37a1dfe1787b3af9353acecea2))
 
 # [1.17.0](https://github.com/SocialGouv/mano/compare/v1.16.0...v1.17.0) (2021-10-21)
 
-
 ### Features
 
-* **website:** add matomo website ([#109](https://github.com/SocialGouv/mano/issues/109)) ([f5f8528](https://github.com/SocialGouv/mano/commit/f5f852866201f15e89afb98debb93409fc4fd6dc))
+- **website:** add matomo website ([#109](https://github.com/SocialGouv/mano/issues/109)) ([f5f8528](https://github.com/SocialGouv/mano/commit/f5f852866201f15e89afb98debb93409fc4fd6dc))
 
 # [1.16.0](https://github.com/SocialGouv/mano/compare/v1.15.0...v1.16.0) (2021-10-21)
 
-
 ### Features
 
-* add cookie to preserve session ([#96](https://github.com/SocialGouv/mano/issues/96)) ([9a20b48](https://github.com/SocialGouv/mano/commit/9a20b48357c7637141639da7ef7c493ec478aae0))
+- add cookie to preserve session ([#96](https://github.com/SocialGouv/mano/issues/96)) ([9a20b48](https://github.com/SocialGouv/mano/commit/9a20b48357c7637141639da7ef7c493ec478aae0))
 
 # [1.15.0](https://github.com/SocialGouv/mano/compare/v1.14.1...v1.15.0) (2021-10-21)
 
-
 ### Features
 
-* **dashboard:** add places in filters for persons ([#89](https://github.com/SocialGouv/mano/issues/89)) ([90aef52](https://github.com/SocialGouv/mano/commit/90aef52566faaa696714c71e7d13cd2ec9ab4488))
+- **dashboard:** add places in filters for persons ([#89](https://github.com/SocialGouv/mano/issues/89)) ([90aef52](https://github.com/SocialGouv/mano/commit/90aef52566faaa696714c71e7d13cd2ec9ab4488))
 
 ## [1.14.1](https://github.com/SocialGouv/mano/compare/v1.14.0...v1.14.1) (2021-10-21)
 
-
 ### Bug Fixes
 
-* create report when current team exists ([#105](https://github.com/SocialGouv/mano/issues/105)) ([fcc55f6](https://github.com/SocialGouv/mano/commit/fcc55f62fd340de79be688844abe0f03a93340d9))
+- create report when current team exists ([#105](https://github.com/SocialGouv/mano/issues/105)) ([fcc55f6](https://github.com/SocialGouv/mano/commit/fcc55f62fd340de79be688844abe0f03a93340d9))
 
 # [1.14.0](https://github.com/SocialGouv/mano/compare/v1.13.0...v1.14.0) (2021-10-19)
 
-
 ### Bug Fixes
 
-* **app:** phone number on app ([#99](https://github.com/SocialGouv/mano/issues/99)) ([d58a41f](https://github.com/SocialGouv/mano/commit/d58a41fc5b8c32032015428a0042d2e9e80c3780))
-* **app:** territory observation save ([#98](https://github.com/SocialGouv/mano/issues/98)) ([f5342e2](https://github.com/SocialGouv/mano/commit/f5342e2bd3afcf72e855977c682b0316df47256d))
-
+- **app:** phone number on app ([#99](https://github.com/SocialGouv/mano/issues/99)) ([d58a41f](https://github.com/SocialGouv/mano/commit/d58a41fc5b8c32032015428a0042d2e9e80c3780))
+- **app:** territory observation save ([#98](https://github.com/SocialGouv/mano/issues/98)) ([f5342e2](https://github.com/SocialGouv/mano/commit/f5342e2bd3afcf72e855977c682b0316df47256d))
 
 ### Features
 
-* **dashboard:** add categories in actions list ([#90](https://github.com/SocialGouv/mano/issues/90)) ([1831168](https://github.com/SocialGouv/mano/commit/18311681dacd7e90405192eb47fef6b9e7157327))
+- **dashboard:** add categories in actions list ([#90](https://github.com/SocialGouv/mano/issues/90)) ([1831168](https://github.com/SocialGouv/mano/commit/18311681dacd7e90405192eb47fef6b9e7157327))
 
 # [1.13.0](https://github.com/SocialGouv/mano/compare/v1.12.6...v1.13.0) (2021-10-19)
 
-
 ### Features
 
-* **dashboard:** active list ([#92](https://github.com/SocialGouv/mano/issues/92)) ([942476c](https://github.com/SocialGouv/mano/commit/942476c317d9b3f9a3d0cbbedd59f81b097e66aa))
+- **dashboard:** active list ([#92](https://github.com/SocialGouv/mano/issues/92)) ([942476c](https://github.com/SocialGouv/mano/commit/942476c317d9b3f9a3d0cbbedd59f81b097e66aa))
 
 ## [1.12.6](https://github.com/SocialGouv/mano/compare/v1.12.5...v1.12.6) (2021-10-15)
 
-
 ### Bug Fixes
 
-* **dashboard:** due at in action ([#95](https://github.com/SocialGouv/mano/issues/95)) ([18e6f50](https://github.com/SocialGouv/mano/commit/18e6f5065ccf9e28ce16413bec8b2aadd07d4431))
+- **dashboard:** due at in action ([#95](https://github.com/SocialGouv/mano/issues/95)) ([18e6f50](https://github.com/SocialGouv/mano/commit/18e6f5065ccf9e28ce16413bec8b2aadd07d4431))
 
 ## [1.12.5](https://github.com/SocialGouv/mano/compare/v1.12.4...v1.12.5) (2021-10-15)
 
-
 ### Bug Fixes
 
-* remove React does not recognize the showPassword prop on a DOM element warning ([#86](https://github.com/SocialGouv/mano/issues/86)) ([97cb377](https://github.com/SocialGouv/mano/commit/97cb37738d83131e6ae418cc83dfbabc4a93a830))
+- remove React does not recognize the showPassword prop on a DOM element warning ([#86](https://github.com/SocialGouv/mano/issues/86)) ([97cb377](https://github.com/SocialGouv/mano/commit/97cb37738d83131e6ae418cc83dfbabc4a93a830))
 
 ## [1.12.4](https://github.com/SocialGouv/mano/compare/v1.12.3...v1.12.4) (2021-10-11)
 
-
 ### Bug Fixes
 
-* **dashboard:** label is clickable ([cd90c73](https://github.com/SocialGouv/mano/commit/cd90c73f2ea33921c629fa564a5776a496d852a0))
-* **style:** remove invalid style ([aaa8d2c](https://github.com/SocialGouv/mano/commit/aaa8d2c1e55694dbfbe223cf4435e7f07b99e0ed))
+- **dashboard:** label is clickable ([cd90c73](https://github.com/SocialGouv/mano/commit/cd90c73f2ea33921c629fa564a5776a496d852a0))
+- **style:** remove invalid style ([aaa8d2c](https://github.com/SocialGouv/mano/commit/aaa8d2c1e55694dbfbe223cf4435e7f07b99e0ed))
 
 ## [1.12.3](https://github.com/SocialGouv/mano/compare/v1.12.2...v1.12.3) (2021-10-07)
 
-
 ### Bug Fixes
 
-* error message when resetting password ([#87](https://github.com/SocialGouv/mano/issues/87)) ([589c43d](https://github.com/SocialGouv/mano/commit/589c43d85502b8709309d7e8115ec5d3320962e7))
+- error message when resetting password ([#87](https://github.com/SocialGouv/mano/issues/87)) ([589c43d](https://github.com/SocialGouv/mano/commit/589c43d85502b8709309d7e8115ec5d3320962e7))
 
 ## [1.12.2](https://github.com/SocialGouv/mano/compare/v1.12.1...v1.12.2) (2021-10-04)
 
-
 ### Bug Fixes
 
-* **docker:** use nginx image ([#83](https://github.com/SocialGouv/mano/issues/83)) ([628c006](https://github.com/SocialGouv/mano/commit/628c006c7a600a4d9c2abb063d7512a5e7b52b68))
+- **docker:** use nginx image ([#83](https://github.com/SocialGouv/mano/issues/83)) ([628c006](https://github.com/SocialGouv/mano/commit/628c006c7a600a4d9c2abb063d7512a5e7b52b68))
 
 ## [1.12.1](https://github.com/SocialGouv/mano/compare/v1.12.0...v1.12.1) (2021-10-04)
 
-
 ### Bug Fixes
 
-* access person from actions list ([#79](https://github.com/SocialGouv/mano/issues/79)) ([c704ef0](https://github.com/SocialGouv/mano/commit/c704ef0884d41080febd22e5eaf94949833cf450))
+- access person from actions list ([#79](https://github.com/SocialGouv/mano/issues/79)) ([c704ef0](https://github.com/SocialGouv/mano/commit/c704ef0884d41080febd22e5eaf94949833cf450))
 
 # [1.12.0](https://github.com/SocialGouv/mano/compare/v1.11.3...v1.12.0) (2021-10-04)
 
-
 ### Bug Fixes
 
-* collaborations ([#78](https://github.com/SocialGouv/mano/issues/78)) ([cd4e5ef](https://github.com/SocialGouv/mano/commit/cd4e5ef44adb3b6b3f9fa5ec47616ee7bd25bbac))
-
+- collaborations ([#78](https://github.com/SocialGouv/mano/issues/78)) ([cd4e5ef](https://github.com/SocialGouv/mano/commit/cd4e5ef44adb3b6b3f9fa5ec47616ee7bd25bbac))
 
 ### Features
 
-* can make passwords visible ([#81](https://github.com/SocialGouv/mano/issues/81)) ([dfd7884](https://github.com/SocialGouv/mano/commit/dfd7884bebad0d3103c14ffc838ccadda43419f6))
+- can make passwords visible ([#81](https://github.com/SocialGouv/mano/issues/81)) ([dfd7884](https://github.com/SocialGouv/mano/commit/dfd7884bebad0d3103c14ffc838ccadda43419f6))
 
 ## [1.11.3](https://github.com/SocialGouv/mano/compare/v1.11.2...v1.11.3) (2021-09-29)
 
-
 ### Bug Fixes
 
-* sentry+small fixes ([#74](https://github.com/SocialGouv/mano/issues/74)) ([2b2a76b](https://github.com/SocialGouv/mano/commit/2b2a76b8e23537413d3e85143cbdb46126e6dc5f))
+- sentry+small fixes ([#74](https://github.com/SocialGouv/mano/issues/74)) ([2b2a76b](https://github.com/SocialGouv/mano/commit/2b2a76b8e23537413d3e85143cbdb46126e6dc5f))
 
 ## [1.11.2](https://github.com/SocialGouv/mano/compare/v1.11.1...v1.11.2) (2021-09-27)
 
-
 ### Bug Fixes
 
-* Bump version ([7dca32f](https://github.com/SocialGouv/mano/commit/7dca32f89fa44c1f847f3bc93bc805e481a2d792))
+- Bump version ([7dca32f](https://github.com/SocialGouv/mano/commit/7dca32f89fa44c1f847f3bc93bc805e481a2d792))
 
 ## [1.11.1](https://github.com/SocialGouv/mano/compare/v1.11.0...v1.11.1) (2021-09-22)
 
-
 ### Bug Fixes
 
-* can go back when update multiple actions ([e9a3472](https://github.com/SocialGouv/mano/commit/e9a347269ab3ccdb7fd2ab9f088066291416555b))
+- can go back when update multiple actions ([e9a3472](https://github.com/SocialGouv/mano/commit/e9a347269ab3ccdb7fd2ab9f088066291416555b))
 
 # [1.11.0](https://github.com/SocialGouv/mano/compare/v1.10.3...v1.11.0) (2021-09-22)
 
-
 ### Features
 
-* can create action for multiple persons in app ([#36](https://github.com/SocialGouv/mano/issues/36)) ([e3e3de5](https://github.com/SocialGouv/mano/commit/e3e3de556834b0d5d6e32f9263f1ccfcaa1ad2be)), closes [#44](https://github.com/SocialGouv/mano/issues/44)
+- can create action for multiple persons in app ([#36](https://github.com/SocialGouv/mano/issues/36)) ([e3e3de5](https://github.com/SocialGouv/mano/commit/e3e3de556834b0d5d6e32f9263f1ccfcaa1ad2be)), closes [#44](https://github.com/SocialGouv/mano/issues/44)
 
 ## [1.10.3](https://github.com/SocialGouv/mano/compare/v1.10.2...v1.10.3) (2021-09-21)
 
-
 ### Bug Fixes
 
-* search in app ([#45](https://github.com/SocialGouv/mano/issues/45)) ([b77abdc](https://github.com/SocialGouv/mano/commit/b77abdccb18b9b5360ebc8af8cd98eaa1ef933e5))
+- search in app ([#45](https://github.com/SocialGouv/mano/issues/45)) ([b77abdc](https://github.com/SocialGouv/mano/commit/b77abdccb18b9b5360ebc8af8cd98eaa1ef933e5))
 
 ## [1.10.2](https://github.com/SocialGouv/mano/compare/v1.10.1...v1.10.2) (2021-09-21)
 
-
 ### Bug Fixes
 
-* **ci:** semantic release update package.json ([#37](https://github.com/SocialGouv/mano/issues/37)) ([22b1098](https://github.com/SocialGouv/mano/commit/22b1098264975e31ea7776716926625102f59f2e)), closes [#38](https://github.com/SocialGouv/mano/issues/38)
+- **ci:** semantic release update package.json ([#37](https://github.com/SocialGouv/mano/issues/37)) ([22b1098](https://github.com/SocialGouv/mano/commit/22b1098264975e31ea7776716926625102f59f2e)), closes [#38](https://github.com/SocialGouv/mano/issues/38)
 
 ## [1.10.1](https://github.com/SocialGouv/mano/compare/v1.10.0...v1.10.1) (2021-09-17)
 
-
 ### Bug Fixes
 
-* **dashboard:** increase k8s startup delay ([#41](https://github.com/SocialGouv/mano/issues/41)) ([f7abbff](https://github.com/SocialGouv/mano/commit/f7abbff2ee10993c28f137dc2e38f1358b212178))
+- **dashboard:** increase k8s startup delay ([#41](https://github.com/SocialGouv/mano/issues/41)) ([f7abbff](https://github.com/SocialGouv/mano/commit/f7abbff2ee10993c28f137dc2e38f1358b212178))
 
 # [1.10.0](https://github.com/SocialGouv/mano/compare/v1.9.0...v1.10.0) (2021-09-14)
 
-
 ### Features
 
-* add metabase ([#35](https://github.com/SocialGouv/mano/issues/35)) ([4f58930](https://github.com/SocialGouv/mano/commit/4f58930a8c2bcfed9ffe72ac8441e0f75a0122fb))
+- add metabase ([#35](https://github.com/SocialGouv/mano/issues/35)) ([4f58930](https://github.com/SocialGouv/mano/commit/4f58930a8c2bcfed9ffe72ac8441e0f75a0122fb))
 
 # [1.9.0](https://github.com/SocialGouv/mano/compare/v1.8.2...v1.9.0) (2021-09-14)
 
-
 ### Bug Fixes
 
-* can set status of action while creating ([#28](https://github.com/SocialGouv/mano/issues/28)) ([15b4bb5](https://github.com/SocialGouv/mano/commit/15b4bb555fe1026571808aa7a2dbd5f846eebfcd))
-
+- can set status of action while creating ([#28](https://github.com/SocialGouv/mano/issues/28)) ([15b4bb5](https://github.com/SocialGouv/mano/commit/15b4bb555fe1026571808aa7a2dbd5f846eebfcd))
 
 ### Features
 
-* can show structures in the app ([#34](https://github.com/SocialGouv/mano/issues/34)) ([1a6dd07](https://github.com/SocialGouv/mano/commit/1a6dd07e8e11916bf0024eddd3a48a7b0caa2111))
+- can show structures in the app ([#34](https://github.com/SocialGouv/mano/issues/34)) ([1a6dd07](https://github.com/SocialGouv/mano/commit/1a6dd07e8e11916bf0024eddd3a48a7b0caa2111))
 
 ## [1.8.2](https://github.com/SocialGouv/mano/compare/v1.8.1...v1.8.2) (2021-09-14)
 
-
 ### Bug Fixes
 
-* add night shift for teams ([#25](https://github.com/SocialGouv/mano/issues/25)) ([3cd657a](https://github.com/SocialGouv/mano/commit/3cd657ad7a546f77694cfaae43c218753c09e071))
+- add night shift for teams ([#25](https://github.com/SocialGouv/mano/issues/25)) ([3cd657a](https://github.com/SocialGouv/mano/commit/3cd657ad7a546f77694cfaae43c218753c09e071))
 
 ## [1.8.1](https://github.com/SocialGouv/mano/compare/v1.8.0...v1.8.1) (2021-09-14)
 
-
 ### Bug Fixes
 
-* bug on email sending ([70edbb2](https://github.com/SocialGouv/mano/commit/70edbb26623f97216967685a42997b3e8067c94f))
+- bug on email sending ([70edbb2](https://github.com/SocialGouv/mano/commit/70edbb26623f97216967685a42997b3e8067c94f))
 
 # [1.8.0](https://github.com/SocialGouv/mano/compare/v1.7.4...v1.8.0) (2021-09-13)
 
-
 ### Features
 
-* add mobile app ([#22](https://github.com/SocialGouv/mano/issues/22)) ([8266cfc](https://github.com/SocialGouv/mano/commit/8266cfc8e8de70d1feb64c3d3eefb05ab68abd7d))
+- add mobile app ([#22](https://github.com/SocialGouv/mano/issues/22)) ([8266cfc](https://github.com/SocialGouv/mano/commit/8266cfc8e8de70d1feb64c3d3eefb05ab68abd7d))
 
 ## [1.7.4](https://github.com/SocialGouv/mano/compare/v1.7.3...v1.7.4) (2021-09-13)
 
-
 ### Bug Fixes
 
-* update kosko charts ([978ff4e](https://github.com/SocialGouv/mano/commit/978ff4ebe455452b5fc56a39fc571d804e11f046))
+- update kosko charts ([978ff4e](https://github.com/SocialGouv/mano/commit/978ff4ebe455452b5fc56a39fc571d804e11f046))
 
 ## [1.7.3](https://github.com/SocialGouv/mano/compare/v1.7.2...v1.7.3) (2021-09-13)
 
-
 ### Bug Fixes
 
-* update preprod api secret ([491e2f9](https://github.com/SocialGouv/mano/commit/491e2f9a7d15e3ab043cb9e487406169cbde9eae))
+- update preprod api secret ([491e2f9](https://github.com/SocialGouv/mano/commit/491e2f9a7d15e3ab043cb9e487406169cbde9eae))
 
 ## [1.7.2](https://github.com/SocialGouv/mano/compare/v1.7.1...v1.7.2) (2021-09-13)
 
-
 ### Bug Fixes
 
-* update kostko.toml ([7515e99](https://github.com/SocialGouv/mano/commit/7515e993ad07e447b5e00f952ebdfab8c6735603))
+- update kostko.toml ([7515e99](https://github.com/SocialGouv/mano/commit/7515e993ad07e447b5e00f952ebdfab8c6735603))
 
 ## [1.7.1](https://github.com/SocialGouv/mano/compare/v1.7.0...v1.7.1) (2021-09-13)
 
-
 ### Bug Fixes
 
-* **ci:** add rancher id in env ([4e5b18e](https://github.com/SocialGouv/mano/commit/4e5b18e33b4962d9398ff244b27b443035d1ea20))
-* **ci:** add rancher id in env preproduction ([3f52fa8](https://github.com/SocialGouv/mano/commit/3f52fa8060e27324634f80c12c5efe99a6baa804))
+- **ci:** add rancher id in env ([4e5b18e](https://github.com/SocialGouv/mano/commit/4e5b18e33b4962d9398ff244b27b443035d1ea20))
+- **ci:** add rancher id in env preproduction ([3f52fa8](https://github.com/SocialGouv/mano/commit/3f52fa8060e27324634f80c12c5efe99a6baa804))
 
 # [1.7.0](https://github.com/SocialGouv/mano/compare/v1.6.1...v1.7.0) (2021-09-13)
 
-
 ### Features
 
-* **ci:** deploy api in production ([#21](https://github.com/SocialGouv/mano/issues/21)) ([05c1063](https://github.com/SocialGouv/mano/commit/05c10631904c4e40e77f876ac0b977b2982fd5f0))
+- **ci:** deploy api in production ([#21](https://github.com/SocialGouv/mano/issues/21)) ([05c1063](https://github.com/SocialGouv/mano/commit/05c10631904c4e40e77f876ac0b977b2982fd5f0))
 
 ## [1.6.1](https://github.com/SocialGouv/mano/compare/v1.6.0...v1.6.1) (2021-09-13)
 
-
 ### Bug Fixes
 
-* bump version ([44c6b4c](https://github.com/SocialGouv/mano/commit/44c6b4c4cc489787a37d213e0f010f5788d2d848))
+- bump version ([44c6b4c](https://github.com/SocialGouv/mano/commit/44c6b4c4cc489787a37d213e0f010f5788d2d848))
 
 # [1.6.0](https://github.com/SocialGouv/mano/compare/v1.5.1...v1.6.0) (2021-09-13)
 
-
 ### Features
 
-* add api in review ([#15](https://github.com/SocialGouv/mano/issues/15)) ([e913b5d](https://github.com/SocialGouv/mano/commit/e913b5df488a9b749feea1748a5fd24f9e7aebd4)), closes [#16](https://github.com/SocialGouv/mano/issues/16)
+- add api in review ([#15](https://github.com/SocialGouv/mano/issues/15)) ([e913b5d](https://github.com/SocialGouv/mano/commit/e913b5df488a9b749feea1748a5fd24f9e7aebd4)), closes [#16](https://github.com/SocialGouv/mano/issues/16)
 
 ## [1.5.1](https://github.com/SocialGouv/mano/compare/v1.5.0...v1.5.1) (2021-09-11)
 
-
 ### Bug Fixes
 
-* can view report ([98794f2](https://github.com/SocialGouv/mano/commit/98794f2d958bfcd947630ed57c67bbecdffe3905))
+- can view report ([98794f2](https://github.com/SocialGouv/mano/commit/98794f2d958bfcd947630ed57c67bbecdffe3905))
 
 # [1.5.0](https://github.com/SocialGouv/mano/compare/v1.4.1...v1.5.0) (2021-09-10)
 
-
 ### Features
 
-* add api ([#14](https://github.com/SocialGouv/mano/issues/14)) ([b951367](https://github.com/SocialGouv/mano/commit/b951367bb07e330ebc73dfa8d2dbc7c0132ffd03))
+- add api ([#14](https://github.com/SocialGouv/mano/issues/14)) ([b951367](https://github.com/SocialGouv/mano/commit/b951367bb07e330ebc73dfa8d2dbc7c0132ffd03))
 
 ## [1.4.1](https://github.com/SocialGouv/mano/compare/v1.4.0...v1.4.1) (2021-09-10)
 
-
 ### Bug Fixes
 
-* add another maraud in report ([#12](https://github.com/SocialGouv/mano/issues/12)) ([c543440](https://github.com/SocialGouv/mano/commit/c54344013a89ffe8b8cde0387773941b9f0aefe3))
+- add another maraud in report ([#12](https://github.com/SocialGouv/mano/issues/12)) ([c543440](https://github.com/SocialGouv/mano/commit/c54344013a89ffe8b8cde0387773941b9f0aefe3))
 
 # [1.4.0](https://github.com/SocialGouv/mano/compare/v1.3.0...v1.4.0) (2021-09-10)
 
-
 ### Features
 
-* **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([#11](https://github.com/SocialGouv/mano/issues/11)) ([816a643](https://github.com/SocialGouv/mano/commit/816a6434d22207397aa19c6feeaf5233441783e3))
+- **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([#11](https://github.com/SocialGouv/mano/issues/11)) ([816a643](https://github.com/SocialGouv/mano/commit/816a6434d22207397aa19c6feeaf5233441783e3))
 
 # [1.4.0-alpha.1](https://github.com/SocialGouv/mano/compare/v1.3.0...v1.4.0-alpha.1) (2021-09-10)
 
-
 ### Features
 
-* **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([3ac41bc](https://github.com/SocialGouv/mano/commit/3ac41bc719e507e319b87e88825ec80430759151))
+- **ci:** deploy to prod ([#10](https://github.com/SocialGouv/mano/issues/10)) ([3ac41bc](https://github.com/SocialGouv/mano/commit/3ac41bc719e507e319b87e88825ec80430759151))
 
 # [1.3.0](https://github.com/SocialGouv/mano/compare/v1.2.0...v1.3.0) (2021-09-10)
 
-
 ### Features
 
-* **ci:** add component dashboard only for dev env ([#9](https://github.com/SocialGouv/mano/issues/9)) ([36af8db](https://github.com/SocialGouv/mano/commit/36af8db09179341ade62e230cbba204a89469538))
+- **ci:** add component dashboard only for dev env ([#9](https://github.com/SocialGouv/mano/issues/9)) ([36af8db](https://github.com/SocialGouv/mano/commit/36af8db09179341ade62e230cbba204a89469538))
 
 # [1.2.0](https://github.com/SocialGouv/mano/compare/v1.1.0...v1.2.0) (2021-09-03)
 
-
 ### Features
 
-* add dashboard ([#7](https://github.com/SocialGouv/mano/issues/7)) ([988fd16](https://github.com/SocialGouv/mano/commit/988fd16d08945984c8b19834d32f71e84e237f96))
+- add dashboard ([#7](https://github.com/SocialGouv/mano/issues/7)) ([988fd16](https://github.com/SocialGouv/mano/commit/988fd16d08945984c8b19834d32f71e84e237f96))
 
 # [1.1.0](https://github.com/SocialGouv/mano/compare/v1.0.0...v1.1.0) (2021-09-03)
 
-
 ### Features
 
-* deploy to prod ([#6](https://github.com/SocialGouv/mano/issues/6)) ([c8f31a6](https://github.com/SocialGouv/mano/commit/c8f31a64474794e8944657918101244afdd2c525)), closes [#3](https://github.com/SocialGouv/mano/issues/3) [#3](https://github.com/SocialGouv/mano/issues/3) [#5](https://github.com/SocialGouv/mano/issues/5)
+- deploy to prod ([#6](https://github.com/SocialGouv/mano/issues/6)) ([c8f31a6](https://github.com/SocialGouv/mano/commit/c8f31a64474794e8944657918101244afdd2c525)), closes [#3](https://github.com/SocialGouv/mano/issues/3) [#3](https://github.com/SocialGouv/mano/issues/3) [#5](https://github.com/SocialGouv/mano/issues/5)
 
 # [1.1.0-alpha.3](https://github.com/SocialGouv/mano/compare/v1.1.0-alpha.2...v1.1.0-alpha.3) (2021-09-02)
 
-
 ### Bug Fixes
 
-* bump version ([304b705](https://github.com/SocialGouv/mano/commit/304b7055dc03eedf5d0e5ba92d667f028c213285))
+- bump version ([304b705](https://github.com/SocialGouv/mano/commit/304b7055dc03eedf5d0e5ba92d667f028c213285))
 
 # [1.1.0-alpha.2](https://github.com/SocialGouv/mano/compare/v1.1.0-alpha.1...v1.1.0-alpha.2) (2021-09-02)
 
-
 ### Bug Fixes
 
-* **ci:** rename job to deploy-preproduction ([647a280](https://github.com/SocialGouv/mano/commit/647a2808b1eae073dbced3adc35cd9ebb01c118b))
+- **ci:** rename job to deploy-preproduction ([647a280](https://github.com/SocialGouv/mano/commit/647a2808b1eae073dbced3adc35cd9ebb01c118b))
 
 # [1.1.0-alpha.1](https://github.com/SocialGouv/mano/compare/v1.0.0...v1.1.0-alpha.1) (2021-09-02)
 
-
 ### Features
 
-* **ci:** add prod and pre-prod deployment ([#3](https://github.com/SocialGouv/mano/issues/3)) ([2eaf32e](https://github.com/SocialGouv/mano/commit/2eaf32e4b6a8574a4412eb191c02aa2f6ede8a5d))
+- **ci:** add prod and pre-prod deployment ([#3](https://github.com/SocialGouv/mano/issues/3)) ([2eaf32e](https://github.com/SocialGouv/mano/commit/2eaf32e4b6a8574a4412eb191c02aa2f6ede8a5d))
 
 # 1.0.0 (2021-09-02)
 
-
 ### Bug Fixes
 
-* **ci:** remove useless url ([30c5993](https://github.com/SocialGouv/mano/commit/30c5993707ad1226d81e3c3700451f1a638728da))
-* missing releaserc ([e44d777](https://github.com/SocialGouv/mano/commit/e44d77763d8111d20a9c8d6d98207e9c8978bb35))
-* **ci:** branches ([0c00e06](https://github.com/SocialGouv/mano/commit/0c00e06d4684a3ac85d6d31b386917aa095485d5))
-
+- **ci:** remove useless url ([30c5993](https://github.com/SocialGouv/mano/commit/30c5993707ad1226d81e3c3700451f1a638728da))
+- missing releaserc ([e44d777](https://github.com/SocialGouv/mano/commit/e44d77763d8111d20a9c8d6d98207e9c8978bb35))
+- **ci:** branches ([0c00e06](https://github.com/SocialGouv/mano/commit/0c00e06d4684a3ac85d6d31b386917aa095485d5))
 
 ### Features
 
-* add semantic release ([82ad799](https://github.com/SocialGouv/mano/commit/82ad799e36fda1ff2a9cd930eb06b0112697cda1))
+- add semantic release ([82ad799](https://github.com/SocialGouv/mano/commit/82ad799e36fda1ff2a9cd930eb06b0112697cda1))

--- a/app/src/recoil/comments.js
+++ b/app/src/recoil/comments.js
@@ -5,7 +5,7 @@ export const commentsState = atom({
   default: [],
 });
 
-const encryptedFields = ['comment', 'type', 'item', 'person', 'action', 'team', 'user', 'date'];
+const encryptedFields = ['comment', 'type', 'person', 'action', 'team', 'user', 'date'];
 
 export const prepareCommentForEncryption = (comment) => {
   const decrypted = {};

--- a/app/src/recoil/comments.js
+++ b/app/src/recoil/comments.js
@@ -5,7 +5,7 @@ export const commentsState = atom({
   default: [],
 });
 
-const encryptedFields = ['comment', 'type', 'person', 'action', 'team', 'user', 'date'];
+const encryptedFields = ['comment', 'person', 'action', 'team', 'user', 'date'];
 
 export const prepareCommentForEncryption = (comment) => {
   const decrypted = {};

--- a/app/src/scenes/Comments/NewCommentInput.js
+++ b/app/src/scenes/Comments/NewCommentInput.js
@@ -26,12 +26,10 @@ const NewCommentInput = ({ person, action, forwardRef, onFocus, writeComment: wr
     };
     if (person) {
       body.person = person;
-      body.item = person;
       body.type = 'person';
     }
     if (action) {
       body.action = action;
-      body.item = action;
       body.type = 'action';
     }
     if (!body.user) body.user = user._id;

--- a/app/src/scenes/Comments/NewCommentInput.js
+++ b/app/src/scenes/Comments/NewCommentInput.js
@@ -24,14 +24,8 @@ const NewCommentInput = ({ person, action, forwardRef, onFocus, writeComment: wr
     const body = {
       comment,
     };
-    if (person) {
-      body.person = person;
-      body.type = 'person';
-    }
-    if (action) {
-      body.action = action;
-      body.type = 'action';
-    }
+    if (person) body.person = person;
+    if (action) body.action = action;
     if (!body.user) body.user = user._id;
     if (!body.team) body.team = currentTeam._id;
     if (!body.organisation) body.organisation = organisation._id;

--- a/dashboard/src/components/Comments.js
+++ b/dashboard/src/components/Comments.js
@@ -65,12 +65,10 @@ const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
       organisation: organisation._id,
     };
     if (!!personId) {
-      commentBody.item = personId;
       commentBody.person = personId;
       commentBody.type = 'person';
     }
     if (!!actionId) {
-      commentBody.item = actionId;
       commentBody.action = actionId;
       commentBody.type = 'action';
     }

--- a/dashboard/src/components/Comments.js
+++ b/dashboard/src/components/Comments.js
@@ -64,14 +64,8 @@ const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
       team: currentTeam._id,
       organisation: organisation._id,
     };
-    if (!!personId) {
-      commentBody.person = personId;
-      commentBody.type = 'person';
-    }
-    if (!!actionId) {
-      commentBody.action = actionId;
-      commentBody.type = 'action';
-    }
+    if (!!personId) commentBody.person = personId;
+    if (!!actionId) commentBody.action = actionId;
 
     const response = await API.post({ path: '/comment', body: prepareCommentForEncryption(commentBody) });
     if (!response.ok) return;

--- a/dashboard/src/recoil/comments.js
+++ b/dashboard/src/recoil/comments.js
@@ -6,7 +6,7 @@ export const commentsState = atom({
   default: [],
 });
 
-const encryptedFields = ['comment', 'type', 'item', 'person', 'action', 'team', 'user', 'date'];
+const encryptedFields = ['comment', 'type', 'person', 'action', 'team', 'user', 'date'];
 
 export const prepareCommentForEncryption = (comment) => {
   const decrypted = {};

--- a/dashboard/src/recoil/comments.js
+++ b/dashboard/src/recoil/comments.js
@@ -6,7 +6,7 @@ export const commentsState = atom({
   default: [],
 });
 
-const encryptedFields = ['comment', 'type', 'person', 'action', 'team', 'user', 'date'];
+const encryptedFields = ['comment', 'person', 'action', 'team', 'user', 'date'];
 
 export const prepareCommentForEncryption = (comment) => {
   const decrypted = {};

--- a/dashboard/src/scenes/report/view.js
+++ b/dashboard/src/scenes/report/view.js
@@ -434,12 +434,12 @@ const CommentCreatedAt = ({ date, onUpdateResults = () => null }) => {
         .map((comment) => {
           const commentPopulated = { ...comment };
           if (comment.person) {
-            const id = comment?.person || comment?.item;
+            const id = comment?.person;
             commentPopulated.person = persons.find((p) => p._id === id);
             commentPopulated.type = 'person';
           }
           if (comment.action) {
-            const id = comment?.action || comment?.item;
+            const id = comment?.action;
             const action = actions.find((p) => p._id === id);
             commentPopulated.action = action;
             commentPopulated.person = persons.find((p) => p._id === action?.person);


### PR DESCRIPTION
`item` et `type` étaient utilisés au début, avant que `person` et `action` ne soient là