### PR TITLE
fix(dashboard): retire une entrée buggée de l'historique, où on enregistrait la personne entière

### DIFF
--- a/dashboard/src/scenes/person/OutOfActiveList.js
+++ b/dashboard/src/scenes/person/OutOfActiveList.js
@@ -10,13 +10,14 @@ import API from '../../services/api';
 import DatePicker from 'react-datepicker';
 import { dateForDatePicker } from '../../services/date';
 import SelectCustom from '../../components/SelectCustom';
+import { cleanHistory } from './components/History';
 
 const OutOfActiveList = ({ person }) => {
   const [open, setOpen] = useState(false);
-  
+
   const preparePersonForEncryption = usePreparePersonForEncryption();
   const user = useRecoilValue(userState);
-  
+
   const fieldsPersonsCustomizableOptions = useRecoilValue(fieldsPersonsCustomizableOptionsSelector);
   const setPersons = useSetRecoilState(personsState);
 
@@ -30,8 +31,8 @@ const OutOfActiveList = ({ person }) => {
         outOfActiveListDate: { oldValue: person.outOfActiveListDate, newValue: null },
       },
     };
-    
-    const history = [...(person.history || []), historyEntry];
+
+    const history = [...(cleanHistory(person.history) || []), historyEntry];
     const response = await API.put({
       path: `/person/${person._id}`,
       body: preparePersonForEncryption({ ...person, outOfActiveList: false, outOfActiveListReasons: [], outOfActiveListDate: null, history }),
@@ -61,7 +62,7 @@ const OutOfActiveList = ({ person }) => {
       },
     };
 
-    updatedPerson.history = [...(person.history || []), historyEntry];
+    updatedPerson.history = [...(cleanHistory(person.history) || []), historyEntry];
     const response = await API.put({
       path: `/person/${person._id}`,
       body: preparePersonForEncryption(updatedPerson),
@@ -77,7 +78,7 @@ const OutOfActiveList = ({ person }) => {
       toast.success(person.name + ' est hors de la file active');
     }
   };
-  
+
   return (
     <>
       <ButtonCustom
@@ -87,7 +88,9 @@ const OutOfActiveList = ({ person }) => {
         color={'warning'}
       />
       <Modal isOpen={open} toggle={() => setOpen(false)} size="lg" backdrop="static">
-        <ModalHeader className="tw-break-all" toggle={() => setOpen(false)}>Sortie de file active de {person.name}</ModalHeader>
+        <ModalHeader className="tw-break-all" toggle={() => setOpen(false)}>
+          Sortie de file active de {person.name}
+        </ModalHeader>
         <ModalBody>
           <Formik
             initialValues={{ ...person, outOfActiveListDate: dateForDatePicker(Date.now()), outOfActiveListReasons: [] }}

--- a/dashboard/src/scenes/person/components/EditModal.js
+++ b/dashboard/src/scenes/person/components/EditModal.js
@@ -20,6 +20,7 @@ import ButtonCustom from '../../../components/ButtonCustom';
 import { Formik } from 'formik';
 import { toast } from 'react-toastify';
 import API from '../../../services/api';
+import { cleanHistory } from './History';
 
 export default function EditModal({ person, selectedPanel, onClose }) {
   const [openPanels, setOpenPanels] = useState([selectedPanel]);
@@ -54,7 +55,7 @@ export default function EditModal({ person, selectedPanel, onClose }) {
               if (!allowedFieldsInHistory.includes(key)) continue;
               if (body[key] !== person[key]) historyEntry.data[key] = { oldValue: person[key], newValue: body[key] };
             }
-            if (!!Object.keys(historyEntry.data).length) body.history = [...(person.history || []), historyEntry];
+            if (!!Object.keys(historyEntry.data).length) body.history = [...cleanHistory(person.history || []), historyEntry];
 
             const response = await API.put({
               path: `/person/${person._id}`,

--- a/dashboard/src/scenes/person/components/History.js
+++ b/dashboard/src/scenes/person/components/History.js
@@ -19,7 +19,7 @@ export const cleanHistory = (history) => {
 const History = ({ person }) => {
   const personFieldsIncludingCustomFields = useRecoilValue(personFieldsIncludingCustomFieldsSelector);
   const teams = useRecoilValue(teamsState);
-  const history = useMemo(() => cleanHistory([...(person.history || [])]).reverse(), [person.history]);
+  const history = useMemo(() => cleanHistory(person.history || []).reverse(), [person.history]);
 
   return (
     <div>


### PR DESCRIPTION
note: 
suite à la carte https://trello.com/c/z3Qec0Tl/1023-bug-daffichage-de-lhistorique j'ai envoyé un hotfix  https://github.com/SocialGouv/mano/commit/257d8dfb7564f6781c66033b9b318d8988b5eff5 avec cette fonction:

https://github.com/SocialGouv/mano/blob/c3ac6326f7a3d03b945948825d6cbd9944735ddf/dashboard/src/scenes/person/components/History.js#L10-L17

je propose d'étendre cette fonction au-delà de la lecture de l'historique, et de cleaner l'historique à l'écriture aussi

refus entendable !


