### PR TITLE
fix(dashboard): onboarding message for teams was always displayed

### DIFF
--- a/dashboard/src/scenes/team/list.js
+++ b/dashboard/src/scenes/team/list.js
@@ -110,7 +110,7 @@ const Create = () => {
           {onboardingForTeams ? 'Dernière étape !' : 'Créer une nouvelle équipe'}
         </ModalHeader>
         <ModalBody>
-          <span>Veuillez créer une première équipe avant de commencer à utiliser la plateforme</span>
+          {Boolean(onboardingForTeams) && <span>Veuillez créer une première équipe avant de commencer à utiliser la plateforme</span>}
           <br />
           <br />
           <Formik

--- a/dashboard/src/scenes/team/list.js
+++ b/dashboard/src/scenes/team/list.js
@@ -110,9 +110,12 @@ const Create = () => {
           {onboardingForTeams ? 'Dernière étape !' : 'Créer une nouvelle équipe'}
         </ModalHeader>
         <ModalBody>
-          {Boolean(onboardingForTeams) && <span>Veuillez créer une première équipe avant de commencer à utiliser la plateforme</span>}
-          <br />
-          <br />
+          {Boolean(onboardingForTeams) && (
+            <span>
+              Veuillez créer une première équipe avant de commencer à utiliser la plateforme <br />
+              <br />
+            </span>
+          )}
           <Formik
             initialValues={{ name: '' }}
             onSubmit={async (values, actions) => {


### PR DESCRIPTION
J'ai corrigé le fait que le message "Veuillez créer une première équipe avant de commencer à utiliser la plateforme" s'affiche tout le temps même quand on n'est pas en onboarding. Ce message devrait s'afficher uniquement la première fois quand on crée une nouvelle organisation (car une première organisation est obligatoire).

Mais ça ne devrait pas s'afficher tout le temps.

<img width="897" alt="Capture d’écran 2023-01-17 à 11 16 15" src="https://user-images.githubusercontent.com/1575946/212872144-2a1573db-e09b-4c12-943e-90f6c7abe9a9.png">
<img width="958" alt="Capture d’écran 2023-01-17 à 11 16 04" src="https://user-images.githubusercontent.com/1575946/212872154-c4f6686e-c2a5-4d30-af16-fecf63f17945.png">
