### PR TITLE
fix(dashboard): noms de services trop longs dans l'onglet Accueil de la page statistique

### DIFF
--- a/dashboard/src/scenes/stats/Reception.js
+++ b/dashboard/src/scenes/stats/Reception.js
@@ -40,18 +40,17 @@ const ReceptionStats = ({ passages, reportsServices, period, teamsId }) => {
         />
       </div>
       {servicesFromDatabase !== null && (
-        <div className="[overflow-wrap:anywhere]">
           <CustomResponsivePie
             title="Services"
             help={`Services enregistrés dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des services.`}
             data={organisation.services?.map((service) => {
               return {
+                id: service,
                 label: service,
                 value: reportsServices.reduce((serviceNumber, rep) => (rep?.[service] || 0) + serviceNumber, 0) + (servicesFromDatabase[service] || 0),
               };
             })}
           />
-        </div>
       )}
     </>
   );

--- a/dashboard/src/scenes/stats/Reception.js
+++ b/dashboard/src/scenes/stats/Reception.js
@@ -40,17 +40,17 @@ const ReceptionStats = ({ passages, reportsServices, period, teamsId }) => {
         />
       </div>
       {servicesFromDatabase !== null && (
-          <CustomResponsivePie
-            title="Services"
-            help={`Services enregistrés dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des services.`}
-            data={organisation.services?.map((service) => {
-              return {
-                id: service,
-                label: service,
-                value: reportsServices.reduce((serviceNumber, rep) => (rep?.[service] || 0) + serviceNumber, 0) + (servicesFromDatabase[service] || 0),
-              };
-            })}
-          />
+        <CustomResponsivePie
+          title="Services"
+          help={`Services enregistrés dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des services.`}
+          data={organisation.services?.map((service) => {
+            return {
+              id: service,
+              label: service,
+              value: reportsServices.reduce((serviceNumber, rep) => (rep?.[service] || 0) + serviceNumber, 0) + (servicesFromDatabase[service] || 0),
+            };
+          })}
+        />
       )}
     </>
   );

--- a/dashboard/src/scenes/stats/Reception.js
+++ b/dashboard/src/scenes/stats/Reception.js
@@ -40,17 +40,18 @@ const ReceptionStats = ({ passages, reportsServices, period, teamsId }) => {
         />
       </div>
       {servicesFromDatabase !== null && (
-        <CustomResponsivePie
-          title="Services"
-          help={`Services enregistrés dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des services.`}
-          data={organisation.services?.map((service) => {
-            return {
-              id: service,
-              label: service,
-              value: reportsServices.reduce((serviceNumber, rep) => (rep?.[service] || 0) + serviceNumber, 0) + (servicesFromDatabase[service] || 0),
-            };
-          })}
-        />
+        <div className="[overflow-wrap:anywhere]">
+          <CustomResponsivePie
+            title="Services"
+            help={`Services enregistrés dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des services.`}
+            data={organisation.services?.map((service) => {
+              return {
+                label: service,
+                value: reportsServices.reduce((serviceNumber, rep) => (rep?.[service] || 0) + serviceNumber, 0) + (servicesFromDatabase[service] || 0),
+              };
+            })}
+          />
+        </div>
       )}
     </>
   );

--- a/dashboard/src/scenes/stats/charts.js
+++ b/dashboard/src/scenes/stats/charts.js
@@ -32,7 +32,7 @@ export const CustomResponsivePie = ({ data = [], title, onItemClick, help }) => 
               .sort((a, b) => (a.value < b.value ? 1 : -1))
               .map(({ key, label, value }) => (
                 <tr key={key + label + value} onClick={() => onClick({ id: label })}>
-                  <td className="tw-border tw-border-zinc-400">{label}</td>
+                  <td className="tw-border tw-border-zinc-400 [overflow-wrap:anywhere]">{label}</td>
                   <td className="tw-border tw-border-zinc-400 tw-text-center">{value}</td>
                   {total ? <td className="tw-border tw-border-zinc-400 tw-text-center">{`${Math.round((value / total) * 1000) / 10}%`}</td> : <></>}
                 </tr>


### PR DESCRIPTION
Avant : 

![Capture d’écran 2023-02-11 à 13 59 46](https://user-images.githubusercontent.com/39462001/218259896-78c756a7-9069-40fb-874d-570a520f9652.png)

Après : 

![Capture d’écran 2023-02-11 à 14 08 23](https://user-images.githubusercontent.com/39462001/218259911-118d3fbb-adb2-4788-b33b-0d32acb54f0d.png)

La bande à droite se rétréci dans le cas où l'on met des mots trop longs et que l'on réduit un peu la fenêtre, du coup c'est pas hyper jolie... Peux tu tester et me dire ce que tu en penses ? Sinon j'essai de trouver une propriété pour éviter ça. On part quand même du principe que personne ne devrait mettre des noms à rallonge mais bon...  