### PR TITLE
fix(api): handle file not found

### DIFF
--- a/api/src/controllers/person.js
+++ b/api/src/controllers/person.js
@@ -116,7 +116,7 @@ router.delete(
     const dir = personDocumentBasedir(req.user.organisation, req.params.id);
     const file = path.join(dir, req.params.filename);
     if (!fs.existsSync(file)) {
-      // if it is not found, it might not be deleted but it's lst in the database, so we return ok.
+      // if it is not found, it might not be deleted but it's still in the database, so we return ok.
       res.send({ ok: true });
     } else {
       fs.unlinkSync(file);

--- a/api/src/controllers/person.js
+++ b/api/src/controllers/person.js
@@ -89,7 +89,7 @@ router.get(
     const dir = personDocumentBasedir(req.user.organisation, req.params.id);
     const file = path.join(dir, req.params.filename);
     if (!fs.existsSync(file)) {
-      res.status(404).send({ ok: false, message: "File not found" });
+      res.status(404).send({ ok: false, error: "Désolé, le fichier n'est plus disponible." });
     } else {
       res.sendFile(file);
     }
@@ -116,7 +116,8 @@ router.delete(
     const dir = personDocumentBasedir(req.user.organisation, req.params.id);
     const file = path.join(dir, req.params.filename);
     if (!fs.existsSync(file)) {
-      res.status(404).send({ ok: false, message: "File not found" });
+      // if it is not found, it might not be deleted but it's lst in the database, so we return ok.
+      res.send({ ok: true });
     } else {
       fs.unlinkSync(file);
       res.send({ ok: true });


### PR DESCRIPTION
Pourquoi cette PR ?

- ça fixe [MANO-2P](https://sentry.fabrique.social.gouv.fr/organizations/incubateur/issues/61797/events/36a874c9f0f341b4ba87ce7061530b84/?project=52&query=is%3Aunresolved)
- quand un fichier est introuvable, c'est fort probablement parce que il appartenait à une personne qui a été fusionnée avec une autre, et qu'on avait pas anticipé ce problème et donc que le lien vers les documents lui appartenant a disparu. Il est donc perdu dans la DB... donc on peut peut-être assumer que: si on veut le télécharger, on prévient qu'il n'est plus disponible, et si on veut le supprimer, on peut dire qu'il l'est sans rentrer dans les détails
