### PR TITLE
fix(app): person considered modified and losing previous info on focus

### DIFF
--- a/app/src/scenes/Persons/Person.js
+++ b/app/src/scenes/Persons/Person.js
@@ -9,6 +9,7 @@ import ScreenTitle from '../../components/ScreenTitle';
 import FoldersNavigator from './FoldersNavigator';
 import Tabs from '../../components/Tabs';
 import colors from '../../utils/colors';
+import { useFocusEffect } from '@react-navigation/native';
 import {
   customFieldsPersonsMedicalSelector,
   customFieldsPersonsSocialSelector,
@@ -111,17 +112,18 @@ const Person = ({ route, navigation }) => {
       onGoBackRequested();
     };
 
-    const handleFocus = () => {
-      setPerson(castToPerson(personDB));
-    };
-    const focusListenerUnsubscribe = navigation.addListener('focus', handleFocus);
     const beforeRemoveListenerUnsbscribe = navigation.addListener('beforeRemove', handleBeforeRemove);
     return () => {
-      focusListenerUnsubscribe();
       beforeRemoveListenerUnsbscribe();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [navigation, route?.params?.person]);
+
+  useFocusEffect(
+    useCallback(() => {
+      setPerson(castToPerson(personDB));
+    }, [personDB])
+  );
 
   const onEdit = () => setEditable((e) => !e);
 


### PR DESCRIPTION
Pour reproduire le problème : 

Modifier une personne, continuer à naviguer dans les screens de cette personne et re-sauvegarder cette personne. On perd potentiellement des infos et on revient dans un state différent.

J'ai mis trois heures à expérimenter des choses, et j'ai retenu une solution parmi d'autre, mais je challengerai bien le truc dans son ensemble pour voir ce qu'on a comme alternative.

La solution retenue est de listen via une callback aux changements de `personDB` pour ne pas reprendre une vieille version de `personDB` (ce qui arrivait actuellement)

Ça semble marcher mais ça vaut le coup de tester.

3 heures, 3 lignes.