### PR TITLE
fix(api): find or create report

### DIFF
--- a/api/src/controllers/report.js
+++ b/api/src/controllers/report.js
@@ -73,35 +73,11 @@ router.post(
       return next(error);
     }
 
-    if (req.body.date && req.body.team) {
-      const existingReport = await Report.findOne({
-        where: { organisation: req.user.organisation, team: req.body.team, date: req.body.date },
-      });
-      if (!!existingReport) {
-        return res.status(200).send({
-          ok: true,
-          data: {
-            _id: existingReport._id,
-            encrypted: existingReport.encrypted,
-            encryptedEntityKey: existingReport.encryptedEntityKey,
-            organisation: existingReport.organisation,
-            team: existingReport.team,
-            date: existingReport.date,
-            createdAt: existingReport.createdAt,
-            updatedAt: existingReport.updatedAt,
-            deletedAt: existingReport.deletedAt,
-          },
-        });
-      }
-    }
-
-    const data = await Report.create(
-      {
-        organisation: req.user.organisation,
+    const [data, _created] = await Report.findOrCreate({
+      where: { organisation: req.user.organisation, team: req.body.team, date: req.body.date },
+      defaults: {
         encrypted: req.body.encrypted,
         encryptedEntityKey: req.body.encryptedEntityKey,
-        team: req.body.team,
-        date: req.body.date,
         debug: {
           version: req.headers.version,
           user: req.user._id,
@@ -110,8 +86,9 @@ router.post(
           function: req.headers["debug-report-function"],
         },
       },
-      { returning: true }
-    );
+      returning: true,
+    });
+
     return res.status(200).send({
       ok: true,
       data: {


### PR DESCRIPTION
il y a parfois un écart de 2 ms entre la création du premier et du second compte-rendu, je me dis qu'au lieu de 1. checker si un compte-rendu existe et 2. le créer s'il n'existe pas, c'est peut-être trop tard. donc est-ce que la fonction `findOrCreate` ne ferait pas le boulot comme on le veut ?

quand je log la requête SQL ça fait:

```
Executing (d8a16bb0-a289-41a4-95df-0299bc15331b): START TRANSACTION;
Executing (d8a16bb0-a289-41a4-95df-0299bc15331b): SELECT "_id", "organisation", "date", "team", "debug", "encrypted", "encryptedEntityKey", "createdAt", "updatedAt", "deletedAt" FROM "mano"."Report" AS "Report" WHERE ("Report"."deletedAt" IS NULL AND ("Report"."organisation" = '00000000-5f5a-89e2-2e60-88fa20cc50bf' AND "Report"."team" = '8b18a173-f129-42ee-8724-494bd44e63b7' AND "Report"."date" = '2022-12-06')) LIMIT 1;
Executing (d8a16bb0-a289-41a4-95df-0299bc15331b): CREATE OR REPLACE FUNCTION pg_temp.testfunc(OUT response "mano"."Report", OUT sequelize_caught_exception text) RETURNS RECORD AS $func_f8ac627e7f5e4b5fafaa8d059c0d4493$ BEGIN INSERT INTO "mano"."Report" ("_id","organisation","date","team","debug","encrypted","encryptedEntityKey","createdAt","updatedAt") VALUES ('7d8f44ec-6b44-426d-8202-afe02efd0cfe','00000000-5f5a-89e2-2e60-88fa20cc50bf','2022-12-06','8b18a173-f129-42ee-8724-494bd44e63b7','{"version":"1.196.1","user":"33400b35-7b77-406b-bb4d-da9bc2dc1830","component":"ReceptionService","parentComponent":"report"}','5zcoB/NMqPEwRGeE+k7gwrUyFms13A9bEGkha5em8T9cOOinTWTtX9fh0sysri+PmaRehFl+PuZ7A1mCTATxJnVfneJbd8T7D6DGmDWLr5NtrxoIFn7IhKraWGzkwSR7jBUvaR3H51huEPWFFKDEtvEi5x0vpNsxKUe59i6ZxQv05TuTulM51Iqp0f8vffyrW9eUReG2KxONMiUqAWY+hG4jhSW2fZ3+n91IAHN0+sIWKFg707kGxlk5b9tsHZjZ','yyrztXfYwrW9BSU2Z5CzpuOatOW9oYca/pyIK03YTYdfPqQV4yIv0TyZVPgKg9sfLgZVeYjAkAt3W48mOW+2yFZYtDmOJv/I','2022-12-21 18:26:10.011 +01:00','2022-12-21 18:26:10.011 +01:00') RETURNING * INTO response; EXCEPTION WHEN unique_violation THEN GET STACKED DIAGNOSTICS sequelize_caught_exception = PG_EXCEPTION_DETAIL; END $func_f8ac627e7f5e4b5fafaa8d059c0d4493$ LANGUAGE plpgsql; SELECT (testfunc.response)."_id", (testfunc.response)."organisation", (testfunc.response)."date", (testfunc.response)."team", (testfunc.response)."debug", (testfunc.response)."encrypted", (testfunc.response)."encryptedEntityKey", (testfunc.response)."createdAt", (testfunc.response)."updatedAt", (testfunc.response)."deletedAt", testfunc.sequelize_caught_exception FROM pg_temp.testfunc(); DROP FUNCTION IF EXISTS pg_temp.testfunc();
Executing (d8a16bb0-a289-41a4-95df-0299bc15331b): COMMIT;
```

j'y comprend pas grand chose pour être honnête...
