### PR TITLE
fix: date and team in reports

### DIFF
--- a/api/src/db/migrations/2022-11-29_add_reports_columns.js
+++ b/api/src/db/migrations/2022-11-29_add_reports_columns.js
@@ -1,0 +1,16 @@
+const { capture } = require("../../sentry");
+const sequelize = require("../sequelize");
+
+module.exports = async () => {
+  try {
+    // No injection here, no need to escape.
+    await sequelize.query(`
+      ALTER TABLE "mano"."Report"
+      ADD COLUMN IF NOT EXISTS "team" uuid,
+      ADD COLUMN IF NOT EXISTS "date" text,
+      ADD CONSTRAINT "Report_team_fkey" FOREIGN KEY ("team") REFERENCES "mano"."Team"("_id") ON DELETE CASCADE ON UPDATE CASCADE
+    `);
+  } catch (e) {
+    capture(e);
+  }
+};

--- a/api/src/db/migrations/index.js
+++ b/api/src/db/migrations/index.js
@@ -22,4 +22,5 @@
   await require("./2022-11-07_add_grouped_categories")();
   await require("./2022-11-14_add_group_table")();
   await require("./2022-11-29_add_grouped_services")();
+  await require("./2022-11-29_add_reports_columns")();
 })();

--- a/api/src/db/relation.js
+++ b/api/src/db/relation.js
@@ -55,6 +55,8 @@ Organisation.hasMany(Structure, organisationForeignKey);
 // Report
 Report.belongsTo(Organisation, organisationForeignKey);
 Organisation.hasMany(Report, organisationForeignKey);
+Report.belongsTo(Team, teamForeignKey);
+Team.hasMany(Report, teamForeignKey);
 
 // Comment
 Comment.belongsTo(Organisation, organisationForeignKey);

--- a/api/src/models/report.js
+++ b/api/src/models/report.js
@@ -6,6 +6,8 @@ class Report extends Model {}
 const schema = {
   _id: { type: DataTypes.UUID, allowNull: false, defaultValue: Sequelize.UUIDV4, primaryKey: true },
   organisation: { type: DataTypes.UUID, references: { model: "Organisation", key: "_id", deferrable: Deferrable.INITIALLY_IMMEDIATE } },
+  date: { type: DataTypes.TEXT },
+  team: { type: DataTypes.UUID, references: { model: "Team", key: "_id", deferrable: Deferrable.INITIALLY_IMMEDIATE } },
   encrypted: { type: DataTypes.TEXT },
   encryptedEntityKey: { type: DataTypes.TEXT },
 };

--- a/app/src/recoil/reports.js
+++ b/app/src/recoil/reports.js
@@ -37,6 +37,8 @@ export const prepareReportForEncryption = (report) => {
     createdAt: report.createdAt,
     updatedAt: report.updatedAt,
     organisation: report.organisation,
+    date: report.date,
+    team: report.team,
 
     decrypted,
     entityKey: report.entityKey,

--- a/dashboard/src/recoil/reports.js
+++ b/dashboard/src/recoil/reports.js
@@ -72,6 +72,8 @@ export const prepareReportForEncryption = (report) => {
     createdAt: report.createdAt,
     updatedAt: report.updatedAt,
     organisation: report.organisation,
+    date: report.date,
+    team: report.team,
 
     decrypted,
     entityKey: report.entityKey,


### PR DESCRIPTION
Comme on a dit
-> ça ne change rien au comportement actuel global, sauf que ça renvoie le compte-rendu déjà créé s'il existe

Question
-> est-ce qu'on ne mettrait pas non plus les services en clair aussi, au passage ? 

En tout cas c'est cadeau, si tu veux la merger de suite tu peux, avec release de l'app et forçage de MAJ aussi (j'ai demandé à Guillaume pour le faire mardi, parce que j'en avais marre des vieilles versions, il m'avait dit OK)

À lundi !