### PR TITLE
feat(dashboard): ajout de 10 couleurs supplémentaires pour différenciation des équipes

### DIFF
--- a/dashboard/src/components/TagTeam.js
+++ b/dashboard/src/components/TagTeam.js
@@ -20,7 +20,7 @@ const TagTeam = ({ teamId }) => {
   );
 };
 
-const teamsColors = ['#255c99cc', '#74776bcc', '#00c6a5cc', '#ff4b64cc', '#ef798acc'];
-const borderColors = ['#255c99', '#74776b', '#00c6a5', '#ff4b64', '#ef798a'];
+const teamsColors = ['#255c99cc', '#74776bcc', '#00c6a5cc', '#ff4b64cc', '#ef798acc', '#a066ffcc', '#00e6d6cc', '#124660cc', '#ff4f38cc', '#1b9476cc', '#4dbac7cc','#ffa500cc', '#e392dbcc', '#28A428cc', '#f5c000cc'];
+const borderColors = ['#255c99', '#74776b', '#00c6a5', '#ff4b64', '#ef798a', '#a066ff', '#00e6d6', '#124660', '#ff4f38', '#1b9476', '#4dbac7', '#ffa500', '#e392db', '#28a428', '#f5d000'];
 
 export default TagTeam;

--- a/dashboard/src/components/TopBar.js
+++ b/dashboard/src/components/TopBar.js
@@ -135,8 +135,8 @@ const ColorHeadband = ({ teamId }) => {
   );
 };
 
-const teamsColors = ['#255c99cc', '#74776bcc', '#00c6a5cc', '#ff4b64cc', '#ef798acc'];
-const borderColors = ['#255c99', '#74776b', '#00c6a5', '#ff4b64', '#ef798a'];
+const teamsColors = ['#255c99cc', '#74776bcc', '#00c6a5cc', '#ff4b64cc', '#ef798acc', '#a066ffcc', '#00e6d6cc', '#124660cc', '#ff4f38cc', '#1b9476cc', '#4dbac7cc','#ffa500cc', '#e392dbcc', '#28A428cc', '#f5c000cc'];
+const borderColors = ['#255c99', '#74776b', '#00c6a5', '#ff4b64', '#ef798a', '#a066ff', '#00e6d6', '#124660', '#ff4f38', '#1b9476', '#4dbac7', '#ffa500', '#e392db', '#28a428', '#f5d000'];
 
 const DropdownToggleStyled = styled(DropdownToggle)`
   border-radius: 40px !important;


### PR DESCRIPTION
A tester si les couleurs semblent adaptées...

J'ai eu un bug lors du changement de noms d'une équipe (2 fois), l'équipe changeait de couleur, comme si l'ID se modifiait et ne se trouvait donc plus au même index dans le tableau (je l'explique comme ça mais cela venait peut être de modifications dans mon ordre des couleurs sans rafraichir etc... bref)...  Après avoir tout remis au propre, mis mes couleurs dans l'ordres etc..., je n'arrive plus à reproduire ce bug mais je vais refaire d'autre tests par précaution... A garder en tête si jamais... Ne pouvons nous pas ajouter un attribut couleur à une team le cas échéant ? 