### PR TITLE
fix(dashboard,app): possibilité de rechercher plusieurs mots dans le désordre pour retrouver par exemple une personne via nom prénom ou prénom nom

### DIFF
--- a/app/src/utils/search.js
+++ b/app/src/utils/search.js
@@ -34,9 +34,10 @@ export const filterBySearch = (search, items = []) => {
   const searchNormalized = search.toLocaleLowerCase();
   const searchTerms = searchNormalized.split(' ');
   // Add lowerCaseName once to items for faster search.
-  const itemsWithLowerCaseName = items.map((item) => ({ ...item, lowerCaseName: item?.name?.toLocaleLowerCase() }));
+  const itemsWithLowerCaseName = items.map((item) => ({ ...item, lowerCaseName: item?.name?.toLocaleLowerCase() || '' }));
   // Items that have exact match in the beginning of the search string are first.
   const firstItems = itemsWithLowerCaseName.filter((item) => item.lowerCaseName.startsWith(searchNormalized));
+
   const firstItemsIds = new Set(firstItems.map((item) => item._id));
   // Items that have all words in search (the order does not matter) are second.
   const secondItems = itemsWithLowerCaseName.filter(

--- a/app/src/utils/search.js
+++ b/app/src/utils/search.js
@@ -31,18 +31,24 @@ const prepareItemForSearch = (item) => {
 };
 
 export const filterBySearch = (search, items = []) => {
-  search = search.toLocaleLowerCase();
-  const firstItems = items.filter((item) => item?.name?.toLocaleLowerCase().startsWith(search));
+  const searchNormalized = search.toLocaleLowerCase();
+  const searchTerms = searchNormalized.split(' ');
+  // Add lowerCaseName once to items for faster search.
+  const itemsWithLowerCaseName = items.map((item) => ({ ...item, lowerCaseName: item?.name?.toLocaleLowerCase() }));
+  // Items that have exact match in the beginning of the search string are first.
+  const firstItems = itemsWithLowerCaseName.filter((item) => item.lowerCaseName.startsWith(searchNormalized));
   const firstItemsIds = new Set(firstItems.map((item) => item._id));
-  const secondItems = items.filter((item) => !firstItemsIds.has(item._id)).filter((item) => item?.name?.toLocaleLowerCase().includes(search));
+  // Items that have all words in search (the order does not matter) are second.
+  const secondItems = itemsWithLowerCaseName.filter(
+    (item) => !firstItemsIds.has(item._id) && searchTerms.every((e) => item.lowerCaseName.includes(e))
+  );
   const secondItemsIds = new Set(secondItems.map((item) => item._id));
-  const lastItems = items
-    .filter((item) => !firstItemsIds.has(item._id))
-    .filter((item) => !secondItemsIds.has(item._id))
-    .filter((item) => {
-      const stringifiedItem = JSON.stringify(prepareItemForSearch(item));
-      return stringifiedItem.toLocaleLowerCase().includes(search);
-    });
+  const lastItems = items.filter((item) => {
+    if (firstItemsIds.has(item._id) || secondItemsIds.has(item._id)) return false;
+    const stringifiedItem = JSON.stringify(prepareItemForSearch(item)).toLocaleLowerCase();
+    for (const term of searchTerms) if (!stringifiedItem.includes(term)) return false;
+    return true;
+  });
 
   return [...firstItems, ...secondItems, ...lastItems];
 };

--- a/dashboard/src/scenes/search/utils.js
+++ b/dashboard/src/scenes/search/utils.js
@@ -31,17 +31,24 @@ const prepareItemForSearch = (item) => {
 };
 
 export const filterBySearch = (search, items = []) => {
-  search = search.toLocaleLowerCase();
-  const firstItems = items.filter((item) => item?.name?.toLocaleLowerCase().startsWith(search));
+  const searchNormalized = search.toLocaleLowerCase();
+  const searchTerms = searchNormalized.split(' ');
+  // Add lowerCaseName once to items for faster search.
+  const itemsWithLowerCaseName = items.map((item) => ({ ...item, lowerCaseName: item?.name?.toLocaleLowerCase() }));
+  // Items that have exact match in the beginning of the search string are first.
+  const firstItems = itemsWithLowerCaseName.filter((item) => item.lowerCaseName.startsWith(searchNormalized));
   const firstItemsIds = new Set(firstItems.map((item) => item._id));
-  const secondItems = items.filter((item) => !firstItemsIds.has(item._id)).filter((item) => item?.name?.toLocaleLowerCase().includes(search));
+  // Items that have all words in search (the order does not matter) are second.
+  const secondItems = itemsWithLowerCaseName.filter(
+    (item) => !firstItemsIds.has(item._id) && searchTerms.every((e) => item.lowerCaseName.includes(e))
+  );
   const secondItemsIds = new Set(secondItems.map((item) => item._id));
-  const lastItems = items
-    .filter((item) => !firstItemsIds.has(item._id))
-    .filter((item) => !secondItemsIds.has(item._id))
-    .filter((item) => {
-      const stringifiedItem = JSON.stringify(prepareItemForSearch(item));
-      return stringifiedItem.toLocaleLowerCase().includes(search);
-    });
+  const lastItems = items.filter((item) => {
+    if (firstItemsIds.has(item._id) || secondItemsIds.has(item._id)) return false;
+    const stringifiedItem = JSON.stringify(prepareItemForSearch(item)).toLocaleLowerCase();
+    for (const term of searchTerms) if (!stringifiedItem.includes(term)) return false;
+    return true;
+  });
+
   return [...firstItems, ...secondItems, ...lastItems];
 };

--- a/dashboard/src/scenes/search/utils.js
+++ b/dashboard/src/scenes/search/utils.js
@@ -34,7 +34,7 @@ export const filterBySearch = (search, items = []) => {
   const searchNormalized = search.toLocaleLowerCase();
   const searchTerms = searchNormalized.split(' ');
   // Add lowerCaseName once to items for faster search.
-  const itemsWithLowerCaseName = items.map((item) => ({ ...item, lowerCaseName: item?.name?.toLocaleLowerCase() }));
+  const itemsWithLowerCaseName = items.map((item) => ({ ...item, lowerCaseName: item?.name?.toLocaleLowerCase() || '' }));
   // Items that have exact match in the beginning of the search string are first.
   const firstItems = itemsWithLowerCaseName.filter((item) => item.lowerCaseName.startsWith(searchNormalized));
   const firstItemsIds = new Set(firstItems.map((item) => item._id));

--- a/e2e/scripts/populate-db.ts
+++ b/e2e/scripts/populate-db.ts
@@ -299,3 +299,16 @@ export async function populate() {
     console.error(err);
   }
 }
+
+export async function deleteAllPersons() {
+  try {
+    const client = new pg.Client({
+      connectionString: `${process.env.PGBASEURL}/manotest`,
+    });
+    await client.connect();
+    await client.query(`DELETE FROM mano."Person"`);
+    await client.end();
+  } catch (err) {
+    console.error(err);
+  }
+}

--- a/e2e/search-with-accent-and-disorder.spec.ts
+++ b/e2e/search-with-accent-and-disorder.spec.ts
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test";
+import { deleteAllPersons, populate } from "./scripts/populate-db";
+import { loginWith } from "./utils";
+
+test.beforeAll(async () => {
+  await populate();
+  await deleteAllPersons();
+});
+
+test("search in reception and user list using different order and accent", async ({ page }) => {
+  await loginWith(page, "admin1@example.org");
+  await page.getByRole("link", { name: "Personnes suivies" }).click();
+  await page.getByRole("button", { name: "Créer une nouvelle personne" }).click();
+  await page.getByLabel("Nom").click();
+  await page.getByLabel("Nom").fill("azertyé qsdfghç");
+  await page.getByRole("button", { name: "Sauvegarder" }).click();
+  await page.getByText("Création réussie !").click();
+  await page.getByRole("link", { name: "Personnes suivies" }).click();
+  await page.getByRole("button", { name: "Créer une nouvelle personne" }).click();
+  await page.getByLabel("Nom").click();
+  await page.getByLabel("Nom").fill("azertyé wxcvbn");
+  await page.getByRole("button", { name: "Sauvegarder" }).click();
+  await page.getByText("Création réussie !").click();
+  await page.getByRole("link", { name: "Personnes suivies" }).click();
+  await page.locator("#search").click();
+  await page.locator("#search").fill("qsDFghç AZrtyé");
+  await page.getByText("azertyé qsdfghç").click();
+  await page.getByRole("link", { name: "Personnes suivies" }).click();
+  await page.locator("#search").click();
+  await page.locator("#search").fill("wxcvbn");
+  await page.getByText("azertyé wxcvbn").click();
+  await page.getByRole("link", { name: "Personnes suivies" }).click();
+  await page.locator("#search").click();
+  await page.locator("#search").fill("azertyé");
+  await page.getByText("(Total: 2)").click();
+  await page.locator("#search").click();
+  await page.locator("#search").fill("azertyé qsd");
+  await page.getByText("(Total: 1)").click();
+  await page.locator("#search").click();
+  await page.locator("#search").fill("azertyé qsdm");
+  await page.getByText("(Total: 0)").click();
+  await page.getByRole("link", { name: "Accueil" }).click();
+  await page.locator(".person-select-and-create-reception__input-container").click();
+  await page.locator("#person-select-and-create-reception").fill("qsdfghç azertyé");
+  await page.locator("#react-select-10-option-0").getByText("azertyé qsdfghç").click();
+  await page.locator("#person-select-and-create-reception").fill("az");
+  await page.locator("#react-select-10-option-1").getByText("azertyé wxcvbn").click();
+});


### PR DESCRIPTION
See: https://trello.com/c/12YDi3xO/1026-bug-saisi-recherche

Un peu de duplication tant qu'on n'aura pas statué sur ce qu'on attend de la recherche.
Je pense que le JSON n'est pas bon car par exemple si je tape "abd" pour "abdel" j'ai de grande chance d'avoir des UUID en tout genre qui ressorte ou des encrypted content. Bref ça fait des résultats surprenants.

> Rap2h
Bon je vais peut être pas factoriser, mais voilà le truc :
Celle de l’accueil “normalise” les mots (accents, etc.) et regarde sur le nom et la date de naissance
Celle de la liste des personne ne normalise pas les mots et regarde sur un json stringifié de l’item. Elle est utilisée pour tous les autres types de recherche.
Les deux ont des pour et des contres.
J’aurai tendance à privilégier la première mais avec plus de champs (mais pas tous et hiérarchisés). Une sorte de mix des deux. En gros de faire une recherche un peu pertinente et pas juste aveugle, mais en même temps un peu plus large (genre pourquoi ya pas le pseudo ou le tel)
Bon mais rien ne presse je garde en double pour l’instant.
>
>Arnaud
 J’aurai tendance à privilégier la première mais avec plus de champs (mais pas tous et hiérarchisés).
c'est en réponse à une demande, ce n'est pas mon choix initial - je pense que si on retire on va se faire taper sur les doigts
moi je suggère plutôt
la normalisation des mots dans tous les cas
la gestion des espaces comme le montre le vidéo, puis
soit on garde un comportement différent dans les deux recherches (plutôt pour)
soit on harmonise, avec la recherche sur tout ce qui concerne une personne (plutôt contre)
>
> Rap2h
Ah pardon j’ai pas précisé : dans tous les cas je corrige les espaces
donc ok on est d’accord