### PR TITLE
fix(dashboard): cut too long words without spaces in action

### DIFF
--- a/dashboard/src/scenes/organisation/ActionCategoriesSettings.js
+++ b/dashboard/src/scenes/organisation/ActionCategoriesSettings.js
@@ -261,7 +261,7 @@ const ActionCategoriesGroup = ({ groupTitle, categories, onDragAndDrop }) => {
 
   return (
     <>
-      <div className="tw-min-h-full tw-basis-1/2 tw-p-1 xl:tw-basis-1/3">
+      <div className="tw-min-h-full tw-basis-1/2 tw-p-1 xl:tw-basis-1/3 tw-break-all">
         <details
           open
           key={groupTitle}
@@ -270,7 +270,7 @@ const ActionCategoriesGroup = ({ groupTitle, categories, onDragAndDrop }) => {
           className="service-group tw-flex tw-min-h-full tw-flex-col tw-rounded-2xl tw-bg-main tw-bg-opacity-10 tw-p-4">
           <summary className="tw-basis-full tw-text-sm tw-font-bold tw-tracking-wide tw-text-gray-700">
             <div className="tw-group tw-inline-flex tw-w-11/12 tw-shrink tw-justify-between">
-              <span className="category-group-title tw-pl-2">
+              <span className="category-group-title tw-pl-2"> 
                 {groupTitle} ({categories.length})
               </span>
               <button
@@ -288,7 +288,7 @@ const ActionCategoriesGroup = ({ groupTitle, categories, onDragAndDrop }) => {
             ) : (
               categories.map((category) => <Category category={category} key={category} groupTitle={groupTitle} />)
             )}
-            <form className="tw-mt-4 tw-flex" onSubmit={onAddCategory}>
+            <form className="tw-mt-4 tw-flex tw-break-normal" onSubmit={onAddCategory}>
               <input
                 type="text"
                 id="newCategory"


### PR DESCRIPTION
Ah ba je voulais modifier un truc concernant l'affichage et le fait de gérer le break des mots ça a changer aussi ce que je souhaitais faire dans une autre PR. L'affichage ne s'adaptait pas dans action alors qu'elle le faisait dans service. 
 action : 
![Capture d’écran 2023-01-20 à 15 04 20](https://user-images.githubusercontent.com/39462001/213716347-6ba6919c-4061-4fe4-af6a-56775acda580.png)

service : 
![Capture d’écran 2023-01-20 à 15 04 31](https://user-images.githubusercontent.com/39462001/213716410-146aa19f-b9e1-4e3a-8dfc-71b39d74204b.png)

Bon là apparemment on est bon pour les mots et pour cet affichage...