### PR TITLE
chore: stop testing chrome

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -56,12 +56,12 @@ const config: PlaywrightTestConfig = {
       },
     },
 
-    {
-      name: "chromium",
-      use: {
-        ...devices["Desktop Chrome"],
-      },
-    },
+    // {
+    //   name: "chromium",
+    //   use: {
+    //     ...devices["Desktop Chrome"],
+    //   },
+    // },
 
     // {
     //   name: "webkit",


### PR DESCRIPTION
Pourquoi ?

- pour aller plus vite dans l'exécution des tests
- parce qu'on dev plutôt sur Chrome, donc on teste pas mal déjà
- parce qu'on a qu'à tester sur chrome localement et sur firefox en github actions et ça devrait faire l'affaire

on remettre chrome si on se rend compte que ne pas tester sur chrome fait péter la production
