### PR TITLE
fix(metabase): skip auth for public routes

### DIFF
--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -41,3 +41,6 @@ oauth2-proxy:
         name: oauth2-proxy-configmap
     - secretRef:
         name: oauth2-proxy-sealed-secret
+  additionalArgs:
+    - --skip-auth-route
+    - ^/public/.*,^/app/dist/.*,^/api/public/.*,^/api/session/.*,^/app/assets/.*


### PR DESCRIPTION
ceci permet de bypasser le proxy d'authentification pour les routes utilisées dans les dashboards metabase publics (ex: stats publiques)