### PR TITLE
chore: release without bot token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,32 +10,27 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
-    - name: Checkout repository
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-        persist-credentials: false
-
-    - name: Semantic Release
-      uses: cycjimmy/semantic-release-action@v2
-      with:
-        semantic_version: 17
-        extra_plugins: |
-          @semantic-release/changelog@5.0.1
-          @semantic-release/git@9.0.0
-          @google/semantic-release-replace-plugin@1.1.0
-        branches: |
-          [
-            '+([0-9])?(.{+([0-9]),x}).x',
-            'main', 
-            'next', 
-            {name: 'beta', prerelease: true}, 
-            {name: 'alpha', prerelease: true}
-          ]
-      env:
-        GIT_AUTHOR_EMAIL: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
-        GIT_AUTHOR_NAME: ${{ secrets.SOCIALGROOVYBOT_NAME }}
-        GIT_COMMITTER_EMAIL: ${{ secrets.SOCIALGROOVYBOT_EMAIL }}
-        GIT_COMMITTER_NAME: ${{ secrets.SOCIALGROOVYBOT_NAME }}
-        GITHUB_TOKEN: ${{ secrets.SOCIALGROOVYBOT_BOTO_PAT }}
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v2
+        with:
+          semantic_version: 17
+          extra_plugins: |
+            @semantic-release/changelog@5.0.1
+            @semantic-release/git@9.0.0
+            @google/semantic-release-replace-plugin@1.1.0
+          branches: |
+            [
+              '+([0-9])?(.{+([0-9]),x}).x',
+              'main',
+              'next',
+              {name: 'beta', prerelease: true},
+              {name: 'alpha', prerelease: true}
+            ]
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Utiliser la **deploy key** dans le secrets du repo plutôt que le PAT du Social Groovy bot