### PR TITLE
fix(dashboard): create report only when activity on the day

### DIFF
--- a/api/src/controllers/report.js
+++ b/api/src/controllers/report.js
@@ -53,8 +53,10 @@ router.post(
   validateEncryptionAndMigrations,
   catchErrors(async (req, res, next) => {
     try {
-      z.string().parse(req.body.encrypted);
-      z.string().parse(req.body.encryptedEntityKey);
+      z.object({
+        encrypted: z.string(),
+        encryptedEntityKey: z.string(),
+      }).parse(req.body);
     } catch (e) {
       const error = new Error(`Invalid request in report creation: ${e}`);
       error.status = 400;
@@ -91,9 +93,12 @@ router.put(
   validateEncryptionAndMigrations,
   catchErrors(async (req, res, next) => {
     try {
-      z.string().regex(looseUuidRegex).parse(req.params._id);
-      z.string().parse(req.body.encrypted);
-      z.string().parse(req.body.encryptedEntityKey);
+      z.object({
+        _id: z.string().regex(looseUuidRegex),
+        encrypted: z.string(),
+        encryptedEntityKey: z.string(),
+        organisation: z.string().regex(looseUuidRegex),
+      }).parse(req.body);
     } catch (e) {
       const error = new Error(`Invalid request in report put: ${e}`);
       error.status = 400;

--- a/app/src/scenes/Actions/Action.js
+++ b/app/src/scenes/Actions/Action.js
@@ -213,7 +213,8 @@ const Action = ({ navigation, route }) => {
           return a;
         })
       );
-      createReportAtDateIfNotExist(newAction.completedAt || newAction.createdAt);
+      createReportAtDateIfNotExist(newAction.createdAt);
+      if (newAction.completedAt) createReportAtDateIfNotExist(newAction.completedAt);
       if (!statusChanged) return response;
       const comment = {
         comment: `${user.name} a changé le status de l'action: ${mappedIdsToLabels.find((status) => status._id === newAction.status)?.name}`,

--- a/app/src/scenes/Actions/Action.js
+++ b/app/src/scenes/Actions/Action.js
@@ -29,6 +29,7 @@ import API from '../../services/api';
 import { currentTeamState, organisationState, userState } from '../../recoil/auth';
 import { capture } from '../../services/sentry';
 import CheckboxLabelled from '../../components/CheckboxLabelled';
+import useCreateReportAtDateIfNotExist from '../../utils/useCreateReportAtDateIfNotExist';
 
 const castToAction = (action) => {
   if (!action) action = {};
@@ -56,6 +57,7 @@ const Action = ({ navigation, route }) => {
   const allPersons = useRecoilValue(personsState);
   const [comments, setComments] = useRecoilState(commentsState);
   const currentTeam = useRecoilValue(currentTeamState);
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const [actionDB, setActionDB] = useState(() => {
     const existingAction = actions.find((a) => a._id === route.params?.action?._id);
@@ -203,18 +205,16 @@ const Action = ({ navigation, route }) => {
         path: `/action/${oldAction._id}`,
         body: prepareActionForEncryption(action),
       });
-      if (response.ok) {
-        setActions((actions) =>
-          actions.map((a) => {
-            if (a._id === response.decryptedData._id) return response.decryptedData;
-            return a;
-          })
-        );
-      }
       if (!response?.ok) return response;
       const newAction = response.decryptedData;
+      setActions((actions) =>
+        actions.map((a) => {
+          if (a._id === newAction._id) return newAction;
+          return a;
+        })
+      );
+      createReportAtDateIfNotExist(newAction.completedAt || newAction.createdAt);
       if (!statusChanged) return response;
-
       const comment = {
         comment: `${user.name} a changé le status de l'action: ${mappedIdsToLabels.find((status) => status._id === newAction.status)?.name}`,
         action: actionDB?._id,
@@ -297,6 +297,8 @@ const Action = ({ navigation, route }) => {
       return;
     }
     setActions((actions) => [response.decryptedData, ...actions]);
+    createReportAtDateIfNotExist(response.decryptedData.createdAt);
+
     for (let c of comments.filter((c) => c.action === actionDB._id).filter((c) => !c.comment.includes('a changé le status'))) {
       const body = {
         comment: c.comment,

--- a/app/src/scenes/Actions/NewActionForm.js
+++ b/app/src/scenes/Actions/NewActionForm.js
@@ -18,6 +18,7 @@ import { currentTeamState, userState } from '../../recoil/auth';
 import API from '../../services/api';
 import ActionCategoriesMultiCheckboxes from '../../components/MultiCheckBoxes/ActionCategoriesMultiCheckboxes';
 import CheckboxLabelled from '../../components/CheckboxLabelled';
+import useCreateReportAtDateIfNotExist from '../../utils/useCreateReportAtDateIfNotExist';
 
 const NewActionForm = ({ route, navigation }) => {
   const setActions = useSetRecoilState(actionsState);
@@ -32,6 +33,7 @@ const NewActionForm = ({ route, navigation }) => {
   const forCurrentPerson = useRef(!!route.params?.person).current;
   const [posting, setPosting] = useState(false);
   const [status, setStatus] = useState(TODO);
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const backRequestHandledRef = useRef(null);
 
@@ -88,6 +90,7 @@ const NewActionForm = ({ route, navigation }) => {
       setActions((actions) => [response.decryptedData, ...actions]);
       actions.push(response.decryptedData);
     }
+    createReportAtDateIfNotExist(newAction.completedAt || newAction.createdAt);
     // because when we go back from Action to ActionsList, we don't want the Back popup to be triggered
     backRequestHandledRef.current = true;
     Sentry.setContext('action', { _id: newAction._id });

--- a/app/src/scenes/Actions/NewActionForm.js
+++ b/app/src/scenes/Actions/NewActionForm.js
@@ -90,7 +90,8 @@ const NewActionForm = ({ route, navigation }) => {
       setActions((actions) => [response.decryptedData, ...actions]);
       actions.push(response.decryptedData);
     }
-    createReportAtDateIfNotExist(newAction.completedAt || newAction.createdAt);
+    createReportAtDateIfNotExist(newAction.createdAt);
+    if (newAction.completedAt) createReportAtDateIfNotExist(newAction.completedAt);
     // because when we go back from Action to ActionsList, we don't want the Back popup to be triggered
     backRequestHandledRef.current = true;
     Sentry.setContext('action', { _id: newAction._id });

--- a/app/src/scenes/Comments/CommentRow.js
+++ b/app/src/scenes/Comments/CommentRow.js
@@ -11,6 +11,8 @@ const CommentRow = ({ onUpdate, comment, showActionSheetWithOptions, itemName, o
   const user = useRecoilValue(userState);
   const setComments = useSetRecoilState(commentsState);
 
+  console.log({ comment });
+
   const onMorePress = async () => {
     const options = ['Supprimer', 'Annuler'];
     if (onUpdate && comment.user === user._id) options.unshift('Modifier');

--- a/app/src/scenes/Comments/CommentRow.js
+++ b/app/src/scenes/Comments/CommentRow.js
@@ -11,8 +11,6 @@ const CommentRow = ({ onUpdate, comment, showActionSheetWithOptions, itemName, o
   const user = useRecoilValue(userState);
   const setComments = useSetRecoilState(commentsState);
 
-  console.log({ comment });
-
   const onMorePress = async () => {
     const options = ['Supprimer', 'Annuler'];
     if (onUpdate && comment.user === user._id) options.unshift('Modifier');

--- a/app/src/scenes/Comments/NewCommentInput.js
+++ b/app/src/scenes/Comments/NewCommentInput.js
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { Alert, Keyboard } from 'react-native';
+import dayjs from 'dayjs';
 import Button from '../../components/Button';
 import InputMultilineAutoAdjust from '../../components/InputMultilineAutoAdjust';
 import Spacer from '../../components/Spacer';
@@ -9,7 +10,7 @@ import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { commentsState, prepareCommentForEncryption } from '../../recoil/comments';
 import { currentTeamState, organisationState, userState } from '../../recoil/auth';
 import API from '../../services/api';
-import dayjs from 'dayjs';
+import useCreateReportAtDateIfNotExist from '../../utils/useCreateReportAtDateIfNotExist';
 
 const NewCommentInput = ({ person, action, forwardRef, onFocus, onCommentWrite }) => {
   const [comment, setComment] = useState('');
@@ -18,6 +19,7 @@ const NewCommentInput = ({ person, action, forwardRef, onFocus, onCommentWrite }
   const organisation = useRecoilValue(organisationState);
   const currentTeam = useRecoilValue(currentTeamState);
   const user = useRecoilValue(userState);
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const onCreateComment = async () => {
     setPosting(true);
@@ -37,13 +39,12 @@ const NewCommentInput = ({ person, action, forwardRef, onFocus, onCommentWrite }
       Alert.alert(response.error || response.code);
       return;
     }
-    if (response.ok) {
-      setComments((comments) => [response.decryptedData, ...comments]);
-      Keyboard.dismiss();
-      setPosting(false);
-      setComment('');
-      onCommentWrite?.('');
-    }
+    setComments((comments) => [response.decryptedData, ...comments]);
+    createReportAtDateIfNotExist(response.decryptedData.date);
+    Keyboard.dismiss();
+    setPosting(false);
+    setComment('');
+    onCommentWrite?.('');
   };
 
   const onCancelRequest = () => {

--- a/app/src/scenes/Persons/Consultation.js
+++ b/app/src/scenes/Persons/Consultation.js
@@ -20,6 +20,7 @@ import { CANCEL, DONE, TODO } from '../../recoil/actions';
 import CheckboxLabelled from '../../components/CheckboxLabelled';
 import ButtonsContainer from '../../components/ButtonsContainer';
 import ButtonDelete from '../../components/ButtonDelete';
+import useCreateReportAtDateIfNotExist from '../../utils/useCreateReportAtDateIfNotExist';
 
 const cleanValue = (value) => {
   if (typeof value === 'string') return (value || '').trim();
@@ -33,6 +34,7 @@ const Consultation = ({ navigation, route }) => {
   const personDB = route?.params?.personDB;
   const consultationDB = route?.params?.consultationDB;
   const isNew = !consultationDB?._id;
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const castToConsultation = useCallback(
     (consult = {}) => {
@@ -111,6 +113,7 @@ const Consultation = ({ navigation, route }) => {
           .sort((a, b) => new Date(b.startDate) - new Date(a.startDate))
       );
     }
+    createReportAtDateIfNotExist(consultationResponse.decryptedData.completedAt || consultationResponse.decryptedData.createdAt);
     onBack();
   };
 

--- a/app/src/scenes/Persons/Consultation.js
+++ b/app/src/scenes/Persons/Consultation.js
@@ -113,7 +113,8 @@ const Consultation = ({ navigation, route }) => {
           .sort((a, b) => new Date(b.startDate) - new Date(a.startDate))
       );
     }
-    createReportAtDateIfNotExist(consultationResponse.decryptedData.completedAt || consultationResponse.decryptedData.createdAt);
+    createReportAtDateIfNotExist(consultationResponse.decryptedData.createdAt);
+    if (consultationResponse.decryptedData.completedAt) createReportAtDateIfNotExist(consultationResponse.decryptedData.completedAt);
     onBack();
   };
 

--- a/app/src/scenes/Reports/Report.js
+++ b/app/src/scenes/Reports/Report.js
@@ -143,7 +143,6 @@ const Report = ({ navigation, route }) => {
   const onUpdateReport = async () => {
     const reportToUpdate = reportDB || (await createReportAtDateIfNotExist(day));
     setUpdating(true);
-    console.log({ ...reportToUpdate, ...castToReport(report) });
     const response = await API.put({
       path: `/report/${reportToUpdate?._id}`,
       body: prepareReportForEncryption({ ...reportToUpdate, ...castToReport(report) }),

--- a/app/src/scenes/Reports/Report.js
+++ b/app/src/scenes/Reports/Report.js
@@ -2,7 +2,7 @@ import { useIsFocused } from '@react-navigation/native';
 import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { ActivityIndicator, Alert } from 'react-native';
-import { selector, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import InputLabelled from '../../components/InputLabelled';
 import Label from '../../components/Label';
@@ -18,6 +18,7 @@ import { currentTeamState } from '../../recoil/auth';
 import { prepareReportForEncryption, reportsState } from '../../recoil/reports';
 import API from '../../services/api';
 import colors from '../../utils/colors';
+import useCreateReportAtDateIfNotExist from '../../utils/useCreateReportAtDateIfNotExist';
 import {
   actionsCompletedOrCanceledForReport,
   actionsCreatedForReport,
@@ -30,7 +31,6 @@ import { getPeriodTitle } from './utils';
 const castToReport = (report = {}) => ({
   description: report.description?.trim() || '',
   collaborations: report.collaborations || [],
-  date: report.date,
 });
 
 const ReportLoading = ({ navigation, route }) => {
@@ -73,37 +73,49 @@ const Report = ({ navigation, route }) => {
   const [reportDB, setReportDB] = useState(() => route?.params?.report);
   const [report, setReport] = useState(() => castToReport(reportDB));
 
+  const actionsCreated = useRecoilValue(actionsCreatedForReport({ date: day }));
+  const actionsCompleted = useRecoilValue(actionsCompletedOrCanceledForReport({ date: day, status: DONE }));
+  const actionsCanceled = useRecoilValue(actionsCompletedOrCanceledForReport({ date: day, status: CANCEL }));
+  const comments = useRecoilValue(commentsForReport({ date: day }));
+  const observations = useRecoilValue(observationsForReport({ date: day }));
+
   const isFocused = useIsFocused();
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
+
   useEffect(() => {
-    if (isFocused) {
-      if (!reportDB?._id) {
+    if (!isFocused) return;
+    if (!reportDB?._id) {
+      // to update collaborations
+      const reportFoundByDate = teamsReports.find((r) => r.date === day);
+      if (reportFoundByDate) {
+        setReportDB(reportFoundByDate);
+        setReport(castToReport(reportFoundByDate));
+        return;
+      }
+      // to update regarding actions etc.
+      if (actionsCreated.length || actionsCompleted.length || actionsCanceled.length || comments.length || observations.length) {
         (async () => {
-          const report = teamsReports.find((r) => r.date === day);
-          if (report) {
-            setReportDB(report);
-            setReport(castToReport(report));
-          } else {
-            const res = await API.post({ path: '/report', body: prepareReportForEncryption({ team: currentTeam._id, date: day }) });
-            const newReport = res.decryptedData;
-            setReports((reports) => [newReport, ...reports].sort((r1, r2) => (dayjs(r1.date).isBefore(dayjs(r2.date), 'day') ? 1 : -1)));
-            setReportDB(newReport);
-            setReport(castToReport(newReport));
-          }
+          const newReport = await createReportAtDateIfNotExist(day);
+          setReportDB(newReport);
+          setReport(castToReport(newReport));
         })();
-      } else {
-        // to update collaborations
-        const freshReport = teamsReports.find((r) => r._id === reportDB?._id);
-        setReportDB(freshReport);
-        setReport(castToReport(freshReport));
+        return;
       }
     }
-  }, [isFocused, reportDB]);
-
-  const actionsCreated = useRecoilValue(actionsCreatedForReport({ date: reportDB?.date }));
-  const actionsCompleted = useRecoilValue(actionsCompletedOrCanceledForReport({ date: reportDB?.date, status: DONE }));
-  const actionsCanceled = useRecoilValue(actionsCompletedOrCanceledForReport({ date: reportDB?.date, status: CANCEL }));
-  const comments = useRecoilValue(commentsForReport({ date: reportDB?.date }));
-  const observations = useRecoilValue(observationsForReport({ date: reportDB?.date }));
+    // to update collaborations
+    const freshReport = teamsReports.find((r) => r._id === reportDB?._id);
+    setReportDB(freshReport);
+    setReport(castToReport(freshReport));
+  }, [
+    isFocused,
+    reportDB?._id,
+    teamsReports,
+    actionsCreated.length,
+    actionsCompleted.length,
+    actionsCanceled.length,
+    comments.length,
+    observations.length,
+  ]);
 
   const [updating, setUpdating] = useState(false);
   const [editable, setEditable] = useState(route?.params?.editable || false);
@@ -121,8 +133,7 @@ const Report = ({ navigation, route }) => {
   };
 
   const isUpdateDisabled = useMemo(() => {
-    if (!reportDB) return true;
-    const newReport = { ...reportDB, ...castToReport(report) };
+    const newReport = { ...(reportDB || {}), ...castToReport(report) };
     if (JSON.stringify(castToReport(reportDB)) !== JSON.stringify(castToReport(newReport))) return false;
     return true;
   }, [reportDB, report]);
@@ -130,10 +141,12 @@ const Report = ({ navigation, route }) => {
   const onEdit = () => setEditable((e) => !e);
 
   const onUpdateReport = async () => {
+    const reportToUpdate = reportDB || (await createReportAtDateIfNotExist(day));
     setUpdating(true);
+    console.log({ ...reportToUpdate, ...castToReport(report) });
     const response = await API.put({
-      path: `/report/${reportDB?._id}`,
-      body: prepareReportForEncryption({ ...reportDB, ...castToReport(report) }),
+      path: `/report/${reportToUpdate?._id}`,
+      body: prepareReportForEncryption({ ...reportToUpdate, ...castToReport(report) }),
     });
     if (response.error) {
       setUpdating(false);
@@ -143,7 +156,7 @@ const Report = ({ navigation, route }) => {
     if (response.ok) {
       setReports((reports) =>
         reports.map((a) => {
-          if (a._id === reportDB?._id) return response.decryptedData;
+          if (a._id === reportToUpdate?._id) return response.decryptedData;
           return a;
         })
       );
@@ -191,24 +204,6 @@ const Report = ({ navigation, route }) => {
     [currentTeam?.name, currentTeam?.nightSession, day]
   );
 
-  if (!report) {
-    return (
-      <SceneContainer>
-        <ScreenTitle
-          title={title}
-          onBack={onGoBackRequested}
-          onEdit={!editable ? onEdit : null}
-          onSave={!editable || isUpdateDisabled ? null : onUpdateReport}
-          saving={updating}
-          testID="report"
-        />
-        <ScrollContainer noPadding>
-          <ActivityIndicator size="large" color={colors.app.color} />
-        </ScrollContainer>
-      </SceneContainer>
-    );
-  }
-
   return (
     <SceneContainer>
       <ScreenTitle
@@ -234,7 +229,7 @@ const Report = ({ navigation, route }) => {
             data={report.collaborations}
             onChange={(collaborations) => setReport((r) => ({ ...r, collaborations }))}
             editable={editable}
-            onAddRequest={() => navigation.navigate('Collaborations', { report: reportDB })}
+            onAddRequest={() => navigation.navigate('Collaborations', { report: reportDB, day })}
             renderTag={(collaboration) => <MyText>{collaboration}</MyText>}
           />
         </Summary>

--- a/app/src/scenes/Reports/Report.js
+++ b/app/src/scenes/Reports/Report.js
@@ -1,7 +1,7 @@
 import { useIsFocused } from '@react-navigation/native';
 import dayjs from 'dayjs';
 import React, { useEffect, useMemo, useRef, useState } from 'react';
-import { ActivityIndicator, Alert } from 'react-native';
+import { ActivityIndicator, Alert, InteractionManager } from 'react-native';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import styled from 'styled-components';
 import InputLabelled from '../../components/InputLabelled';
@@ -45,9 +45,9 @@ const ReportLoading = ({ navigation, route }) => {
   );
 
   useEffect(() => {
-    setTimeout(() => {
+    InteractionManager.runAfterInteractions(() => {
       setIsLoading(false);
-    }, 500);
+    });
   }, []);
 
   if (isLoading) {

--- a/app/src/utils/useCreateReportAtDateIfNotExist.js
+++ b/app/src/utils/useCreateReportAtDateIfNotExist.js
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { currentTeamState } from '../recoil/auth';
-import { reportsState } from '../recoil/reports';
+import { prepareReportForEncryption, reportsState } from '../recoil/reports';
 import { currentTeamReportsSelector } from '../scenes/Reports/selectors';
 import API from '../services/api';
 

--- a/app/src/utils/useCreateReportAtDateIfNotExist.js
+++ b/app/src/utils/useCreateReportAtDateIfNotExist.js
@@ -1,0 +1,24 @@
+import dayjs from 'dayjs';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { currentTeamState } from '../recoil/auth';
+import { reportsState } from '../recoil/reports';
+import { currentTeamReportsSelector } from '../scenes/Reports/selectors';
+import API from '../services/api';
+
+const useCreateReportAtDateIfNotExist = () => {
+  const currentTeam = useRecoilValue(currentTeamState);
+  const currentTeamReports = useRecoilValue(currentTeamReportsSelector);
+  const setReports = useSetRecoilState(reportsState);
+
+  return async (date) => {
+    date = dayjs(date).startOf('day').format('YYYY-MM-DD');
+    const reportAtDate = currentTeamReports.find((report) => report.date === date);
+    if (!!reportAtDate) return;
+    const res = await API.post({ path: '/report', body: prepareReportForEncryption({ team: currentTeam._id, date }) });
+    if (!res.ok) return;
+    setReports((reports) => [res.decryptedData, ...reports]);
+    return res.decryptedData;
+  };
+};
+
+export default useCreateReportAtDateIfNotExist;

--- a/dashboard/src/components/Comments.js
+++ b/dashboard/src/components/Comments.js
@@ -17,6 +17,7 @@ import { formatDateTimeWithNameOfDay, dateForDatePicker } from '../services/date
 import useApi from '../services/api';
 import ExclamationMarkButton from './ExclamationMarkButton';
 import { useDataLoader } from './DataLoader';
+import useCreateReportAtDateIfNotExist from '../services/useCreateReportAtDateIfNotExist';
 
 const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
   const [editingId, setEditing] = useState(null);
@@ -27,6 +28,7 @@ const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
   const currentTeam = useRecoilValue(currentTeamState);
   const organisation = useRecoilValue(organisationState);
   const { isLoading } = useDataLoader();
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const comments = useMemo(
     () =>
@@ -71,6 +73,7 @@ const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
     if (!response.ok) return;
     setComments((comments) => [response.decryptedData, ...comments]);
     toast.success('Commentaire ajouté !');
+    createReportAtDateIfNotExist(response.decryptedData.date);
     setClearNewCommentKey((k) => k + 1);
   };
 
@@ -86,6 +89,7 @@ const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
           return c;
         })
       );
+      createReportAtDateIfNotExist(response.decryptedData.date);
     }
     if (!response.ok) return;
     toast.success('Commentaire mis à jour');

--- a/dashboard/src/components/Comments.js
+++ b/dashboard/src/components/Comments.js
@@ -89,7 +89,7 @@ const Comments = ({ personId = '', actionId = '', onUpdateResults }) => {
           return c;
         })
       );
-      createReportAtDateIfNotExist(response.decryptedData.date);
+      createReportAtDateIfNotExist(response.decryptedData.date || response.decryptedData.createdAt);
     }
     if (!response.ok) return;
     toast.success('Commentaire mis à jour');

--- a/dashboard/src/components/CreateActionModal.js
+++ b/dashboard/src/components/CreateActionModal.js
@@ -16,6 +16,7 @@ import SelectPerson from './SelectPerson';
 import ButtonCustom from './ButtonCustom';
 import SelectStatus from './SelectStatus';
 import SelectCustom from './SelectCustom';
+import useCreateReportAtDateIfNotExist from '../services/useCreateReportAtDateIfNotExist';
 
 const CreateActionModal = ({ person = null, persons = null, isMulti = false, completedAt, dueAt, open = false, setOpen = () => {} }) => {
   const teams = useRecoilValue(teamsState);
@@ -24,11 +25,13 @@ const CreateActionModal = ({ person = null, persons = null, isMulti = false, com
   const setActions = useSetRecoilState(actionsState);
   const history = useHistory();
   const API = useApi();
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const onAddAction = async (body) => {
     if (body.status !== TODO) body.completedAt = completedAt || Date.now();
     const response = await API.post({ path: '/action', body: prepareActionForEncryption(body) });
     if (response.ok) setActions((actions) => [response.decryptedData, ...actions]);
+    createReportAtDateIfNotExist(response.decryptedData.date);
     return response;
   };
 

--- a/dashboard/src/components/CreateObservation.js
+++ b/dashboard/src/components/CreateObservation.js
@@ -15,6 +15,7 @@ import { territoriesState } from '../recoil/territory';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { dateForDatePicker } from '../services/date';
 import useApi from '../services/api';
+import useCreateReportAtDateIfNotExist from '../services/useCreateReportAtDateIfNotExist';
 export const policeSelect = ['Oui', 'Non'];
 export const atmosphereSelect = ['Violences', 'Tensions', 'RAS'];
 
@@ -31,11 +32,13 @@ const CreateObservation = ({ observation = {}, forceOpen = 0 }) => {
   const customFieldsObs = useRecoilValue(customFieldsObsSelector);
   const setTerritoryObs = useSetRecoilState(territoryObservationsState);
   const API = useApi();
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const addTerritoryObs = async (obs) => {
     const res = await API.post({ path: '/territory-observation', body: prepareObsForEncryption(customFieldsObs)(obs) });
     if (res.ok) {
       setTerritoryObs((territoryObservations) => [res.decryptedData, ...territoryObservations]);
+      createReportAtDateIfNotExist(res.decryptedData.observedAt);
     }
     return res;
   };
@@ -49,6 +52,7 @@ const CreateObservation = ({ observation = {}, forceOpen = 0 }) => {
           return a;
         })
       );
+      createReportAtDateIfNotExist(res.decryptedData.observedAt);
     }
     return res;
   };

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -239,7 +239,6 @@ export default function DataLoader() {
           : mergeItems(reports, res.decryptedData)
               // This line should be removed when `clean-reports-with-no-team-nor-date` migration has run on all organisations.
               .filter((r) => !!r.team && !!r.date)
-              .sort((r1, r2) => (dayjsInstance(r1.date).isBefore(dayjsInstance(r2.date), 'day') ? 1 : -1))
       );
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);

--- a/dashboard/src/components/Passage.js
+++ b/dashboard/src/components/Passage.js
@@ -13,12 +13,14 @@ import useApi from '../services/api';
 import { passagesState, preparePassageForEncryption } from '../recoil/passages';
 import SelectTeam from './SelectTeam';
 import SelectPerson from './SelectPerson';
+import useCreateReportAtDateIfNotExist from '../services/useCreateReportAtDateIfNotExist';
 
 const Passage = ({ passage, onFinished }) => {
   const user = useRecoilValue(userState);
   const teams = useRecoilValue(teamsState);
   const [open, setOpen] = useState(false);
   const API = useApi();
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const setPassages = useSetRecoilState(passagesState);
 
@@ -78,6 +80,7 @@ const Passage = ({ passage, onFinished }) => {
                     });
                     if (response.ok) {
                       setPassages((passages) => [response.decryptedData, ...passages]);
+                      createReportAtDateIfNotExist(response.decryptedData.date);
                     }
                   }
                 } else if (showMultiSelect) {
@@ -88,6 +91,7 @@ const Passage = ({ passage, onFinished }) => {
                     });
                     if (response.ok) {
                       setPassages((passages) => [response.decryptedData, ...passages]);
+                      createReportAtDateIfNotExist(response.decryptedData.date);
                     }
                   }
                 } else {
@@ -97,6 +101,7 @@ const Passage = ({ passage, onFinished }) => {
                   });
                   if (response.ok) {
                     setPassages((passages) => [response.decryptedData, ...passages]);
+                    createReportAtDateIfNotExist(response.decryptedData.date);
                   }
                 }
 
@@ -117,6 +122,7 @@ const Passage = ({ passage, onFinished }) => {
                     return p;
                   })
                 );
+                createReportAtDateIfNotExist(response.decryptedData.date);
               }
               if (!response.ok) return;
               setOpen(false);

--- a/dashboard/src/scenes/action/view.js
+++ b/dashboard/src/scenes/action/view.js
@@ -27,6 +27,7 @@ import { commentsState, prepareCommentForEncryption } from '../../recoil/comment
 import useApi from '../../services/api';
 import useTitle from '../../services/useTitle';
 import { useDataLoader } from '../../components/DataLoader';
+import useCreateReportAtDateIfNotExist from '../../services/useCreateReportAtDateIfNotExist';
 
 const View = () => {
   const { id } = useParams();
@@ -36,6 +37,7 @@ const View = () => {
   const currentTeam = useRecoilValue(currentTeamState);
   const [actions, setActions] = useRecoilState(actionsState);
   const [comments, setComments] = useRecoilState(commentsState);
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const history = useHistory();
   const API = useApi();
@@ -136,6 +138,7 @@ const View = () => {
                 return a;
               })
             );
+            createReportAtDateIfNotExist(newAction.completedAt || newAction.createdAt);
             if (statusChanged) {
               const comment = {
                 comment: `${user.name} a changé le status de l'action: ${mappedIdsToLabels.find((status) => status._id === newAction.status)?.name}`,

--- a/dashboard/src/scenes/action/view.js
+++ b/dashboard/src/scenes/action/view.js
@@ -138,7 +138,8 @@ const View = () => {
                 return a;
               })
             );
-            createReportAtDateIfNotExist(newAction.completedAt || newAction.createdAt);
+            createReportAtDateIfNotExist(newAction.createdAt);
+            if (newAction.completedAt) createReportAtDateIfNotExist(newAction.completedAt);
             if (statusChanged) {
               const comment = {
                 comment: `${user.name} a changé le status de l'action: ${mappedIdsToLabels.find((status) => status._id === newAction.status)?.name}`,

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -33,6 +33,7 @@ import { consultationsState, defaultConsultationFields, prepareConsultationForEn
 import { prepareTreatmentForEncryption, treatmentsState } from '../../recoil/treatments';
 import { medicalFileState, prepareMedicalFileForEncryption, customFieldsMedicalFileSelector } from '../../recoil/medicalFiles';
 import { modalConfirmState } from '../../components/ModalConfirm';
+import useCreateReportAtDateIfNotExist from '../../services/useCreateReportAtDateIfNotExist';
 
 export function MedicalFile({ person }) {
   const setPersons = useSetRecoilState(personsState);
@@ -62,6 +63,7 @@ export function MedicalFile({ person }) {
   const user = useRecoilValue(userState);
   const users = useRecoilValue(usersState);
   const API = useApi();
+  const createReportAtDateIfNotExist = useCreateReportAtDateIfNotExist();
 
   const loadConsultation = (consultation) => {
     setShowAddConsultation(true);
@@ -708,6 +710,7 @@ export function MedicalFile({ person }) {
                   .sort((a, b) => new Date(b.dueAt) - new Date(a.dueAt))
               );
             }
+            createReportAtDateIfNotExist(consultationResponse.decryptedData.completedAt || consultationResponse.decryptedData.createdAt);
             resetCurrentConsultation();
           }}>
           {({ values, handleChange, handleSubmit, isSubmitting, touched, errors }) => (

--- a/dashboard/src/scenes/person/MedicalFile.js
+++ b/dashboard/src/scenes/person/MedicalFile.js
@@ -710,7 +710,8 @@ export function MedicalFile({ person }) {
                   .sort((a, b) => new Date(b.dueAt) - new Date(a.dueAt))
               );
             }
-            createReportAtDateIfNotExist(consultationResponse.decryptedData.completedAt || consultationResponse.decryptedData.createdAt);
+            createReportAtDateIfNotExist(consultationResponse.decryptedData.createdAt);
+            if (consultationResponse.decryptedData.completedAt) createReportAtDateIfNotExist(consultationResponse.decryptedData.completedAt);
             resetCurrentConsultation();
           }}>
           {({ values, handleChange, handleSubmit, isSubmitting, touched, errors }) => (

--- a/dashboard/src/scenes/report/list.js
+++ b/dashboard/src/scenes/report/list.js
@@ -1,11 +1,8 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { useHistory } from 'react-router-dom';
 import { SmallHeader } from '../../components/header';
 import { currentTeamState } from '../../recoil/auth';
-import { prepareReportForEncryption, reportsState } from '../../recoil/reports';
-import { useRecoilValue, useSetRecoilState } from 'recoil';
-import useApi from '../../services/api';
-import { currentTeamReportsSelector } from '../../recoil/selectors';
+import { useRecoilValue } from 'recoil';
 import useTitle from '../../services/useTitle';
 import { useDataLoader } from '../../components/DataLoader';
 import ReportsMonthly from '../../components/ReportsMonthly';
@@ -15,23 +12,12 @@ const List = () => {
   useDataLoader({ refreshOnMount: true });
 
   const currentTeam = useRecoilValue(currentTeamState);
-  const reports = useRecoilValue(currentTeamReportsSelector);
-  const [submiting, setSubmiting] = useState(false);
-  const API = useApi();
-  const setReports = useSetRecoilState(reportsState);
 
   const history = useHistory();
 
   const onReportClick = async (report, date) => {
     if (report) return history.push(`/report/${report._id}`);
-    if (submiting) return;
-    setSubmiting(true);
-    const existingReport = reports.find((r) => r.date === date && r.team === currentTeam._id);
-    if (!!existingReport) return history.push(`/report/${existingReport._id}`);
-    const res = await API.post({ path: '/report', body: prepareReportForEncryption({ team: currentTeam._id, date }) });
-    if (!res.ok) return;
-    setReports((reports) => [res.decryptedData, ...reports].sort((r1, r2) => r2.date.localeCompare(r1.date)));
-    history.push(`/report/${res.data._id}`);
+    history.push(`/report/new__${date}`);
   };
 
   return (

--- a/dashboard/src/scenes/stats/index.js
+++ b/dashboard/src/scenes/stats/index.js
@@ -830,8 +830,9 @@ function CustomFieldsStats({ customFields, data, additionalCols = [] }) {
     .filter((f) => f.enabled)
     .filter((f) => f.showInStats)
     .filter((field) => ['boolean', 'yes-no', 'enum', 'multi-choice'].includes(field.type));
+
   const totalCols = customFieldsNumber.length + customFieldsDate.length + additionalCols.length;
-  console.log(customFieldsNumber);
+
   const colSize = getColsSize(totalCols);
   return (
     <>

--- a/dashboard/src/services/useCreateReportAtDateIfNotExist.js
+++ b/dashboard/src/services/useCreateReportAtDateIfNotExist.js
@@ -1,3 +1,4 @@
+import dayjs from 'dayjs';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { currentTeamState } from '../recoil/auth';
 import { prepareReportForEncryption, reportsState } from '../recoil/reports';
@@ -11,6 +12,7 @@ const useCreateReportAtDateIfNotExist = () => {
   const API = useApi();
 
   return async (date) => {
+    date = dayjs(date).startOf('day').format('YYYY-MM-DD');
     const reportAtDate = currentTeamReports.find((report) => report.date === date);
     if (!!reportAtDate) return;
     const res = await API.post({ path: '/report', body: prepareReportForEncryption({ team: currentTeam._id, date }) });

--- a/dashboard/src/services/useCreateReportAtDateIfNotExist.js
+++ b/dashboard/src/services/useCreateReportAtDateIfNotExist.js
@@ -1,0 +1,23 @@
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { currentTeamState } from '../recoil/auth';
+import { prepareReportForEncryption, reportsState } from '../recoil/reports';
+import { currentTeamReportsSelector } from '../recoil/selectors';
+import useApi from './api';
+
+const useCreateReportAtDateIfNotExist = () => {
+  const currentTeam = useRecoilValue(currentTeamState);
+  const currentTeamReports = useRecoilValue(currentTeamReportsSelector);
+  const setReports = useSetRecoilState(reportsState);
+  const API = useApi();
+
+  return async (date) => {
+    const reportAtDate = currentTeamReports.find((report) => report.date === date);
+    if (!!reportAtDate) return;
+    const res = await API.post({ path: '/report', body: prepareReportForEncryption({ team: currentTeam._id, date }) });
+    if (!res.ok) return;
+    setReports((reports) => [res.decryptedData, ...reports]);
+    return res.decryptedData;
+  };
+};
+
+export default useCreateReportAtDateIfNotExist;

--- a/tests/src/__tests__/report.test.ts
+++ b/tests/src/__tests__/report.test.ts
@@ -28,9 +28,7 @@ describe("Organisation CRUD", () => {
   it("should be able to update stuff in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format(
-        "dddd D MMMM YYYY"
-      )} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
     );
     await page.waitForTimeout(2000);
 
@@ -89,9 +87,7 @@ describe("Organisation CRUD", () => {
   it("should be able to see the action in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format(
-        "dddd D MMMM YYYY"
-      )} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toMatch("Mon action");
   });
@@ -99,19 +95,11 @@ describe("Organisation CRUD", () => {
   it("should be able to add a passage", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format(
-        "dddd D MMMM YYYY"
-      )} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toClick("input#person-select-and-create-reception");
-    await expect(page).toClick(
-      "div.person-select-and-create-reception__option"
-    );
-    expect(
-      await getInnerText(
-        "div.person-select-and-create-reception__multi-value__label"
-      )
-    ).toBe(
+    await expect(page).toClick("div.person-select-and-create-reception__option");
+    expect(await getInnerText("div.person-select-and-create-reception__multi-value__label")).toBe(
       `Ma première personne
 
 Accéder au dossier`
@@ -127,9 +115,7 @@ Accéder au dossier`
   it("should be able go in the report", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
+    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
     await expect(page).toClick("button", { text: dayjs().format("D") });
     await page.waitForTimeout(1000);
     await expect(page).toMatch(`Compte rendu de l'équipe Encrypted Orga Team`);
@@ -139,23 +125,17 @@ Accéder au dossier`
   it("should be able to go to previous report then next report", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(2000);
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
+    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Suivant" });
     await expect(page).toMatch(`Journée du ${dayjs().format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Précédent" });
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Suivant" });
     await page.waitForTimeout(1000);
   });
@@ -179,12 +159,8 @@ Accéder au dossier`
   it("should be able to see passages in the report", async () => {
     await expect(page).toClick("a", { text: "Passages (3)" });
     await page.waitForTimeout(1000);
-    expect(await getInnerText("span#report-passages-anonymous-count")).toBe(
-      "2"
-    );
-    expect(await getInnerText("span#report-passages-non-anonymous-count")).toBe(
-      "1"
-    );
+    expect(await getInnerText("span#report-passages-anonymous-count")).toBe("2");
+    expect(await getInnerText("span#report-passages-non-anonymous-count")).toBe("1");
     await expect(page).toMatch("Ma première personne");
     await expect(page).toMatch("Anonyme");
   });
@@ -205,12 +181,8 @@ Accéder au dossier`
     await expect(page).toClick("td", { text: "Mon action" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("input#update-action-select-status");
-    await expect(page).toClick(
-      "div.update-action-select-status__option:nth-of-type(2)"
-    );
-    expect(
-      await getInnerText("div.update-action-select-status__single-value")
-    ).toBe("FAITE");
+    await expect(page).toClick("div.update-action-select-status__option:nth-of-type(2)");
+    expect(await getInnerText("div.update-action-select-status__single-value")).toBe("FAITE");
     await scrollDown();
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
@@ -232,16 +204,10 @@ Accéder au dossier`
     await expect(page).toClick("td", { text: "Mon action" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("input#update-action-select-status");
-    await expect(page).toClick(
-      "div.update-action-select-status__option:nth-of-type(3)"
-    );
-    expect(
-      await getInnerText("div.update-action-select-status__single-value")
-    ).toBe("ANNULÉE");
+    await expect(page).toClick("div.update-action-select-status__option:nth-of-type(3)");
+    expect(await getInnerText("div.update-action-select-status__single-value")).toBe("ANNULÉE");
     await scrollDown();
-    await page.evaluate(
-      `window.originalConfirm = window.confirm;window.confirm = () => false; `
-    ); // to skip the confirmation
+    await page.evaluate(`window.originalConfirm = window.confirm;window.confirm = () => false; `); // to skip the confirmation
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
     await expect(page).toMatch("Mise à jour !");
@@ -259,12 +225,8 @@ Accéder au dossier`
     await expect(page).toClick("a", { text: "Commentaires (2)" });
     await page.waitForTimeout(1000);
     await expect(page).toMatch("Mon action");
-    await expect(page).toMatch(
-      "Encrypted Orga Admin a changé le status de l'action: FAITE"
-    );
-    await expect(page).toMatch(
-      "Encrypted Orga Admin a changé le status de l'action: ANNULÉE"
-    );
+    await expect(page).toMatch("Encrypted Orga Admin a changé le status de l'action: FAITE");
+    await expect(page).toMatch("Encrypted Orga Admin a changé le status de l'action: ANNULÉE");
   });
 
   it("should be able to add a collaboration", async () => {
@@ -274,10 +236,7 @@ Accéder au dossier`
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
-    await expect(page).toFill(
-      "input#report-select-collaboration",
-      "Ma deuxième collab"
-    );
+    await expect(page).toFill("input#report-select-collaboration", "Ma deuxième collab");
     await expect(page).toClick("div.report-select-collaboration__option");
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
@@ -290,20 +249,12 @@ Accéder au dossier`
   it("should be able to use an added collaboration", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
-<<<<<<< HEAD
     await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
-=======
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
->>>>>>> 1c37e4d3 (chore(dashboard): remove redux et toastr (#898))
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
@@ -325,22 +276,17 @@ Accéder au dossier`
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", { text: "Ajouter une description" });
     await expect(page).toMatch("Description", { timeout: 10000 });
-    await expect(page).toFill(
-      'textarea[name="description"]',
-      "Ceci est une description"
-    );
+    await expect(page).toFill('textarea[name="description"]', "Ceci est une description");
     await expect(page).toClick("button", { text: "Enregistrer" });
     await page.waitForTimeout(2000);
     await expect(page).toClick("button.Toastify__close-button");
     await expect(page).toMatch("Description", { timeout: 2000 });
-    await expect(page).toMatch("Ceci est une description");
+    await expect(page).toMatch("Ceci est une description", { timeout: 2000 });
   });
 });

--- a/tests/src/__tests__/report.test.ts
+++ b/tests/src/__tests__/report.test.ts
@@ -28,7 +28,9 @@ describe("Organisation CRUD", () => {
   it("should be able to update stuff in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format(
+        "dddd D MMMM YYYY"
+      )} de l'équipe Encrypted Orga Team`
     );
     await page.waitForTimeout(2000);
 
@@ -87,7 +89,9 @@ describe("Organisation CRUD", () => {
   it("should be able to see the action in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format(
+        "dddd D MMMM YYYY"
+      )} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toMatch("Mon action");
   });
@@ -95,11 +99,19 @@ describe("Organisation CRUD", () => {
   it("should be able to add a passage", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format(
+        "dddd D MMMM YYYY"
+      )} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toClick("input#person-select-and-create-reception");
-    await expect(page).toClick("div.person-select-and-create-reception__option");
-    expect(await getInnerText("div.person-select-and-create-reception__multi-value__label")).toBe(
+    await expect(page).toClick(
+      "div.person-select-and-create-reception__option"
+    );
+    expect(
+      await getInnerText(
+        "div.person-select-and-create-reception__multi-value__label"
+      )
+    ).toBe(
       `Ma première personne
 
 Accéder au dossier`
@@ -115,7 +127,9 @@ Accéder au dossier`
   it("should be able go in the report", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
-    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
+    await expect(page).toMatch(
+      "Comptes rendus de l'équipe Encrypted Orga Team"
+    );
     await expect(page).toClick("button", { text: dayjs().format("D") });
     await page.waitForTimeout(1000);
     await expect(page).toMatch(`Compte rendu de l'équipe Encrypted Orga Team`);
@@ -125,17 +139,23 @@ Accéder au dossier`
   it("should be able to go to previous report then next report", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(2000);
-    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
+    await expect(page).toMatch(
+      "Comptes rendus de l'équipe Encrypted Orga Team"
+    );
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
+    await expect(page).toMatch(
+      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
+    );
     await expect(page).toClick("button", { text: "Suivant" });
     await expect(page).toMatch(`Journée du ${dayjs().format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Précédent" });
-    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
+    await expect(page).toMatch(
+      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
+    );
     await expect(page).toClick("button", { text: "Suivant" });
     await page.waitForTimeout(1000);
   });
@@ -159,8 +179,12 @@ Accéder au dossier`
   it("should be able to see passages in the report", async () => {
     await expect(page).toClick("a", { text: "Passages (3)" });
     await page.waitForTimeout(1000);
-    expect(await getInnerText("span#report-passages-anonymous-count")).toBe("2");
-    expect(await getInnerText("span#report-passages-non-anonymous-count")).toBe("1");
+    expect(await getInnerText("span#report-passages-anonymous-count")).toBe(
+      "2"
+    );
+    expect(await getInnerText("span#report-passages-non-anonymous-count")).toBe(
+      "1"
+    );
     await expect(page).toMatch("Ma première personne");
     await expect(page).toMatch("Anonyme");
   });
@@ -181,8 +205,12 @@ Accéder au dossier`
     await expect(page).toClick("td", { text: "Mon action" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("input#update-action-select-status");
-    await expect(page).toClick("div.update-action-select-status__option:nth-of-type(2)");
-    expect(await getInnerText("div.update-action-select-status__single-value")).toBe("FAITE");
+    await expect(page).toClick(
+      "div.update-action-select-status__option:nth-of-type(2)"
+    );
+    expect(
+      await getInnerText("div.update-action-select-status__single-value")
+    ).toBe("FAITE");
     await scrollDown();
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
@@ -204,10 +232,16 @@ Accéder au dossier`
     await expect(page).toClick("td", { text: "Mon action" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("input#update-action-select-status");
-    await expect(page).toClick("div.update-action-select-status__option:nth-of-type(3)");
-    expect(await getInnerText("div.update-action-select-status__single-value")).toBe("ANNULÉE");
+    await expect(page).toClick(
+      "div.update-action-select-status__option:nth-of-type(3)"
+    );
+    expect(
+      await getInnerText("div.update-action-select-status__single-value")
+    ).toBe("ANNULÉE");
     await scrollDown();
-    await page.evaluate(`window.originalConfirm = window.confirm;window.confirm = () => false; `); // to skip the confirmation
+    await page.evaluate(
+      `window.originalConfirm = window.confirm;window.confirm = () => false; `
+    ); // to skip the confirmation
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
     await expect(page).toMatch("Mise à jour !");
@@ -225,8 +259,12 @@ Accéder au dossier`
     await expect(page).toClick("a", { text: "Commentaires (2)" });
     await page.waitForTimeout(1000);
     await expect(page).toMatch("Mon action");
-    await expect(page).toMatch("Encrypted Orga Admin a changé le status de l'action: FAITE");
-    await expect(page).toMatch("Encrypted Orga Admin a changé le status de l'action: ANNULÉE");
+    await expect(page).toMatch(
+      "Encrypted Orga Admin a changé le status de l'action: FAITE"
+    );
+    await expect(page).toMatch(
+      "Encrypted Orga Admin a changé le status de l'action: ANNULÉE"
+    );
   });
 
   it("should be able to add a collaboration", async () => {
@@ -236,7 +274,10 @@ Accéder au dossier`
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
-    await expect(page).toFill("input#report-select-collaboration", "Ma deuxième collab");
+    await expect(page).toFill(
+      "input#report-select-collaboration",
+      "Ma deuxième collab"
+    );
     await expect(page).toClick("div.report-select-collaboration__option");
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
@@ -249,12 +290,20 @@ Accéder au dossier`
   it("should be able to use an added collaboration", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
+<<<<<<< HEAD
     await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
+=======
+    await expect(page).toMatch(
+      "Comptes rendus de l'équipe Encrypted Orga Team"
+    );
+>>>>>>> 1c37e4d3 (chore(dashboard): remove redux et toastr (#898))
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
+    await expect(page).toMatch(
+      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
+    );
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
@@ -276,13 +325,18 @@ Accéder au dossier`
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
+    await expect(page).toMatch(
+      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
+    );
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", { text: "Ajouter une description" });
     await expect(page).toMatch("Description", { timeout: 10000 });
-    await expect(page).toFill('textarea[name="description"]', "Ceci est une description");
+    await expect(page).toFill(
+      'textarea[name="description"]',
+      "Ceci est une description"
+    );
     await expect(page).toClick("button", { text: "Enregistrer" });
     await page.waitForTimeout(2000);
     await expect(page).toClick("button.Toastify__close-button");

--- a/tests/src/__tests__/report.test.ts
+++ b/tests/src/__tests__/report.test.ts
@@ -285,7 +285,6 @@ Accéder au dossier`
     await expect(page).toFill('textarea[name="description"]', "Ceci est une description");
     await expect(page).toClick("button", { text: "Enregistrer" });
     await page.waitForTimeout(2000);
-    await expect(page).toClick("button.Toastify__close-button");
     await expect(page).toMatch("Description", { timeout: 2000 });
     await expect(page).toMatch("Ceci est une description");
   });

--- a/tests/src/__tests__/report.test.ts
+++ b/tests/src/__tests__/report.test.ts
@@ -287,6 +287,6 @@ Accéder au dossier`
     await page.waitForTimeout(2000);
     await expect(page).toClick("button.Toastify__close-button");
     await expect(page).toMatch("Description", { timeout: 2000 });
-    await expect(page).toMatch("Ceci est une description", { timeout: 2000 });
+    await expect(page).toMatch("Ceci est une description");
   });
 });

--- a/tests/src/__tests__/report.test.ts
+++ b/tests/src/__tests__/report.test.ts
@@ -28,9 +28,7 @@ describe("Organisation CRUD", () => {
   it("should be able to update stuff in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format(
-        "dddd D MMMM YYYY"
-      )} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
     );
     await page.waitForTimeout(2000);
 
@@ -89,9 +87,7 @@ describe("Organisation CRUD", () => {
   it("should be able to see the action in reception", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format(
-        "dddd D MMMM YYYY"
-      )} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toMatch("Mon action");
   });
@@ -99,19 +95,11 @@ describe("Organisation CRUD", () => {
   it("should be able to add a passage", async () => {
     await navigateWithReactRouter("/reception");
     await expect(page).toMatch(
-      `Accueil du ${dayjs().format(
-        "dddd D MMMM YYYY"
-      )} de l'équipe Encrypted Orga Team`
+      `Accueil du ${dayjs().format("dddd D MMMM YYYY")} de l'équipe Encrypted Orga Team`
     );
     await expect(page).toClick("input#person-select-and-create-reception");
-    await expect(page).toClick(
-      "div.person-select-and-create-reception__option"
-    );
-    expect(
-      await getInnerText(
-        "div.person-select-and-create-reception__multi-value__label"
-      )
-    ).toBe(
+    await expect(page).toClick("div.person-select-and-create-reception__option");
+    expect(await getInnerText("div.person-select-and-create-reception__multi-value__label")).toBe(
       `Ma première personne
 
 Accéder au dossier`
@@ -127,9 +115,7 @@ Accéder au dossier`
   it("should be able go in the report", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
+    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
     await expect(page).toClick("button", { text: dayjs().format("D") });
     await page.waitForTimeout(1000);
     await expect(page).toMatch(`Compte rendu de l'équipe Encrypted Orga Team`);
@@ -139,23 +125,17 @@ Accéder au dossier`
   it("should be able to go to previous report then next report", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(2000);
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
+    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Suivant" });
     await expect(page).toMatch(`Journée du ${dayjs().format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Précédent" });
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await expect(page).toClick("button", { text: "Suivant" });
     await page.waitForTimeout(1000);
   });
@@ -179,12 +159,8 @@ Accéder au dossier`
   it("should be able to see passages in the report", async () => {
     await expect(page).toClick("a", { text: "Passages (3)" });
     await page.waitForTimeout(1000);
-    expect(await getInnerText("span#report-passages-anonymous-count")).toBe(
-      "2"
-    );
-    expect(await getInnerText("span#report-passages-non-anonymous-count")).toBe(
-      "1"
-    );
+    expect(await getInnerText("span#report-passages-anonymous-count")).toBe("2");
+    expect(await getInnerText("span#report-passages-non-anonymous-count")).toBe("1");
     await expect(page).toMatch("Ma première personne");
     await expect(page).toMatch("Anonyme");
   });
@@ -205,12 +181,8 @@ Accéder au dossier`
     await expect(page).toClick("td", { text: "Mon action" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("input#update-action-select-status");
-    await expect(page).toClick(
-      "div.update-action-select-status__option:nth-of-type(2)"
-    );
-    expect(
-      await getInnerText("div.update-action-select-status__single-value")
-    ).toBe("FAITE");
+    await expect(page).toClick("div.update-action-select-status__option:nth-of-type(2)");
+    expect(await getInnerText("div.update-action-select-status__single-value")).toBe("FAITE");
     await scrollDown();
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
@@ -232,16 +204,10 @@ Accéder au dossier`
     await expect(page).toClick("td", { text: "Mon action" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("input#update-action-select-status");
-    await expect(page).toClick(
-      "div.update-action-select-status__option:nth-of-type(3)"
-    );
-    expect(
-      await getInnerText("div.update-action-select-status__single-value")
-    ).toBe("ANNULÉE");
+    await expect(page).toClick("div.update-action-select-status__option:nth-of-type(3)");
+    expect(await getInnerText("div.update-action-select-status__single-value")).toBe("ANNULÉE");
     await scrollDown();
-    await page.evaluate(
-      `window.originalConfirm = window.confirm;window.confirm = () => false; `
-    ); // to skip the confirmation
+    await page.evaluate(`window.originalConfirm = window.confirm;window.confirm = () => false; `); // to skip the confirmation
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
     await expect(page).toMatch("Mise à jour !");
@@ -259,12 +225,8 @@ Accéder au dossier`
     await expect(page).toClick("a", { text: "Commentaires (2)" });
     await page.waitForTimeout(1000);
     await expect(page).toMatch("Mon action");
-    await expect(page).toMatch(
-      "Encrypted Orga Admin a changé le status de l'action: FAITE"
-    );
-    await expect(page).toMatch(
-      "Encrypted Orga Admin a changé le status de l'action: ANNULÉE"
-    );
+    await expect(page).toMatch("Encrypted Orga Admin a changé le status de l'action: FAITE");
+    await expect(page).toMatch("Encrypted Orga Admin a changé le status de l'action: ANNULÉE");
   });
 
   it("should be able to add a collaboration", async () => {
@@ -274,10 +236,7 @@ Accéder au dossier`
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
-    await expect(page).toFill(
-      "input#report-select-collaboration",
-      "Ma deuxième collab"
-    );
+    await expect(page).toFill("input#report-select-collaboration", "Ma deuxième collab");
     await expect(page).toClick("div.report-select-collaboration__option");
     await expect(page).toClick("button", { text: "Mettre à jour" });
     await page.waitForTimeout(2000);
@@ -290,16 +249,12 @@ Accéder au dossier`
   it("should be able to use an added collaboration", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
+    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
@@ -316,29 +271,22 @@ Accéder au dossier`
   it("should be able to use add a description", async () => {
     await navigateWithReactRouter("/report");
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      "Comptes rendus de l'équipe Encrypted Orga Team"
-    );
+    await expect(page).toMatch("Comptes rendus de l'équipe Encrypted Orga Team");
     await expect(page).toClick("button", {
       text: dayjs().add(-1, "day").format("D"),
     });
     await page.waitForTimeout(1000);
-    await expect(page).toMatch(
-      `Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`
-    );
+    await expect(page).toMatch(`Journée du ${dayjs().add(-1, "day").format("D MMMM YYYY")}`);
     await page.waitForTimeout(1000);
     await expect(page).toClick("a", { text: "Résumé" });
     await page.waitForTimeout(1000);
     await expect(page).toClick("button", { text: "Ajouter une description" });
     await expect(page).toMatch("Description", { timeout: 10000 });
-    await expect(page).toFill(
-      'textarea[name="description"]',
-      "Ceci est une description"
-    );
+    await expect(page).toFill('textarea[name="description"]', "Ceci est une description");
     await expect(page).toClick("button", { text: "Enregistrer" });
     await page.waitForTimeout(2000);
     await expect(page).toClick("button.Toastify__close-button");
     await expect(page).toMatch("Description", { timeout: 2000 });
-    await expect(page).toMatch("Ceci est une description");
+    await expect(page).toMatch("Ceci est une description", { timeout: 2000 });
   });
 });


### PR DESCRIPTION
j'ai choisi une stratégie de custom hook parce que le code à reproduire à chaque fois est un peu long

```js
const useCreateReportAtDateIfNotExist = () => {
  const currentTeam = useRecoilValue(currentTeamState);
  const currentTeamReports = useRecoilValue(currentTeamReportsSelector);
  const setReports = useSetRecoilState(reportsState);
  const API = useApi();

  return async (date) => {
    const reportAtDate = currentTeamReports.find((report) => report.date === date);
    if (!!reportAtDate) return;
    const res = await API.post({ path: '/report', body: prepareReportForEncryption({ team: currentTeam._id, date }) });
    if (!res.ok) return;
    setReports((reports) => [res.decryptedData, ...reports]);
    return res.decryptedData;
  };
};
```

j'ai hésité avec un effect dans les atoms, mais j'ai trouvé que c'était mieux

je reste ouvert à une autre proposition, même une qui dirait "vaut mieux copier coller ce bout de code partout où y'a besoin" (j'ai compté 7 fois).

bref, avant de faire la même chose dans l'app, je préfère qu'on débatte sur cette base !