### PR TITLE
feat(dashboard): show new stuff in dashboard

### DIFF
--- a/api/src/middleware/versionCheck.js
+++ b/api/src/middleware/versionCheck.js
@@ -2,15 +2,39 @@ const { VERSION, MINIMUM_DASHBOARD_VERSION } = require("../config");
 
 const MINIMUM_MOBILE_APP_VERSION = [2, 30, 0];
 
-const featuresDashboard = {
-  "1.218.0": "En cliquant sur une statistique d'action, on peut voir la liste d'actions concernées",
-  "1.217.0":
-    "Vous n'êtes plus déconnectés automatiquement après 3h d'inactivité, mais la clé de chiffrement vous sera demandée pour continuer votre session",
-  "1.216.0": "Une bulle d'aide est disponbile dans 2 statistiques de personnes suivies",
-  "1.215.0": "Dans l'export depuis les statistiques, le nom d'utilisateur n'est plus exporté avec les actions",
-  "1.214.1": "Les commentaires créées en même temps qu'une action sont de nouveau disponibles dans les comptes-rendus",
-  "1.214.0": "Possibilité de filtrer par date non renseignée",
-};
+const featuresDashboard = [
+  {
+    version: "1.221.0",
+    feature: "Une bulle d'aide est disponible dans chaque statistique",
+    date: "2023-01-17",
+  },
+  {
+    version: "1.218.0",
+    feature: "En cliquant sur une statistique d'action, on peut voir la liste d'actions concernées",
+    date: "2023-01-13",
+  },
+  {
+    version: "1.217.0",
+    feature:
+      "Vous n'êtes plus déconnectés automatiquement après 3h d'inactivité, mais la clé de chiffrement vous sera demandée pour continuer votre session",
+    date: "2023-01-13",
+  },
+  {
+    version: "1.215.0",
+    feature: "Dans l'export depuis les statistiques, le nom d'utilisateur n'est plus exporté avec les actions",
+    date: "2023-01-12",
+  },
+  {
+    version: "1.214.1",
+    feature: "Les commentaires créées en même temps qu'une action sont de nouveau disponibles dans les comptes-rendus",
+    date: "2023-01-11",
+  },
+  {
+    version: "1.214.0",
+    feature: "Possibilité de filtrer par date non renseignée",
+    date: "2023-01-11",
+  },
+];
 
 module.exports = ({ headers: { version, platform } }, res, next) => {
   if (platform === "website") return next();
@@ -21,11 +45,7 @@ module.exports = ({ headers: { version, platform } }, res, next) => {
     res.header("X-MINIMUM-DASHBOARD-VERSION", MINIMUM_DASHBOARD_VERSION);
     res.header(
       "X-DASHBOARD-NEWFEATURES",
-      Object.keys(featuresDashboard)
-        .filter((v) => v > version)
-        .reverse()
-        .map((version) => featuresDashboard[version])
-        .join("_")
+      featuresDashboard.filter((item) => item.version > version)
     );
     // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
     res.header("Access-Control-Expose-Headers", "X-API-VERSION, X-MINIMUM-DASHBOARD-VERSION, X-DASHBOARD-NEWFEATURES");

--- a/api/src/middleware/versionCheck.js
+++ b/api/src/middleware/versionCheck.js
@@ -2,14 +2,33 @@ const { VERSION, MINIMUM_DASHBOARD_VERSION } = require("../config");
 
 const MINIMUM_MOBILE_APP_VERSION = [2, 30, 0];
 
+const featuresDashboard = {
+  "1.218.0": "En cliquant sur une statistique d'action, on peut voir la liste d'actions concernées",
+  "1.217.0":
+    "Vous n'êtes plus déconnectés automatiquement après 3h d'inactivité, mais la clé de chiffrement vous sera demandée pour continuer votre session",
+  "1.216.0": "Une bulle d'aide est disponbile dans 2 statistiques de personnes suivies",
+  "1.215.0": "Dans l'export depuis les statistiques, le nom d'utilisateur n'est plus exporté avec les actions",
+  "1.214.1": "Les commentaires créées en même temps qu'une action sont de nouveau disponibles dans les comptes-rendus",
+  "1.214.0": "Possibilité de filtrer par date non renseignée",
+};
+
 module.exports = ({ headers: { version, platform } }, res, next) => {
   if (platform === "website") return next();
   if (platform === "dashboard") {
     // Add header with API version to compare with client.
+    // version = "1.215.1";
     res.header("X-API-VERSION", VERSION);
     res.header("X-MINIMUM-DASHBOARD-VERSION", MINIMUM_DASHBOARD_VERSION);
+    res.header(
+      "X-DASHBOARD-NEWFEATURES",
+      Object.keys(featuresDashboard)
+        .filter((v) => v > version)
+        .reverse()
+        .map((version) => featuresDashboard[version])
+        .join("_")
+    );
     // See: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers
-    res.header("Access-Control-Expose-Headers", "X-API-VERSION, X-MINIMUM-DASHBOARD-VERSION");
+    res.header("Access-Control-Expose-Headers", "X-API-VERSION, X-MINIMUM-DASHBOARD-VERSION, X-DASHBOARD-NEWFEATURES");
     return next();
   }
 

--- a/api/src/utils/features.js
+++ b/api/src/utils/features.js
@@ -1,0 +1,37 @@
+const dashboardFeatures = [
+  {
+    version: "1.221.0",
+    feature: "Une bulle d'aide est disponible dans chaque statistique",
+    date: "2023-01-17",
+  },
+  {
+    version: "1.218.0",
+    feature: "En cliquant sur une statistique d'action, on peut voir la liste d'actions concernées",
+    date: "2023-01-13",
+  },
+  {
+    version: "1.217.0",
+    feature:
+      "Vous n'êtes plus déconnectés automatiquement après 3h d'inactivité, mais la clé de chiffrement vous sera demandée pour continuer votre session",
+    date: "2023-01-13",
+  },
+  {
+    version: "1.215.0",
+    feature: "Dans l'export depuis les statistiques, le nom d'utilisateur n'est plus exporté avec les actions",
+    date: "2023-01-12",
+  },
+  {
+    version: "1.214.1",
+    feature: "Les commentaires créées en même temps qu'une action sont de nouveau disponibles dans les comptes-rendus",
+    date: "2023-01-11",
+  },
+  {
+    version: "1.214.0",
+    feature: "Possibilité de filtrer par date non renseignée",
+    date: "2023-01-11",
+  },
+];
+
+module.exports = {
+  dashboardFeatures,
+};

--- a/dashboard/src/components/VersionOutdatedAlert.js
+++ b/dashboard/src/components/VersionOutdatedAlert.js
@@ -1,7 +1,7 @@
 import { useRecoilValue } from 'recoil';
 import { compare } from 'compare-versions';
 import { VERSION } from '../config';
-import { apiVersionState, minimumDashboardVersionState } from '../recoil/version';
+import { apiVersionState, dashboardNewFeaturesState, minimumDashboardVersionState } from '../recoil/version';
 
 export default function VersionOutdatedAlert() {
   const apiVersion = useRecoilValue(apiVersionState);
@@ -26,6 +26,7 @@ export default function VersionOutdatedAlert() {
           rafraichissez cette page
         </a>
         .
+        <NewStuff />
       </div>
     );
   }
@@ -43,6 +44,23 @@ export default function VersionOutdatedAlert() {
         Rafraichissez cette page
       </a>{' '}
       pour l'utiliser !
+      <NewStuff />
     </div>
   );
 }
+
+const NewStuff = () => {
+  const dashboardNewFeatures = useRecoilValue(dashboardNewFeaturesState);
+  if (!!!dashboardNewFeatures?.length) return null;
+  return (
+    <>
+      <br />
+      <b>Nouveautés :</b>
+      <ul className="tw-max-w-2xl tw-list-disc">
+        {dashboardNewFeatures.split('_').map((line, i) => (
+          <li key={i}>{line}</li>
+        ))}
+      </ul>
+    </>
+  );
+};

--- a/dashboard/src/config.js
+++ b/dashboard/src/config.js
@@ -33,6 +33,7 @@ const HOST = getHost();
 const SCHEME = process.env.NODE_ENV === 'development' || process.env.REACT_APP_TEST === 'true' ? process.env.REACT_APP_SCHEME : 'https';
 const ENV = process.env.NODE_ENV || 'production';
 const VERSION = packageInfo.version;
+// const VERSION = process.env.NODE_ENV === 'development' ? '1.215.0' : packageInfo.version;
 const DEFAULT_ORGANISATION_KEY =
   process.env.NODE_ENV === 'development' && process.env.REACT_APP_TEST !== 'true' ? process.env.REACT_APP_DEFAULT_ORGANISATION_KEY : '';
 

--- a/dashboard/src/recoil/version.js
+++ b/dashboard/src/recoil/version.js
@@ -9,3 +9,8 @@ export const minimumDashboardVersionState = atom({
   key: 'minimumDashboardVersionState',
   default: null,
 });
+
+export const dashboardNewFeaturesState = atom({
+  key: 'dashboardNewFeaturesState',
+  default: '',
+});

--- a/dashboard/src/services/api.js
+++ b/dashboard/src/services/api.js
@@ -4,11 +4,11 @@ import URI from 'urijs';
 import { toast } from 'react-toastify';
 import fetchRetry from 'fetch-retry';
 import packageInfo from '../../package.json';
-import { HOST, SCHEME } from '../config';
+import { HOST, SCHEME, VERSION } from '../config';
 import { organisationState } from '../recoil/auth';
 import { decrypt, derivedMasterKey, encrypt, generateEntityKey, checkEncryptedVerificationKey, encryptFile, decryptFile } from './encryption';
 import { AppSentry, capture } from './sentry';
-import { apiVersionState, minimumDashboardVersionState } from '../recoil/version';
+import { apiVersionState, minimumDashboardVersionState, dashboardNewFeaturesState } from '../recoil/version';
 const fetch = fetchRetry(window.fetch);
 
 const getUrl = (path, query = {}) => {
@@ -199,7 +199,13 @@ const execute = async ({ method, path = '', body = null, query = {}, headers = {
       method,
       mode: 'cors',
       credentials: 'include',
-      headers: { ...headers, 'Content-Type': 'application/json', Accept: 'application/json', platform: 'dashboard', version: packageInfo.version },
+      headers: {
+        ...headers,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+        platform: 'dashboard',
+        version: VERSION,
+      },
     };
 
     if (body) {
@@ -225,6 +231,9 @@ const execute = async ({ method, path = '', body = null, query = {}, headers = {
     }
     if (response.headers.has('x-minimum-dashboard-version')) {
       setRecoil(minimumDashboardVersionState, response.headers.get('x-minimum-dashboard-version'));
+    }
+    if (response.headers.has('x-dashboard-newfeatures')) {
+      setRecoil(dashboardNewFeaturesState, response.headers.get('x-dashboard-newfeatures'));
     }
 
     if (!response.ok && response.status === 401) {


### PR DESCRIPTION
le but c'est d'afficher avec la popup "veuillez rafraichir" les nouvelles fonctionnalités depuis la version qu'il y a actuellement sur le navigateur, afin 
- d'inciter à cliquer sur cette popup
- de permettre une communication plus directe des fonctionnalités de Mano

contrainte : on ne peut pas mettre cette liste côté `dashboard`, puisque le dashboard n'est pas conscient des nouvelles fonctionnalités des dashboard suivants, seule l'api en est consciente donc j'ai mis ce code côté `api`

j'ai mis ça dans un header, mais j'ai pas réfléchi plus que ça : dans un `response.data` ça me va bien