### PR TITLE
fix(app): chargement plus rapide de la liste de personnes

### DIFF
--- a/app/src/recoil/selectors.js
+++ b/app/src/recoil/selectors.js
@@ -87,6 +87,8 @@ export const itemsGroupedByPersonSelector = selector({
     for (const person of persons) {
       personsObject[person._id] = { ...person };
     }
+    const now = Date.now();
+    console.log('here');
     const actions = Object.values(get(actionsWithCommentsSelector));
     const comments = get(commentsState);
     const consultations = get(consultationsState);


### PR DESCRIPTION
l'idée: ne charger le super sélecteur que quand on en a besoin
sur ma machine de guerre, avec le super sélecteur ça met 500ms à charger initialement
sans ça met moitié moins de temps... pas gégé mais sur des machine moins bien c'est peut-être plus efficace