### PR TITLE
feat(dashboard): check data consistency in dashboard

### DIFF
--- a/dashboard/src/components/Loader.js
+++ b/dashboard/src/components/Loader.js
@@ -225,9 +225,10 @@ const Loader = () => {
           setLoading(response.error);
           setProgress(1);
         }
-        return;
+        return false;
       }
-      return migrationIsDone(response.organisation);
+      migrationIsDone(response.organisation);
+      return false;
     }
 
     if (!organisation.migrations?.includes('reports-from-real-date-to-date-id')) {
@@ -264,9 +265,10 @@ const Loader = () => {
           setLoading(response.error);
           setProgress(1);
         }
-        return;
+        return false;
       }
-      return migrationIsDone(response.organisation);
+      migrationIsDone(response.organisation);
+      return false;
     }
 
     if (!organisation.migrations?.includes('clean-reports-with-no-team-nor-date')) {
@@ -295,10 +297,12 @@ const Loader = () => {
           setLoading(response.error);
           setProgress(1);
         }
-        return;
+        return false;
       }
-      return migrationIsDone(response.organisation);
+      migrationIsDone(response.organisation);
+      return false;
     }
+    return true;
   };
 
   const downloadData = async (dataToDownload, { initialLoad, total, lastRefresh }) => {
@@ -566,7 +570,8 @@ const Loader = () => {
     setFullScreen(showFullScreen);
     setLoading(initialLoad ? 'Chargement...' : 'Rafraichissement...');
 
-    await migrate();
+    const migrationsAreComplete = await migrate();
+    if (!migrationsAreComplete) return;
 
     /*
     Get number of data to download to show the appropriate loading progress bar


### PR DESCRIPTION
objectif:
ça peut arriver pour des raisons qui nous échappent (bug qu'on arrive pas à voir ? algo foireux ?) mais aussi des raisons hors de notre pouvoir (problème de réseau) que des données ne soient pas téléchargées.

ce qui peut expliquer les plaintes des utilisateurs de données disparues.

Proposition: 
-> après le `refresh`, on fait un `checkDataConsistency` qui compte le nombre de données dispo en BDD et le nombre de données téléchargées. S'il en manque, on télécharge les données manquantes, jusqu'à temps qu'il n'en manque plus.

Risque: boucle infinie pour je ne sais quelle raison ?

Avantage: utilisateur content.

TODO: côté app, si côté dashboard c'est déjà validé...