### PR TITLE
chore: do not run preproduction to stop it 2 minutes after

### DIFF
--- a/.github/workflows/preproduction.yml
+++ b/.github/workflows/preproduction.yml
@@ -2,9 +2,7 @@ name: Preproduction
 
 on:
   push:
-    branches:
-      - main
-    tags-ignore:
+    tags:
       - v*
 
 concurrency:


### PR DESCRIPTION
Le déploiement en préproduction d'un commit de nous est à chaque fois annulé par semantic release. Si on le met comme la prod, au tag, c'est mieux ça fait des jolies coches vertes partout. Bon en plus on ne s'est pas servi de la pré-prod ces 10 derniers mois (on se sert juste des déploiements de branches de review), donc ça fait surtout du bruit. On fait ça ?

<img width="617" alt="Capture d’écran 2022-12-20 à 14 23 00" src="https://user-images.githubusercontent.com/1575946/208677445-37f4875e-7d8e-4581-9b7f-2eafdcd4bebc.png">

<img width="767" alt="Capture d’écran 2022-12-20 à 14 23 46" src="https://user-images.githubusercontent.com/1575946/208677430-0e88cdcf-4f47-4ead-840e-346441b1d5f3.png">