### PR TITLE
fix(dashboard): Action le premier jour de la semaine qui ne s'affichait pas sur l'agenda hebdo

### DIFF
--- a/dashboard/src/components/ActionsWeekly.js
+++ b/dashboard/src/components/ActionsWeekly.js
@@ -21,7 +21,9 @@ export default function ActionsWeekly({ actions, onCreateAction }) {
     return actions.filter((action) =>
       dayjsInstance([DONE, CANCEL].includes(action.status) ? action.completedAt : action.dueAt).isBetween(
         dayjsInstance(startOfWeek),
-        dayjsInstance(startOfWeek).add(7, 'day').endOf('day')
+        dayjsInstance(startOfWeek).add(7, 'day').endOf('day'),
+        null,
+        '[)'
       )
     );
   }, [actions, startOfWeek]);


### PR DESCRIPTION
Les actions sans heure et sur le premier jour de la semaine, ne s'affichait pas sur l'agenda hebdomadaire. 

cf carte trello : https://trello.com/c/jDj1U714 pour reproduire le bug. 

