### PR TITLE
fix(app, dashboard): mise-à-jour du ou au plus près de la requête du nombre d'éléments à mettre à jour

### DIFF
--- a/app/src/components/Loader.js
+++ b/app/src/components/Loader.js
@@ -107,6 +107,7 @@ export const DataLoader = () => {
     /*
     Get number of data to download to show the appropriate loading progress bar
     */
+    const justChecked = Date.now();
     const response = await API.get({
       path: '/organisation/stats',
       query: { organisation: organisationId, after: lastRefresh, withDeleted: true },
@@ -380,7 +381,7 @@ export const DataLoader = () => {
     */
     initialLoadDone.current = true;
     await new Promise((res) => setTimeout(res, 150));
-    setLastRefresh(Date.now());
+    setLastRefresh(justChecked);
     setLoading('');
     setProgress(0);
     setFullScreen(false);

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import styled from 'styled-components';
 import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'react-toastify';
@@ -88,6 +88,8 @@ export default function DataLoader() {
 
   const organisationId = organisation?._id;
 
+  const justChecked = useRef(null);
+
   // Loader initialization: get data from cache, check stats, init recoils states, and start loader.
   function initLoader() {
     if (loadList.list.length > 0) return;
@@ -121,6 +123,7 @@ export default function DataLoader() {
               withAllMedicalData: initialLoad,
             },
           }).then(({ data: stats }) => {
+            justChecked.current = Date.now();
             if (!stats) return;
             const newList = [];
             let itemsCount =
@@ -371,7 +374,7 @@ export default function DataLoader() {
 
   function stopLoader() {
     setIsLoading(false);
-    setLastLoad(Date.now());
+    setLastLoad(justChecked.current);
     setProgressBuffer(null);
     setProgress(null);
     setTotal(null);


### PR DESCRIPTION
le loading des données est ainsi fait:

- T0: on check combien d’items ont changé depuis le lastLoadValue
- T0: si il y a des items à fetcher, on les fetch - ça prend X secondes (entre 1 seconde et 10 minutes en fonction du nombre d'éléments à aller fetcher) dans l’ordre suivant:
  - personnes
  - actions
  - consultations
  - …
  - rencontres
  - …
  - commentaires
- T0 + X: on set lastLoadValue = Date.now()

Exemple problématique:

- T0: Il y a 10 commentaires à fetcher
- T0: Ce fetch dure 15 secondes, parce qu’on passe sous un tunnel et que la connection est très très lente
- T0+7: indépendamment de ce process, une rencontre est créée par ailleurs, sur un autre appareil
- T0+15: le fetch de 15 secondes fini, on set lastLoadValue = Date.now()

Conséquence: la rencontre créée à T+7 n’apparaitre jamais dans le cache de l’utilisateur.
