### PR TITLE
fix: history 

### DIFF
--- a/app/src/recoil/persons.js
+++ b/app/src/recoil/persons.js
@@ -318,7 +318,6 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
   ];
   const decrypted = {};
   for (let field of encryptedFieldsIncludingCustom) {
-    console.log('field', field);
     if (field === 'history') {
       decrypted[field] = cleanPersonHistory(person[field], encryptedFieldsIncludingCustom);
       continue;
@@ -346,13 +345,6 @@ const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
       for (const field of Object.keys(historyEntry.data)) {
         if (encryptedFieldsIncludingCustom.includes(field)) newData[field] = historyEntry.data[field];
       }
-      console.log(
-        {
-          ...historyEntry,
-          data: newData,
-        },
-        encryptedFieldsIncludingCustom
-      );
       return {
         ...historyEntry,
         data: newData,

--- a/app/src/recoil/persons.js
+++ b/app/src/recoil/persons.js
@@ -318,6 +318,11 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
   ];
   const decrypted = {};
   for (let field of encryptedFieldsIncludingCustom) {
+    console.log('field', field);
+    if (field === 'history') {
+      decrypted[field] = cleanPersonHistory(person[field], encryptedFieldsIncludingCustom);
+      continue;
+    }
     decrypted[field] = person[field];
   }
   return {
@@ -330,6 +335,30 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
     decrypted,
     entityKey: person.entityKey,
   };
+};
+
+const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
+  if (!history) return history;
+  return history
+    .map((historyEntry) => {
+      if (!Object.keys(historyEntry.data).length) return false;
+      const newData = {};
+      for (const field of Object.keys(historyEntry.data)) {
+        if (encryptedFieldsIncludingCustom.includes(field)) newData[field] = historyEntry.data[field];
+      }
+      console.log(
+        {
+          ...historyEntry,
+          data: newData,
+        },
+        encryptedFieldsIncludingCustom
+      );
+      return {
+        ...historyEntry,
+        data: newData,
+      };
+    })
+    .filter((h) => !!Object.keys(historyEntry.data).length);
 };
 
 export const filterPersonsBase = personFields.filter((m) => m.filterable).map(({ name, ...rest }) => ({ field: name, ...rest }));

--- a/app/src/recoil/persons.js
+++ b/app/src/recoil/persons.js
@@ -340,9 +340,9 @@ const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
   if (!history) return history;
   return history
     .map((historyEntry) => {
-      if (!Object.keys(historyEntry.data).length) return false;
       const newData = {};
       for (const field of Object.keys(historyEntry.data)) {
+        if (field === 'history') continue;
         if (encryptedFieldsIncludingCustom.includes(field)) newData[field] = historyEntry.data[field];
       }
       return {
@@ -350,7 +350,7 @@ const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
         data: newData,
       };
     })
-    .filter((h) => !!Object.keys(historyEntry.data).length);
+    .filter((historyEntry) => !!Object.keys(historyEntry.data).length);
 };
 
 export const filterPersonsBase = personFields.filter((m) => m.filterable).map(({ name, ...rest }) => ({ field: name, ...rest }));

--- a/app/src/recoil/persons.js
+++ b/app/src/recoil/persons.js
@@ -133,6 +133,14 @@ export const personFieldsIncludingCustomFieldsSelector = selector({
   },
 });
 
+export const allowedFieldsInHistorySelector = selector({
+  key: 'allowedFieldsInHistorySelector',
+  get: ({ get }) => {
+    const allFields = get(personFieldsIncludingCustomFieldsSelector);
+    return allFields.map((f) => f.name).filter((f) => f !== 'history');
+  },
+});
+
 /*
 Choices on selects
 */
@@ -318,10 +326,6 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
   ];
   const decrypted = {};
   for (let field of encryptedFieldsIncludingCustom) {
-    if (field === 'history') {
-      decrypted[field] = cleanPersonHistory(person[field], encryptedFieldsIncludingCustom);
-      continue;
-    }
     decrypted[field] = person[field];
   }
   return {
@@ -334,23 +338,6 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
     decrypted,
     entityKey: person.entityKey,
   };
