### PR TITLE
fix(dashboard): mots trop long - utilisation de overflow:anywhere

### DIFF
--- a/dashboard/src/components/ActionsCalendar.js
+++ b/dashboard/src/components/ActionsCalendar.js
@@ -129,7 +129,13 @@ const ActionsCalendar = ({ actions, columns = ['Heure', 'Nom', 'Personne suivie'
           sortBy,
           sortOrder,
           dataKey: 'name',
-          render: (action) => <ActionOrConsultationName item={action} />,
+          render: (action) => {
+            return (
+              <div className="[overflow-wrap:anywhere]">
+                <ActionOrConsultationName item={action} />
+              </div>
+            );
+          },
         },
         {
           title: 'Personne suivie',
@@ -138,7 +144,13 @@ const ActionsCalendar = ({ actions, columns = ['Heure', 'Nom', 'Personne suivie'
           sortBy,
           sortOrder,
           dataKey: 'person',
-          render: (action) => <PersonName item={action} />,
+          render: (action) => {
+            return (
+              <div className="[overflow-wrap:anywhere]">
+                <PersonName item={action} />
+              </div>
+            );
+          },
         },
         {
           title: 'Statut',

--- a/dashboard/src/scenes/person/components/InfosMain.js
+++ b/dashboard/src/scenes/person/components/InfosMain.js
@@ -13,7 +13,7 @@ export function InfosMain({ person }) {
       {Boolean(editModal) && <EditModal person={person} selectedPanel={'main'} onClose={() => setEditModal(false)} />}
       <div className="card !tw-rounded-lg !tw-bg-main" data-test-id={person._id}>
         <div className="card-body">
-          <div className="person-name">
+          <div className="person-name [overflow-wrap:anywhere]">
             {person.alertness && <ExclamationMarkButton className="tw-mr-2" />}
             <b>{person.name}</b>
             {person.otherNames && <span> ({person.otherNames})</span>}

--- a/dashboard/src/scenes/person/components/PersonDocuments.js
+++ b/dashboard/src/scenes/person/components/PersonDocuments.js
@@ -99,7 +99,7 @@ const PersonDocuments = ({ person }) => {
                 setDocumentToEdit(doc);
               }}>
               <td className="tw-p-3">
-                <p className="tw-m-0 tw-flex tw-items-center tw-overflow-hidden tw--all tw-font-bold">
+                <p className="tw-m-0 tw-flex tw-items-center tw-overflow-hidden tw-font-bold">
                   {!!organisation.groupsEnabled && !!doc.group && (
                     <span className="tw-mr-2 tw-text-xl" aria-label="Commentaire familial" title="Commentaire familial">
                       👪

--- a/dashboard/src/scenes/person/components/PersonDocuments.js
+++ b/dashboard/src/scenes/person/components/PersonDocuments.js
@@ -108,7 +108,7 @@ const PersonDocuments = ({ person }) => {
                   {doc.name}
                 </p>
                 {!!organisation.groupsEnabled && !!doc.group && !!doc.personPopulated && (
-                  <p className="tw-m-0 tw-mt-1 tw-text-xs">
+                  <p className="tw-m-0 tw-mt-1 tw--xs">
                     Ce document est lié à <PersonName item={doc} />
                   </p>
                 )}

--- a/dashboard/src/scenes/person/components/PersonDocuments.js
+++ b/dashboard/src/scenes/person/components/PersonDocuments.js
@@ -99,7 +99,7 @@ const PersonDocuments = ({ person }) => {
                 setDocumentToEdit(doc);
               }}>
               <td className="tw-p-3">
-                <p className="tw-m-0 tw-flex tw-items-center tw-overflow-hidden tw-break-all tw-font-bold">
+                <p className="tw-m-0 tw-flex tw-items-center tw-overflow-hidden tw--all tw-font-bold">
                   {!!organisation.groupsEnabled && !!doc.group && (
                     <span className="tw-mr-2 tw-text-xl" aria-label="Commentaire familial" title="Commentaire familial">
                       👪
@@ -157,7 +157,7 @@ function DocumentModal({ document, onClose, person }) {
   );
 
   return (
-    <ModalContainer open>
+    <ModalContainer open className="[overflow-wrap:anywhere]" >
       <ModalHeader title={document.name} />
       <ModalBody>
         <div className="tw-flex tw-w-full tw-flex-col tw-justify-between tw-gap-4 tw-px-8">

--- a/dashboard/src/scenes/person/list.js
+++ b/dashboard/src/scenes/person/list.js
@@ -225,11 +225,11 @@ const List = () => {
               if (p.outOfActiveList)
                 return (
                   <div className="tw-text-black50 tw-max-w-md">
-                    <div className="tw-flex tw-break-all tw-font-bold">{p.name}</div>
+                    <div className="tw-flex tw-font-bold [overflow-wrap:anywhere]">{p.name}</div>
                     <div>Sortie de file active : {p.outOfActiveListReasons?.join(', ')}</div>
                   </div>
                 );
-              return <div className="tw-max-w-md tw-flex tw-break-all tw-font-bold">{p.name}</div>
+              return <div className="tw-max-w-md tw-flex tw-font-bold [overflow-wrap:anywhere]">{p.name}</div>
             },
           },
           {

--- a/dashboard/src/scenes/person/view.js
+++ b/dashboard/src/scenes/person/view.js
@@ -116,7 +116,7 @@ export default function View() {
           )}
         </div>
       </div>
-      <div className="tw-break-all tw-pt-4" data-test-id={person?.name + currentTab}>
+      <div className="tw-pt-4" data-test-id={person?.name + currentTab}>
         {person.outOfActiveList && (
           <Alert color="warning" className="noprint">
             {person?.name} est en dehors de la file active, pour{' '}

--- a/dashboard/src/scenes/structure/list.js
+++ b/dashboard/src/scenes/structure/list.js
@@ -79,9 +79,29 @@ const List = () => {
           setCurrentStructureOpen(true);
         }}
         columns={[
-          { title: 'Nom', dataKey: 'name', render: (structures) => <b>{structures.name}</b> },
+          { 
+            title: 'Nom', 
+            dataKey: 'name', 
+            render: (structures) => {
+              return (
+                <div className="[overflow-wrap:anywhere]">
+                  <b>{structures.name}</b>
+                </div> 
+              );
+            },
+          },
           { title: 'Téléphone', dataKey: 'phone' },
-          { title: 'Adresse', dataKey: 'adresse' },
+          { 
+            title: 'Adresse', 
+            dataKey: 'adresse',
+            render: (structures) => {
+              return (
+                <div className="[overflow-wrap:anywhere]">
+                  {structures.adresse}
+                </div>
+              );
+            },
+          },
           { title: 'Code postal', dataKey: 'postcode' },
           { title: 'Ville', dataKey: 'city' },
           {

--- a/dashboard/src/scenes/territory/list.js
+++ b/dashboard/src/scenes/territory/list.js
@@ -1,7 +1,6 @@
 import React, { useMemo, useState } from 'react';
 import { Col, Button as LinkButton, FormGroup, Row, Modal, ModalBody, ModalHeader, Input, Label } from 'reactstrap';
 import { useHistory } from 'react-router-dom';
-import styled from 'styled-components';
 import { toast } from 'react-toastify';
 import { Formik } from 'formik';
 import { useRecoilValue, useSetRecoilState } from 'recoil';
@@ -89,7 +88,13 @@ const List = () => {
             onSortBy: setSortBy,
             sortOrder,
             sortBy,
-            render: (territory) => <b>{territory.name}</b>,
+            render: (territory) => {
+              return (
+                <div className="[overflow-wrap:anywhere]">
+                  <b>{territory.name}</b>,
+                </div>
+              );
+            },
           },
           {
             title: 'Types',
@@ -134,7 +139,7 @@ const CreateTerritory = () => {
   const { refresh, isLoading } = useDataLoader();
 
   return (
-    <CreateStyle>
+    <div className="tw-w-full tw-flex tw-justify-end">
       <LinkButton disabled={isLoading} onClick={() => refresh} color="link" style={{ marginRight: 10 }}>
         Rafraichir
       </LinkButton>
@@ -205,14 +210,8 @@ const CreateTerritory = () => {
           </Formik>
         </ModalBody>
       </Modal>
-    </CreateStyle>
+    </div>
   );
 };
-
-const CreateStyle = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: flex-end;
-`;
 
 export default List;


### PR DESCRIPTION
fait :
- noms de structures dans la liste des structures
- adresses de structures dans la liste des structures
- noms de personnes dans l'agenda
- noms des actions dans l'agenda
- noms des territoires dans la liste des territoires (+ modif CSS vers Tailwind sur le fichier)
 
Correction ancienne PR : 
- noms trop longs sur fiche d'une personne
- noms trop longs sur la liste des personnes

ajout nouveau fix :
- modale de téléchargement document d'un personne