### PR TITLE
fix(api): add unique constraint to avoid duplicate reports

### DIFF
--- a/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
+++ b/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
@@ -4,11 +4,11 @@ const sequelize = require("../sequelize");
 module.exports = async () => {
   try {
     // Check if constraint Report_organisation_team_date_key exists.
-    const [results] = await sequelize.query(`SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE  conname = 'Report_organisation_team_date_key');`);
+    const [results] = await sequelize.query(
+      `SELECT EXISTS (SELECT 1 FROM pg_indexes WHERE tablename = 'Report' AND indexname = 'Report_organisation_team_date_key');`
+    );
     if (!results[0].exists) {
-      await sequelize.query(
-        `create unique index "Report_organisation_team_date_key" on mano."Report" (organisation, "date", team, "deletedAt") where date is not NULL and team is not NULL and "deletedAt" is NULL;`
-      );
+      await sequelize.query(`alter table "mano"."Report" add constraint "Report_organisation_team_date_key" unique (organisation, team, "date");`);
     }
   } catch (e) {
     capture(e);

--- a/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
+++ b/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
@@ -1,0 +1,14 @@
+const { capture } = require("../../sentry");
+const sequelize = require("../sequelize");
+
+module.exports = async () => {
+  try {
+    // Check if constraint Report_organisation_team_date_key exists.
+    const [results] = await sequelize.query(`SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE  conname = 'Report_organisation_team_date_key');`);
+    if (!results[0].exists) {
+      await sequelize.query(`alter table "Report" add constraint "Report_organisation_team_date_key" unique (organisation, team, "date");`);
+    }
+  } catch (e) {
+    capture(e);
+  }
+};

--- a/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
+++ b/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
@@ -7,7 +7,7 @@ module.exports = async () => {
     const [results] = await sequelize.query(`SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE  conname = 'Report_organisation_team_date_key');`);
     if (!results[0].exists) {
       await sequelize.query(
-        `create unique index "Report_organisation_team_date_key" on mano."Report" (organisation, "date", team) where date is not NULL and team is not NULL;`
+        `create unique index "Report_organisation_team_date_key" on mano."Report" (organisation, "date", team, "deletedAt") where date is not NULL and team is not NULL and "deletedAt" is NULL;`
       );
     }
   } catch (e) {

--- a/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
+++ b/api/src/db/migrations/2022-12-27_add-unique-constraint-on-report.js
@@ -6,7 +6,9 @@ module.exports = async () => {
     // Check if constraint Report_organisation_team_date_key exists.
     const [results] = await sequelize.query(`SELECT EXISTS (SELECT 1 FROM pg_constraint WHERE  conname = 'Report_organisation_team_date_key');`);
     if (!results[0].exists) {
-      await sequelize.query(`alter table "Report" add constraint "Report_organisation_team_date_key" unique (organisation, team, "date");`);
+      await sequelize.query(
+        `create unique index "Report_organisation_team_date_key" on mano."Report" (organisation, "date", team) where date is not NULL and team is not NULL;`
+      );
     }
   } catch (e) {
     capture(e);

--- a/api/src/db/migrations/index.js
+++ b/api/src/db/migrations/index.js
@@ -24,4 +24,5 @@
   await require("./2022-11-29_add_grouped_services")();
   await require("./2022-11-29_add_reports_columns")();
   await require("./2022-12-12-debug_report")();
+  await require("./2022-12-27_add-unique-constraint-on-report")();
 })();


### PR DESCRIPTION
Bon déjà prenons le problème autrement : on ne devrait pas pouvoir créer de rapports en double ? Interdisons le en base de données.

Avec cette évolution, le seul impact sera que les utilisateurs recevront "Une erreur est survenue". Pas de rapport en double, et ils sont mis au courant que ça ne va pas. Un nouveau clic sur sauvegarder devrait régler le pb.

WDYT?