### PR TITLE
chore(dahsboard): en français les ponctuations doubles ont un espace insécable avant

### DIFF
--- a/dashboard/src/components/drawer.js
+++ b/dashboard/src/components/drawer.js
@@ -161,8 +161,8 @@ const Drawer = () => {
         )}
       </div>
       <p className="tw-mt-auto tw-flex tw-flex-col tw-justify-between tw-text-[0.65rem] tw-text-main">
-        <span>Version: {packageInfo.version}</span>
-        <span>Accessibilité: partielle</span>
+        <span>Version&nbsp;: {packageInfo.version}</span>
+        <span>Accessibilité&nbsp;: partielle</span>
         <SessionCountDownLimiter />
       </p>
     </nav>


### PR DESCRIPTION
D'une manière générale pour retenir, il faut compter combien de morceaux qu'il y a dans la ponctutation. 1 = pas d'espace avant. 2 = un espace insécable avant et pas après.

> Oh ! Mais c'est bizarre, pourquoi on fait comme ça ? Je sais. Je ne sais pas ! Je pense : non ; si, oui.

En anglais c'est toujours collé

> Oh! That's weird, why do we have to do that way? I know. I don't know! I think: no; yes, yes.

Source : https://fr.wikipedia.org/wiki/Ponctuation#En_fran%C3%A7ais