### PR TITLE
fix(dashboard): ajout des champs personnalisés par défaut lors de la création d'une nouvelle organisation

### DIFF
--- a/api/src/controllers/organisation.js
+++ b/api/src/controllers/organisation.js
@@ -26,6 +26,7 @@ const Place = require("../models/place");
 const RelPersonPlace = require("../models/relPersonPlace");
 const TerritoryObservation = require("../models/territoryObservation");
 const { serializeOrganisation } = require("../utils/data-serializer");
+const { defaultSocialCustomFields, defaultMedicalCustomFields } = require("../utils/custom-fields/person");
 
 const JWT_MAX_AGE = 60 * 60 * 3; // 3 hours in s
 
@@ -121,7 +122,16 @@ router.post(
     const user = await User.findOne({ where: { email } });
     if (!!user) return res.status(400).send({ ok: false, error: "Cet email existe déjà dans une autre organisation" });
 
-    const organisation = await Organisation.create({ name: orgName }, { returning: true });
+    const organisation = await Organisation.create(
+      {
+        name: orgName,
+        // We have to add default custom fields on creation (search for "custom-fields-persons-setup" in code).
+        customFieldsPersonsSocial: defaultSocialCustomFields,
+        customFieldsPersonsMedical: defaultMedicalCustomFields,
+        migrations: ["custom-fields-persons-setup"],
+      },
+      { returning: true }
+    );
     const token = crypto.randomBytes(20).toString("hex");
     const adminUser = await User.create(
       {

--- a/api/src/db/migrations/2022-03-07_add_migrations_in_organisation.js
+++ b/api/src/db/migrations/2022-03-07_add_migrations_in_organisation.js
@@ -9,6 +9,10 @@ module.exports = async () => {
     //    so the script can execut to migrate existing custom fields to the customFieldsPersons.
     // 2. If the organisation is new, it will have the `customPersonsFields by default so it won't need
     //    the 'custom-fields-persons-setup' migration, that's why we setup as default migration here.
+    //
+    // Note(2023-02-07): This migration is useless since the column is not re-created in production.
+    //                   'custom-fields-persons-setup' has to be added when the organisation is created.
+    //
     await sequelize.query(`
       ALTER TABLE "mano"."Organisation"
       ADD COLUMN IF NOT EXISTS "migrations" text[] default array['custom-fields-persons-setup'];


### PR DESCRIPTION
Plusieurs problèmes :
- Si on en croit ce fichier `api/src/db/migrations/2022-03-07_add_migrations_in_organisation.js` la valeur `custom-fields-persons-setup` n'est ajoutée dans migration que si la colonne migration n'existe pas. Ce qui n'arrive jamais, parce que la base de données n'est pas créée sauf pour les nouveaux devs.
- Les champs persos n'étaient pas ajoutés dans la base de données lors de la création d'une organisation. Enfin si : ils l'étaient au prochain déploiement grâce à `api/src/db/migrations/2023-01-19_custom-fields-person.js`. Mais c'est également absurde car ce "correctif" n'arrive que quand on redéploie le dashboard.

Bref maintenant quand on crée une organisation, on ajoute les champs persos.
Source : https://trello.com/c/YMh751zh/1041-quand-on-cr%C3%A9e-une-nouvelle-orga-tous-les-champs-de-la-partie-sociale-et-m%C3%A9dicale-sont-vides-il-faudrait-remettre-ceux-davant-com