### PR TITLE
fix(dashboard): ajout des headers de sécurité (CSP et autres)

### DIFF
--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -20,6 +20,13 @@ app-api:
 app-dashboard:
   host: "dashboard-mano.fabrique.social.gouv.fr"
   certSecretName: dashboard-crt
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        more_set_headers "Content-Security-Policy: default-src 'none'; connect-src 'self' https://*.gouv.fr data:; font-src 'self'; img-src 'self' data:; prefetch-src 'self' https://*.gouv.fr; script-src 'self' https://*.gouv.fr; frame-src 'self' https://*.gouv.fr; style-src 'self' 'unsafe-inline'";
+        more_set_headers "X-Frame-Options: deny";
+        more_set_headers "X-XSS-Protection: 1; mode=block";
+        more_set_headers "X-Content-Type-Options: nosniff";
 
 metabase:
   enabled: true

--- a/.kube-workflow/prod/values.yaml
+++ b/.kube-workflow/prod/values.yaml
@@ -1,6 +1,13 @@
 app-www:
   host: "mano-app.fabrique.social.gouv.fr"
   certSecretName: www-crt
+  ingress:
+    annotations:
+      nginx.ingress.kubernetes.io/configuration-snippet: |
+        more_set_headers "Content-Security-Policy: default-src 'none'; connect-src 'self' https://*.gouv.fr; font-src 'self'; img-src 'self'; prefetch-src 'self' https://*.gouv.fr; script-src 'self' https://*.gouv.fr; frame-src 'self' https://*.gouv.fr; style-src 'self' 'unsafe-inline'";
+        more_set_headers "X-Frame-Options: deny";
+        more_set_headers "X-XSS-Protection: 1; mode=block";
+        more_set_headers "X-Content-Type-Options: nosniff";
 
 app-api:
   host: "mano.fabrique.social.gouv.fr"

--- a/website/pages/_app.js
+++ b/website/pages/_app.js
@@ -16,7 +16,7 @@ class MyApp extends App {
     return (
       <>
         <Head>
-          <meta key='viewport' name='viewport' content='width=device-width, initial-scale=1' />
+          <meta key="viewport" name="viewport" content="width=device-width, initial-scale=1" />
         </Head>
         <Component {...pageProps} />
       </>


### PR DESCRIPTION
Message de Julien Bouquillon
 
> Hello  :slightly_smiling_face:
> 
> On aimerait améliorer les headers de sécurité HTTP sur les applications web de la Fabrique 
> 
>  Nous demandons à chaque équipe de bien vouloir :
> 
> - vérifier les headers HTTP de son frontend sur [Mozilla HTTP Observatory](https://observatory.mozilla.org/) ou [DashLord](https://dashlord-full.fabrique.social.gouv.fr/)
> 
> - faire le point sur les éventuels iframes/sites/urls externes utilisés dans vos frontends pour définir une [content-security-policy](https://developer.mozilla.org/en-US/docs/Web/HTTP/CSP) adaptée
> 
> - ajouter les headers manquants sur son ingress ou son application, [petit tuto ici](https://socialgouv.github.io/support/docs/standards/securite#mettre-%C3%A0-jour-les-headers-http-de-mes-applications).
> 
> Si vous n'avez pas de scripts, fonts, appels externes, alors vous pouvez appliquer une CSP standard;
> 
> A votre dispo si besoin d'infos ou coup de main pour tests/PRs

https://observatory.mozilla.org/analyze/dashboard-mano.fabrique.social.gouv.fr

https://socialgouv.github.io/support/docs/standards/securite/#mettre-à-jour-les-headers-http-de-mes-applications