### PR TITLE
fix: rendre le champ Lieu obligatoire dans l'ajout d'un lieu fréquenté

### DIFF
--- a/dashboard/src/scenes/person/Places.js
+++ b/dashboard/src/scenes/person/Places.js
@@ -224,6 +224,7 @@ const RelPersonPlaceModal = ({ open, setOpen, person, relPersonPlaceModal, setPl
               isDisabled={posting}
               value={places.find((p) => p._id === placeId)}
               creatable
+              required
               onCreateOption={onCreatePlace}
               getOptionValue={(i) => i._id}
               getOptionLabel={(i) => i.name}


### PR DESCRIPTION
devrait résoudre [MANO-9Z](https://sentry.fabrique.social.gouv.fr/organizations/incubateur/issues/92113/?project=52&query=is%3Aunresolved&statsPeriod=14d)