### PR TITLE
feat(dashboard): save current comment and report description in session storage

### DIFF
--- a/dashboard/src/components/Comments.js
+++ b/dashboard/src/components/Comments.js
@@ -172,13 +172,14 @@ const EditingComment = ({ value = {}, commentId, onSubmit, onCancel, newComment 
         <ModalHeader toggle={onCancelRequest}>{newComment ? 'Créer un' : 'Éditer le'} commentaire</ModalHeader>
         <ModalBody>
           <Formik
-            initialValues={value}
+            initialValues={{ ...value, comment: value.comment || window.sessionStorage.getItem('currentComment') }}
             onSubmit={async (body, actions) => {
               if (!body.user && !newComment) return toastr.error('Erreur!', "L'utilisateur est obligatoire");
               if (!body.date && !newComment) return toastr.error('Erreur!', 'La date est obligatoire');
               if (!body.comment) return toastr.error('Erreur!', 'Le commentaire est obligatoire');
               await onSubmit({ ...value, ...body });
               actions.setSubmitting(false);
+              window.sessionStorage.removeItem('currentComment');
             }}>
             {({ values, handleChange, handleSubmit, isSubmitting }) => (
               <React.Fragment>
@@ -219,7 +220,16 @@ const EditingComment = ({ value = {}, commentId, onSubmit, onCancel, newComment 
                   <Col md={12}>
                     <FormGroup>
                       <Label htmlFor="comment">Commentaire</Label>
-                      <Input id="comment" name="comment" type="textarea" value={values.comment} onChange={handleChange} />
+                      <Input
+                        id="comment"
+                        name="comment"
+                        type="textarea"
+                        value={values.comment}
+                        onChange={(e) => {
+                          window.sessionStorage.setItem('currentComment', e.target.value);
+                          handleChange(e);
+                        }}
+                      />
                     </FormGroup>
                   </Col>
                   <Col md={12}>

--- a/dashboard/src/components/ReportDescriptionModale.js
+++ b/dashboard/src/components/ReportDescriptionModale.js
@@ -25,7 +25,7 @@ const ReportDescriptionModale = ({ report }) => {
         <ModalBody>
           <Formik
             className="noprint"
-            initialValues={report}
+            initialValues={{ ...report, description: report.description || window.sessionStorage.getItem('currentReportDescription') }}
             onSubmit={async (body) => {
               const reportUpdate = {
                 ...report,
@@ -41,6 +41,7 @@ const ReportDescriptionModale = ({ report }) => {
                 );
                 toastr.success('Mis à jour !');
                 setOpen(false);
+                window.sessionStorage.removeItem('currentReportDescription');
               }
             }}>
             {({ values, handleChange, handleSubmit, isSubmitting }) => (
@@ -48,7 +49,16 @@ const ReportDescriptionModale = ({ report }) => {
                 <Col md={12}>
                   <FormGroup>
                     <Label htmlFor="description">Description</Label>
-                    <Input id="description" name="description" type="textarea" value={values.description} onChange={handleChange} />
+                    <Input
+                      id="description"
+                      name="description"
+                      type="textarea"
+                      value={values.description}
+                      onChange={(e) => {
+                        window.sessionStorage.setItem('currentReportDescription', e.target.value);
+                        handleChange(e);
+                      }}
+                    />
                   </FormGroup>
                 </Col>
                 <Col md={12} style={{ display: 'flex', justifyContent: 'flex-end' }}>


### PR DESCRIPTION
…on storage

https://trello.com/c/t260xtI0/715-enregistrer-lédition-dun-commentaire-en-sessionstorage