-};
-
-const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
-  if (!history) return history;
-  return history
-    .map((historyEntry) => {
-      const newData = {};
-      for (const field of Object.keys(historyEntry.data)) {
-        if (field === 'history') continue;
-        if (encryptedFieldsIncludingCustom.includes(field)) newData[field] = historyEntry.data[field];
-      }
-      return {
-        ...historyEntry,
-        data: newData,
-      };
-    })
-    .filter((historyEntry) => !!Object.keys(historyEntry.data).length);
 };
 
 export const filterPersonsBase = personFields.filter((m) => m.filterable).map(({ name, ...rest }) => ({ field: name, ...rest }));

--- a/app/src/scenes/Persons/Person.js
+++ b/app/src/scenes/Persons/Person.js
@@ -13,6 +13,7 @@ import colors from '../../utils/colors';
 import {
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,
+  allowedFieldsInHistorySelector,
   personsState,
   preparePersonForEncryption,
 } from '../../recoil/persons';
@@ -32,6 +33,7 @@ const cleanValue = (value) => {
 const Person = ({ route, navigation }) => {
   const customFieldsPersonsMedical = useRecoilValue(customFieldsPersonsMedicalSelector);
   const customFieldsPersonsSocial = useRecoilValue(customFieldsPersonsSocialSelector);
+  const allowedFieldsInHistory = useRecoilValue(allowedFieldsInHistorySelector);
 
   const [persons, setPersons] = useRecoilState(personsState);
   const [actions, setActions] = useRecoilState(actionsState);
@@ -131,9 +133,10 @@ const Person = ({ route, navigation }) => {
       data: {},
     };
     for (const key in personToUpdate) {
+      if (!allowedFieldsInHistory.includes(key)) continue;
       if (personToUpdate[key] !== oldPerson[key]) historyEntry.data[key] = { oldValue: oldPerson[key], newValue: personToUpdate[key] };
     }
-    personToUpdate.history = [...(oldPerson.history || []), historyEntry];
+    if (!!Object.keys(historyEntry.data.length)) personToUpdate.history = [...(oldPerson.history || []), historyEntry];
 
     const response = await API.put({
       path: `/person/${personDB._id}`,

--- a/app/src/scenes/Persons/PersonsOutOfActiveListReason.js
+++ b/app/src/scenes/Persons/PersonsOutOfActiveListReason.js
@@ -8,6 +8,7 @@ import ScrollContainer from '../../components/ScrollContainer';
 import OutOfActiveListReasonMultiCheckBox from '../../components/Selects/OutOfActiveListReasonMultiCheckBox';
 import { userState } from '../../recoil/auth';
 import {
+  allowedFieldsInHistorySelector,
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,
   personsState,
@@ -21,6 +22,8 @@ const PersonsOutOfActiveListReason = ({ navigation, route }) => {
   const [persons, setPersons] = useRecoilState(personsState);
   const customFieldsPersonsMedical = useRecoilValue(customFieldsPersonsMedicalSelector);
   const customFieldsPersonsSocial = useRecoilValue(customFieldsPersonsSocialSelector);
+  const allowedFieldsInHistory = useRecoilValue(allowedFieldsInHistorySelector);
+
   const user = useRecoilValue(userState);
 
   const updatePerson = async () => {
@@ -33,9 +36,10 @@ const PersonsOutOfActiveListReason = ({ navigation, route }) => {
       data: {},
     };
     for (const key in person) {
+      if (!allowedFieldsInHistory.includes(key)) continue;
       if (person[key] !== oldPerson[key]) historyEntry.data[key] = { oldValue: oldPerson[key], newValue: person[key] };
     }
-    person.history = [...(oldPerson.history || []), historyEntry];
+    if (!!Object.keys(historyEntry.data.length)) person.history = [...(oldPerson.history || []), historyEntry];
 
     const response = await API.put({
       path: `/person/${person._id}`,

--- a/dashboard/src/recoil/persons.js
+++ b/dashboard/src/recoil/persons.js
@@ -129,6 +129,13 @@ export const personFieldsIncludingCustomFieldsSelector = selector({
   },
 });
 
+export const allowedFieldsInHistorySelector = selector({
+  key: 'allowedFieldsInHistorySelector',
+  get: ({ get }) => {
+    const allFields = get(personFieldsIncludingCustomFieldsSelector);
+    return allFields.map((f) => f.name).filter((f) => f !== 'history');
+  },
+});
 /*
 Choices on selects
 */
@@ -313,10 +320,6 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
   ];
   const decrypted = {};
   for (let field of encryptedFieldsIncludingCustom) {
-    if (field === 'history') {
-      decrypted[field] = cleanPersonHistory(person[field], encryptedFieldsIncludingCustom);
-      continue;
-    }
     decrypted[field] = person[field];
   }
   return {
@@ -329,23 +332,6 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
     decrypted,
     entityKey: person.entityKey,
   };
-};
-
-const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
-  if (!history) return history;
-  return history
-    .map((historyEntry) => {
-      const newData = {};
-      for (const field of Object.keys(historyEntry.data)) {
-        if (field === 'history') continue;
-        if (encryptedFieldsIncludingCustom.includes(field)) newData[field] = historyEntry.data[field];
-      }
-      return {
-        ...historyEntry,
-        data: newData,
-      };
-    })
-    .filter((historyEntry) => !!Object.keys(historyEntry.data).length);
 };
 
 export const filterPersonsBase = personFields.filter((m) => m.filterable).map(({ name, ...rest }) => ({ field: name, ...rest }));

--- a/dashboard/src/recoil/persons.js
+++ b/dashboard/src/recoil/persons.js
@@ -313,6 +313,10 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
   ];
   const decrypted = {};
   for (let field of encryptedFieldsIncludingCustom) {
+    if (field === 'history') {
+      decrypted[field] = cleanPersonHistory(person[field], encryptedFieldsIncludingCustom);
+      continue;
+    }
     decrypted[field] = person[field];
   }
   return {
@@ -325,6 +329,23 @@ export const preparePersonForEncryption = (customFieldsMedical, customFieldsSoci
     decrypted,
     entityKey: person.entityKey,
   };
+};
+
+const cleanPersonHistory = (history, encryptedFieldsIncludingCustom) => {
+  if (!history) return history;
+  return history
+    .map((historyEntry) => {
+      const newData = {};
+      for (const field of Object.keys(historyEntry.data)) {
+        if (field === 'history') continue;
+        if (encryptedFieldsIncludingCustom.includes(field)) newData[field] = historyEntry.data[field];
+      }
+      return {
+        ...historyEntry,
+        data: newData,
+      };
+    })
+    .filter((historyEntry) => !!Object.keys(historyEntry.data).length);
 };
 
 export const filterPersonsBase = personFields.filter((m) => m.filterable).map(({ name, ...rest }) => ({ field: name, ...rest }));

--- a/dashboard/src/scenes/person/MergeTwoPersons.js
+++ b/dashboard/src/scenes/person/MergeTwoPersons.js
@@ -218,7 +218,8 @@ const MergeTwoPersons = ({ person }) => {
                     historyEntry.data[key] = { oldValue: initMergedPerson[key], newValue: body[key] };
                   }
                 }
-                body.history = [...(initMergedPerson.history || []), historyEntry];
+
+                if (Object.keys(historyEntry.data)?.length) body.history = [...(initMergedPerson.history || []), historyEntry];
 
                 const mergedPerson = preparePersonForEncryption(customFieldsPersonsMedical, customFieldsPersonsSocial)(body);
 

--- a/dashboard/src/scenes/person/MergeTwoPersons.js
+++ b/dashboard/src/scenes/person/MergeTwoPersons.js
@@ -7,6 +7,7 @@ import { toast } from 'react-toastify';
 import dayjs from 'dayjs';
 import ButtonCustom from '../../components/ButtonCustom';
 import {
+  allowedFieldsInHistorySelector,
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,
   personFieldsIncludingCustomFieldsSelector,
@@ -91,6 +92,7 @@ const MergeTwoPersons = ({ person }) => {
   const customFieldsMedicalFile = useRecoilValue(customFieldsMedicalFileSelector);
 
   const allFields = useRecoilValue(personFieldsIncludingCustomFieldsSelector);
+  const allowedFieldsInHistory = useRecoilValue(allowedFieldsInHistorySelector);
 
   const personsToMergeWith = useMemo(() => persons.filter((p) => p._id !== originPerson?._id), [persons, originPerson]);
 
@@ -213,6 +215,7 @@ const MergeTwoPersons = ({ person }) => {
                   data: {},
                 };
                 for (const key in body) {
+                  if (!allowedFieldsInHistory.includes(key)) continue;
                   if (fieldIsEmpty(body[key]) && fieldIsEmpty(originPerson[key])) continue;
                   if (JSON.stringify(body[key]) !== JSON.stringify(initMergedPerson[key])) {
                     historyEntry.data[key] = { oldValue: initMergedPerson[key], newValue: body[key] };

--- a/dashboard/src/scenes/person/components/EditModal.js
+++ b/dashboard/src/scenes/person/components/EditModal.js
@@ -3,6 +3,7 @@ import SelectAsInput from '../../../components/SelectAsInput';
 import {
   addressDetails,
   addressDetailsFixedFields,
+  allowedFieldsInHistorySelector,
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,
   employmentOptions,
@@ -34,6 +35,7 @@ export default function EditModal({ person, selectedPanel, onClose }) {
   const user = useRecoilValue(userState);
   const customFieldsPersonsSocial = useRecoilValue(customFieldsPersonsSocialSelector);
   const customFieldsPersonsMedical = useRecoilValue(customFieldsPersonsMedicalSelector);
+  const allowedFieldsInHistory = useRecoilValue(allowedFieldsInHistorySelector);
   const team = useRecoilValue(currentTeamState);
   const setPersons = useSetRecoilState(personsState);
   const API = useApi();
@@ -56,9 +58,10 @@ export default function EditModal({ person, selectedPanel, onClose }) {
               data: {},
             };
             for (const key in body) {
+              if (!allowedFieldsInHistory.includes(key)) continue;
               if (body[key] !== person[key]) historyEntry.data[key] = { oldValue: person[key], newValue: body[key] };
             }
-            body.history = [...(person.history || []), historyEntry];
+            if (!!Object.keys(historyEntry.data.length)) body.history = [...(person.history || []), historyEntry];
 
             const response = await API.put({
               path: `/person/${person._id}`,

--- a/dashboard/src/scenes/person/components/History.js
+++ b/dashboard/src/scenes/person/components/History.js
@@ -11,6 +11,7 @@ const History = ({ person }) => {
   const personFieldsIncludingCustomFields = useRecoilValue(personFieldsIncludingCustomFieldsSelector);
   const teams = useRecoilValue(teamsState);
   const history = useMemo(() => [...(person.history || [])].reverse(), [person.history]);
+
   return (
     <div>
       <Row style={{ marginTop: '30px', marginBottom: '5px' }}>
@@ -29,7 +30,7 @@ const History = ({ person }) => {
         <tbody className="small">
           {history.map((h) => {
             return (
-              <tr key={h.date}>
+              <tr key={h.date} className="tw-cursor-default">
                 <td>{dayjsInstance(h.date).format('DD/MM/YYYY HH:mm')}</td>
                 <td>
                   <UserName id={h.user} />
@@ -40,13 +41,12 @@ const History = ({ person }) => {
                       const personField = personFieldsIncludingCustomFields.find((f) => f.name === key);
                       if (key === 'assignedTeams') {
                         return (
-                          <div>
-                            {personField?.label} : <br />
-                            {(value.oldValue || []).map((teamId) => {
-                              const team = teams.find((t) => t._id === teamId);
-                              return <div key={teamId}>{team?.name}</div>;
-                            })}
-                          </div>
+                          <p className="tw-flex tw-flex-col" key={key}>
+                            <span>{personField?.label} : </span>
+                            <code>"{(value.oldValue || []).map((teamId) => teams.find((t) => t._id === teamId)?.name).join(', ')}"</code>
+                            <span>↓</span>
+                            <code>"{(value.newValue || []).map((teamId) => teams.find((t) => t._id === teamId)?.name).join(', ')}"</code>
+                          </p>
                         );
                       }
                       return (


### PR DESCRIPTION
ce qu'il y a dedans
-> affichage plus propre du changement d'équipes
-> pas d'entrée dans l'historique lors de la fusion de dossiers si aucun changement
-> clean de l'historique: ce n'est pas un fix en tant que tel, mais bien un élément que je pense important (et qui a le mérite de fixer aussi nos déboires précédentes). Ça retire de l'historique tout ce qui ne contient pas de `data` ainsi que tout ce qui ne fait pas partie des champs d'une personne, comme par exemple un champ custo disparu