### PR TITLE
fix(dashboard): allow change certain types of custom fields

### DIFF
--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -299,7 +299,7 @@ const EditCustomField = ({ data, editingField, onClose, onSaveField, isNewField,
   const optionIsDisabled = useCallback(
     (option) => {
       if (typeIsDisabled) return true;
-      if (isNewField) return false;
+      if (isNewField || !fieldIsUsed) return false;
 
       if (['number'].includes(field.type)) {
         return !['text', 'number', 'textarea', 'enum'].includes(option.value);

--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -299,6 +299,7 @@ const EditCustomField = ({ data, editingField, onClose, onSaveField, isNewField,
   const optionIsDisabled = useCallback(
     (option) => {
       if (typeIsDisabled) return true;
+      if (isNewField) return false;
 
       if (['number'].includes(field.type)) {
         return !['text', 'number', 'textarea', 'enum'].includes(option.value);
@@ -311,7 +312,7 @@ const EditCustomField = ({ data, editingField, onClose, onSaveField, isNewField,
       }
       return true;
     },
-    [typeIsDisabled, field.type]
+    [typeIsDisabled, field.type, isNewField]
   );
 
   return (

--- a/dashboard/src/components/TableCustomFields.js
+++ b/dashboard/src/components/TableCustomFields.js
@@ -1,8 +1,7 @@
-import React, { useMemo, useState } from 'react';
+import React, { useCallback, useMemo, useState } from 'react';
 import { toast } from 'react-toastify';
 import { useRecoilState } from 'recoil';
 import { organisationState } from '../recoil/auth';
-import { typeOptions } from '../utils';
 import API from '../services/api';
 import ButtonCustom from './ButtonCustom';
 import SelectCustom from './SelectCustom';
@@ -12,6 +11,17 @@ import TableCustomFieldteamSelector from './TableCustomFieldTeamSelector';
 import SelectDraggableAndEditable from './SelectDraggableAndEditable';
 import { ModalBody, ModalContainer, ModalFooter, ModalHeader } from './tailwind/Modal';
 
+const typeOptions = [
+  { value: 'text', label: 'Texte' },
+  { value: 'textarea', label: 'Zone de texte multi-lignes' },
+  { value: 'number', label: 'Nombre' },
+  { value: 'date', label: 'Date sans heure' },
+  { value: 'date-with-time', label: 'Date avec heure' },
+  { value: 'yes-no', label: 'Oui/Non' },
+  { value: 'enum', label: 'Choix dans une liste' },
+  { value: 'multi-choice', label: 'Choix multiple dans une liste' },
+  { value: 'boolean', label: 'Case à cocher' },
+];
 const getValueFromType = (type) => typeOptions.find((opt) => opt.value === type);
 
 const sanitizeFields = (field) => {
@@ -277,6 +287,33 @@ const EditCustomField = ({ data, editingField, onClose, onSaveField, isNewField,
     onSaveField(editedField);
   };
 
+  const typeIsDisabled = useMemo(() => {
+    if (isNewField || !fieldIsUsed) return false;
+    // the idea to disable the type is to avoid bugs with existing data if the type is changed.
+    // for example, if the type is changed from multi-choice (array) to text (string), or from boolean to text
+    // BUT some data is compatible, let's allow it
+    if (['boolean', 'multi-choice'].includes(field.type)) return true;
+    return false;
+  }, [isNewField, fieldIsUsed, field.type]);
+
+  const optionIsDisabled = useCallback(
+    (option) => {
+      if (typeIsDisabled) return true;
+
+      if (['number'].includes(field.type)) {
+        return !['text', 'number', 'textarea', 'enum'].includes(option.value);
+      }
+      if (['text', 'textarea', 'enum', 'yes-no'].includes(field.type)) {
+        return !['text', 'textarea', 'enum'].includes(option.value);
+      }
+      if (['date', 'date-with-time'].includes(field.type)) {
+        return !['date', 'date-with-time'].includes(option.value);
+      }
+      return true;
+    },
+    [typeIsDisabled, field.type]
+  );
+
   return (
     <ModalContainer open={open} onClose={() => onClose(null)} size="3xl">
       <ModalHeader title={!isNewField ? 'Modifier le champ' : 'Créer un nouveau champ'} />
@@ -308,7 +345,8 @@ const EditCustomField = ({ data, editingField, onClose, onSaveField, isNewField,
               inputId="type"
               classNamePrefix="type"
               name="type"
-              isDisabled={fieldIsUsed || onlyOptionsEditable}
+              isDisabled={typeIsDisabled || onlyOptionsEditable}
+              isOptionDisabled={optionIsDisabled}
               options={typeOptions}
               value={getValueFromType(field.type)}
               onChange={(v) => setField({ ...field, type: v.value })}

--- a/dashboard/src/utils.js
+++ b/dashboard/src/utils.js
@@ -4,18 +4,6 @@ const isNullOrUndefined = (value) => {
   return false;
 };
 
-const typeOptions = [
-  { value: 'text', label: 'Texte' },
-  { value: 'textarea', label: 'Zone de texte multi-lignes' },
-  { value: 'number', label: 'Nombre' },
-  { value: 'date', label: 'Date sans heure' },
-  { value: 'date-with-time', label: 'Date avec heure' },
-  { value: 'yes-no', label: 'Oui/Non' },
-  { value: 'enum', label: 'Choix dans une liste' },
-  { value: 'multi-choice', label: 'Choix multiple dans une liste' },
-  { value: 'boolean', label: 'Case à cocher' },
-];
-
 // Download a file in browser.
 function download(file, fileName) {
   if (window.navigator.msSaveOrOpenBlob) {
@@ -31,4 +19,4 @@ function download(file, fileName) {
   }
 }
 
-export { download, typeOptions, isNullOrUndefined };
+export { download, isNullOrUndefined };


### PR DESCRIPTION
- parce que Mélissa et Nathan s'en sont plaints quelque fois, et j'ai du changer à la main
- parce que pour certains types, y'a pas de raison de ne pas pouvoir changer finalement (genre tout ce qui est `string`)