### PR TITLE
fix(dashboard): le temps de session restant faisait légèrement danser l'écran

### DIFF
--- a/dashboard/src/components/SessionCountDownLimiter.js
+++ b/dashboard/src/components/SessionCountDownLimiter.js
@@ -51,9 +51,10 @@ const SessionCountDownLimiter = () => {
 
   return (
     <>
-      <span className={['tw-mt-4', remainingSession < warnBeforeEndOfSession ? 'tw-font-bold tw-text-red-500' : ''].join(' ')}>
-        Temps de session: {timeString}
-      </span>
+      <div className={['tw-mt-4', remainingSession < warnBeforeEndOfSession ? 'tw-font-bold tw-text-red-500' : ''].join(' ')}>
+        <div>Temps de session restant</div>
+        <div>{timeString}</div>
+      </div>
       <button
         onClick={() => setReloadModalOpen(true)}
         className={[


### PR DESCRIPTION
<img width="162" alt="Capture d’écran 2023-01-24 à 15 12 39" src="https://user-images.githubusercontent.com/1575946/214317362-fafce146-f31d-4815-b865-09a6c2f14843.png">
