### PR TITLE
fix(dashboard): mots trop longs -> editmodal + titre et texte info medicale et info sociale sur fiche d'une personne

### DIFF
--- a/dashboard/src/scenes/person/components/EditModal.js
+++ b/dashboard/src/scenes/person/components/EditModal.js
@@ -222,6 +222,8 @@ export default function EditModal({ person, selectedPanel, onClose }) {
                         <div className="tw-flex-1">Informations sociales</div>
                         <div>{!openPanels.includes('social') ? '+' : '-'}</div>
                       </div>
+
+                      <div className="[overflow-wrap:anywhere]">
                       {openPanels.includes('social') && (
                         <Row>
                           {customFieldsPersonsSocial
@@ -231,6 +233,7 @@ export default function EditModal({ person, selectedPanel, onClose }) {
                             ))}
                         </Row>
                       )}
+                      </div>
                     </div>
                   )}
                   {!['restricted-access'].includes(user.role) && (
@@ -247,6 +250,7 @@ export default function EditModal({ person, selectedPanel, onClose }) {
                         <div className="tw-flex-1">Informations médicales</div>
                         <div>{!openPanels.includes('medical') ? '+' : '-'}</div>
                       </div>
+                      <div className="[overflow-wrap:anywhere]">
                       {openPanels.includes('medical') && (
                         <Row>
                           {customFieldsPersonsMedical
@@ -256,6 +260,7 @@ export default function EditModal({ person, selectedPanel, onClose }) {
                             ))}
                         </Row>
                       )}
+                      </div>
                     </div>
                   )}
                 </div>

--- a/dashboard/src/scenes/person/components/InfosMedicales.js
+++ b/dashboard/src/scenes/person/components/InfosMedicales.js
@@ -41,7 +41,7 @@ export default function InfosMedicales({ person }) {
 
 function InfoMedicaleLine({ label, value, type = 'text' }) {
   return (
-    <div className="my-2">
+    <div className="my-2 [overflow-wrap:anywhere]">
       <div className="tw-text-sm tw-font-semibold tw-text-gray-600">{label}</div>
       <div>
         <CustomFieldDisplay type={type} value={value} />

--- a/dashboard/src/scenes/person/components/InfosSociales.js
+++ b/dashboard/src/scenes/person/components/InfosSociales.js
@@ -42,7 +42,7 @@ export default function InfosSociales({ person }) {
 
 function InfoSocialeLine({ label, value, type = 'text' }) {
   return (
-    <div className="my-2">
+    <div className="my-2 [overflow-wrap:anywhere]">
       <div className="tw-text-sm tw-font-semibold tw-text-gray-600">{label}</div>
       <div>
         <CustomFieldDisplay type={type} value={value} />


### PR DESCRIPTION
Modale d'edition des champs dans la fiche de la personne (titre de champs trop long): 

![Capture d’écran 2023-02-13 à 18 06 22](https://user-images.githubusercontent.com/39462001/218702698-0699e880-809f-4030-949e-b0469677a369.png)

description dans la fiche d'un personne avec un mot trop long 

![Capture d’écran 2023-02-14 à 11 02 19](https://user-images.githubusercontent.com/39462001/218703217-681d0285-36f3-4e4d-812f-21fea202401e.png)

titre ou champs de texte avec mot trop long sur la fiche d'une personne :

![Capture d’écran 2023-02-14 à 16 08 01](https://user-images.githubusercontent.com/39462001/218777730-04100934-8d34-4d9a-a6af-f7e233ee2f0f.png)

Il y a aussi un soucis sur la page de l'orga au niveau de la configuration des champs. J'ai fait une autre carte trello, dans une autre PR car y'a d'autres trucs de CSS a modifier 


