### PR TITLE
fix(dashboard): remove utc on date display

### DIFF
--- a/dashboard/src/components/DateBloc.js
+++ b/dashboard/src/components/DateBloc.js
@@ -9,7 +9,7 @@ dayjs.locale('fr');
 
 const DateBloc = ({ date }) => {
   if (!date) return <div />;
-  date = dayjs.utc(date);
+  date = dayjs(date);
   return (
     <Container>
       <DayText>{date && date.format('dddd')}</DayText>


### PR DESCRIPTION
@rap2hpoutre je pense que tu veux regarder ça : il semblerait que tu aies mis `dayjs.utc()` pour une bonne raison au départ !
peut-être que tu as mieux à apporter...

en attendant, je merge !