### PR TITLE
fix(style): underline link on hover

### DIFF
--- a/dashboard/src/components/ButtonCustom.js
+++ b/dashboard/src/components/ButtonCustom.js
@@ -67,6 +67,7 @@ const ButtonWrapper = styled.button`
 
   &:hover {
     cursor: pointer;
+    ${(p) => p.color === 'link' && 'text-decoration: underline;'}
   }
 `;
 


### PR DESCRIPTION
Parce qu'on voit pas toujours que c'est des liens (ça m'aide pour une future PR)