### PR TITLE
test:  data within person

### DIFF
--- a/api/src/controllers/migration.js
+++ b/api/src/controllers/migration.js
@@ -8,6 +8,7 @@ const Organisation = require("../models/organisation");
 const Passage = require("../models/passage");
 const Comment = require("../models/comment");
 const Report = require("../models/report");
+const Person = require("../models/person");
 const validateEncryptionAndMigrations = require("../middleware/validateEncryptionAndMigrations");
 const { looseUuidRegex } = require("../utils");
 const { capture } = require("../sentry");
@@ -74,6 +75,12 @@ router.put(
           }
           for (const _id of req.body.reportIdsToDelete) {
             await Report.destroy({ where: { _id, organisation: req.user.organisation }, transaction: tx });
+          }
+        }
+
+        if (req.params.migrationName === "all-data-within-persons") {
+          for (const { _id, encrypted, encryptedEntityKey } of req.body.persons) {
+            await Person.update({ encrypted, encryptedEntityKey }, { where: { _id, organisation: req.user.organisation } });
           }
         }
 

--- a/api/src/index.js
+++ b/api/src/index.js
@@ -45,7 +45,7 @@ app.use(versionCheck);
 
 // Pre middleware
 app.use(express.urlencoded({ extended: true }));
-app.use(express.json({ limit: "50mb" }));
+app.use(express.json({ limit: "200mb" }));
 app.use(helmet());
 app.use(cookieParser());
 

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -116,17 +116,17 @@ export default function DataLoader() {
               0 +
               stats.persons +
               stats.consultations +
-              stats.actions +
+              // stats.actions +
               stats.treatments +
               stats.medicalFiles +
               stats.passages +
-              stats.rencontres +
+              // stats.rencontres +
               stats.reports +
               stats.territories +
               stats.places +
               stats.relsPersonPlace +
-              stats.territoryObservations +
-              stats.comments;
+              // stats.comments +
+              stats.territoryObservations;
 
             if (stats.persons) newList.push('person');
             if (['admin', 'normal'].includes(user.role)) {
@@ -135,14 +135,14 @@ export default function DataLoader() {
               if (stats.medicalFiles) newList.push('medicalFile');
             }
             if (stats.reports) newList.push('report');
-            if (stats.passages) newList.push('passage');
+            // if (stats.passages) newList.push('passage');
             if (stats.rencontres) newList.push('rencontre');
-            if (stats.actions) newList.push('action');
+            // if (stats.actions) newList.push('action');
             if (stats.territories) newList.push('territory');
             if (stats.places) newList.push('place');
             if (stats.relsPersonPlace) newList.push('relsPersonPlace');
             if (stats.territoryObservations) newList.push('territoryObservation');
-            if (stats.comments) newList.push('comment');
+            // if (stats.comments) newList.push('comment');
 
             // In case this is not the initial load, we don't have to load from cache again.
             if (!initialLoad) {
@@ -156,12 +156,12 @@ export default function DataLoader() {
               .then((persons) => setPersons([...persons]))
               .then(() => getCacheItemDefaultValue('report', []))
               .then((reports) => setReports([...reports]))
-              .then(() => getCacheItemDefaultValue('passage', []))
-              .then((passages) => setPassages([...passages]))
+              // .then(() => getCacheItemDefaultValue('passage', []))
+              // .then((passages) => setPassages([...passages]))
               .then(() => getCacheItemDefaultValue('rencontre', []))
               .then((rencontres) => setRencontres([...rencontres]))
-              .then(() => getCacheItemDefaultValue('action', []))
-              .then((actions) => setActions([...actions]))
+              // .then(() => getCacheItemDefaultValue('action', []))
+              // .then((actions) => setActions([...actions]))
               .then(() => getCacheItemDefaultValue('territory', []))
               .then((territories) => setTerritories([...territories]))
               .then(() => getCacheItemDefaultValue('place', []))
@@ -170,8 +170,8 @@ export default function DataLoader() {
               .then((relsPersonPlace) => setRelsPersonPlace([...relsPersonPlace]))
               .then(() => getCacheItemDefaultValue('territory-observation', []))
               .then((territoryObservations) => setTerritoryObservations([...territoryObservations]))
-              .then(() => getCacheItemDefaultValue('comment', []))
-              .then((comments) => setComments([...comments]))
+              // .then(() => getCacheItemDefaultValue('comment', []))
+              // .then((comments) => setComments([...comments]))
               .then(() => startLoader(newList, itemsCount));
           });
         });

--- a/dashboard/src/recoil/persons.js
+++ b/dashboard/src/recoil/persons.js
@@ -310,6 +310,10 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
     ...customFieldsMedical.map((f) => f.name),
     ...fieldsPersonsCustomizableOptions.map((f) => f.name),
     ...encryptedFields,
+    'actions',
+    'comments',
+    'passages',
+    'rencontres',
   ];
   const decrypted = {};
   for (let field of encryptedFieldsIncludingCustom) {

--- a/dashboard/src/scenes/reception/view.js
+++ b/dashboard/src/scenes/reception/view.js
@@ -124,6 +124,7 @@ const Reception = () => {
   const user = useRecoilValue(userState);
   const API = useApi();
   const persons = useRecoilValue(personsState);
+  console.log({ persons });
 
   const history = useHistory();
   const location = useLocation();


### PR DESCRIPTION
étude de piste d'amélioration sur le loading

1er progrès dans la PR #903 : passage de 27 secondes de moyenne à 14 secondes en changeant le batch de 1.000 à 20.000

pour voir si le déchiffrement avait un gros impact sur le temps de chargement initial, plus particulièrement sur le nombre d'éléments à déchiffrer, j'ai fait un test dans cette PR en groupant toutes les actions/commentaires/passages dans les personnes, donc au lieu de déchiffrer 500 personnes + 20k actions + 10k commentaires + 500 passages, on ne déchiffre plus que 500 "grosses" personnes

résultat : on passe de 14 secondes à 13... pas fou !