### PR TITLE
fix(dashboard,app): comment with no more group

### DIFF
--- a/app/src/recoil/selectors.js
+++ b/app/src/recoil/selectors.js
@@ -141,6 +141,7 @@ export const itemsGroupedByPersonSelector = selector({
       personsObject[comment.person].comments.push(comment);
       if (!!comment.group) {
         const group = personsObject[comment.person].group;
+        if (!group) continue;
         for (const person of group.persons) {
           if (!personsObject[person]) continue;
           if (person === comment.person) continue;

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -150,6 +150,7 @@ export const itemsGroupedByPersonSelector = selector({
       personsObject[comment.person].comments.push(comment);
       if (!!comment.group) {
         const group = personsObject[comment.person].group;
+        if (!group) continue;
         for (const person of group.persons) {
           if (!personsObject[person]) continue;
           if (person === comment.person) continue;


### PR DESCRIPTION
Quand on supprime une famille et qu'il reste des commentaires ça fait péter les sélecteurs

<img width="1422" alt="Capture d’écran 2022-12-20 à 12 47 21" src="https://user-images.githubusercontent.com/1575946/208661762-ff52047d-4926-4325-8e98-698d5c165157.png">
