### PR TITLE
chore(dashboard): change higlight mode to avoid table redimensionment

### DIFF
--- a/dashboard/src/components/PersonName.js
+++ b/dashboard/src/components/PersonName.js
@@ -21,7 +21,7 @@ export default function PersonName({ item, redirectToTab = 'résumé' }) {
 
 const BoldOnHover = styled.span`
   &:hover {
-    font-weight: bold;
+    background-color: yellow;
     cursor: zoom-in;
   }
 `;


### PR DESCRIPTION
Actuellement comme on passe en bold au survol, ça fait danser le tableau, c'est un truc qui est plutôt évité le bold au survol. 

Pour que ça flash quand même j'ai mis comme un coup de stabilo. WDYT?
<img width="1088" alt="Capture d’écran 2022-04-05 à 11 43 31" src="https://user-images.githubusercontent.com/1575946/161727146-4ea08b2c-0a6f-4291-ab88-b4bbbbacf558.png">

