### PR TITLE
fix: sorting items when loading

### DIFF
--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -268,10 +268,7 @@ export default function DataLoader() {
       setPassages(() => {
         const mergedItems = mergeItems(passages, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > rencontres.length) {
-          return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
-        }
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -282,10 +279,7 @@ export default function DataLoader() {
       setRencontres(() => {
         const mergedItems = mergeItems(rencontres, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > rencontres.length) {
-          return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
-        }
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -304,8 +298,7 @@ export default function DataLoader() {
       setTerritories(() => {
         const mergedItems = mergeItems(territories, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > territories.length) return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -316,8 +309,7 @@ export default function DataLoader() {
       setPlaces(() => {
         const mergedItems = mergeItems(places, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > places.length) return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -328,8 +320,7 @@ export default function DataLoader() {
       setRelsPersonPlace(() => {
         const mergedItems = mergeItems(relsPersonPlace, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > relsPersonPlace.length) return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -340,10 +331,7 @@ export default function DataLoader() {
       setTerritoryObservations(() => {
         const mergedItems = mergeItems(territoryObservations, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > territoryObservations.length) {
-          return mergedItems.sort((a, b) => new Date(b.observedAt || b.createdAt) - new Date(a.observedAt || a.createdAt));
-        }
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.observedAt || b.createdAt) - new Date(a.observedAt || a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -354,10 +342,7 @@ export default function DataLoader() {
       setComments(() => {
         const mergedItems = mergeItems(comments, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > comments.length) {
-          return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
-        }
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);
@@ -368,10 +353,7 @@ export default function DataLoader() {
       setGroups(() => {
         const mergedItems = mergeItems(groups, res.decryptedData);
         if (res.hasMore) return mergedItems;
-        if (mergedItems.length > groups.length) {
-          return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-        }
-        return mergedItems;
+        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
       });
       handleMore(res.hasMore);
       setProgressBuffer(res.data.length);


### PR DESCRIPTION
use case où ça fonctionnait étrangement
1. je crée une observation de territoire : elle apparait en haut de la liste des observations 
2. je recharge ma page instantanément : la date de création de cette observation est ultérieure à la date du last refresh, donc elle sera téléchargée de la BDD
3. la fonction `mergeItems` place cette obs par défaut à la fin
4. vu que le nombre d'anciens éléments est le même que le nombre de nouveaux, il n'y a pas de tri
5. ma nouvelle obs apparait désormais en bas de la liste des observations

coût de cette PR: un peu plus de sorting, mais finalement pas grand chose puisque quand il n'y a pas de nouvelle donnée, il n'y a pas de tri inutile.
ce qu'on avait fait avant était plutôt de l'overengineering peut-être !