### PR TITLE
fix(dashboard): hide createdAt column in actions tables

### DIFF
--- a/dashboard/src/components/ActionsCalendar.js
+++ b/dashboard/src/components/ActionsCalendar.js
@@ -88,7 +88,6 @@ const ActionsCalendar = ({ actions, columns = ['Heure', 'Nom', 'Personne suivie'
           dataKey: 'person',
           render: (action) => <PersonName item={action} />,
         },
-        { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt || '') },
         { title: 'Statut', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
       ].filter((column) => columns.includes(column.title) || column.dataKey === 'urgent')}
     />

--- a/dashboard/src/scenes/action/list.js
+++ b/dashboard/src/scenes/action/list.js
@@ -210,7 +210,6 @@ const List = () => {
                 dataKey: 'person',
                 render: (action) => <PersonName item={action} />,
               },
-              { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt || '') },
               { title: 'Statut', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
             ]}
           />

--- a/dashboard/src/scenes/report/view.js
+++ b/dashboard/src/scenes/report/view.js
@@ -360,7 +360,6 @@ const ActionCompletedAt = ({ date, status, onUpdateResults = () => null }) => {
               dataKey: 'person',
               render: (action) => <PersonName item={action} />,
             },
-            { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt || '') },
             { title: 'Statut', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
           ]}
         />
@@ -427,7 +426,6 @@ const ActionCreatedAt = ({ date, onUpdateResults = () => null }) => {
               dataKey: 'person',
               render: (action) => <PersonName item={action} />,
             },
-            { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt) },
             { title: 'Statut', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
           ]}
         />

--- a/dashboard/src/scenes/search/index.js
+++ b/dashboard/src/scenes/search/index.js
@@ -147,7 +147,6 @@ const Actions = ({ search, onUpdateResults }) => {
             },
             { title: 'Nom', dataKey: 'name' },
             { title: 'Personne suivie', dataKey: 'person', render: (action) => <PersonName item={action} /> },
-            { title: 'Créée le', dataKey: 'createdAt', render: (action) => formatDateWithFullMonth(action.createdAt || '') },
             { title: 'Statut', dataKey: 'status', render: (action) => <ActionStatus status={action.status} /> },
           ]}
         />


### PR DESCRIPTION
Expérience remontée par Nathan, intéressante

J'en ai conclu qu'il valait mieux retirer cette colonne : elle n'apporte de toutes façons pas une information très utile, et manifestement elle peut porter à confusion

https://user-images.githubusercontent.com/31724752/164717833-8a33db3b-a42a-444e-ae0c-7325c5964f2e.mp4

Je lui ai répondu
> Pour cette action:
-> tu l'as créée le 22 avril
-> elle doit être réalisée le 21 avril
-> tu es sur `Hier`, on est le 22 avril dont hier c'est le 21 avril
-> l'affichage calendrier est l'affichage des actions par date de réalisation
donc tout est normal pour moi
Je pense que tu as pensé qu'il y avait un problème parce que tu as créé une action pour la veille, ce qui n'est probablement pas si habituel que ça ? Là par exemple en face de moi, j'ai une action créée le 8 avril à réaliser le 21, ça ne choque pas.
Si cette date "Créée le" est une peu déstabilisante, on peut enlever cette colonne !