### PR TITLE
fix(app): reset du cache quand on change d'organisation

### DIFF
--- a/app/src/Navigators.js
+++ b/app/src/Navigators.js
@@ -58,6 +58,7 @@ import Consultation from './scenes/Persons/Consultation';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { currentTeamState, organisationState, teamsState, userState } from './recoil/auth';
 import { appCurrentCacheKey, clearCache } from './services/dataManagement';
+import useResetAllCachedDataRecoilStates from './recoil/reset';
 
 const ActionsStack = createStackNavigator();
 const ActionsNavigator = () => {
@@ -280,6 +281,7 @@ const App = () => {
   const appStateListener = useRef(null);
   const navigationRef = useNavigationContainerRef();
 
+  const resetAllRecoilStates = useResetAllCachedDataRecoilStates();
   const [isLoggedIn, setIsLoggedIn] = useState(false);
   const resetOrganisation = useResetRecoilState(organisationState);
   const resetUser = useResetRecoilState(userState);
@@ -325,6 +327,7 @@ const App = () => {
     API.organisation = null;
     if (clearAllRef.current) {
       await clearCache();
+      resetAllRecoilStates();
       setLastRefresh(0);
     }
     InteractionManager.runAfterInteractions(async () => {

--- a/app/src/recoil/reset.js
+++ b/app/src/recoil/reset.js
@@ -1,0 +1,43 @@
+import { useSetRecoilState } from 'recoil';
+import { personsState } from './persons';
+import { territoryObservationsState } from './territoryObservations';
+import { territoriesState } from './territory';
+import { passagesState } from './passages';
+import { rencontresState } from './rencontres';
+import { commentsState } from './comments';
+import { placesState } from './places';
+import { actionsState } from './actions';
+import { reportsState } from './reports';
+import { groupsState } from './groups';
+import { relsPersonPlaceState } from './relPersonPlace';
+
+const usesetAllCachedDataRecoilStates = () => {
+  const setPersons = useSetRecoilState(personsState);
+  const setActions = useSetRecoilState(actionsState);
+  const setPlaces = useSetRecoilState(placesState);
+  const setComments = useSetRecoilState(commentsState);
+  const setPassages = useSetRecoilState(passagesState);
+  const setRencontres = useSetRecoilState(rencontresState);
+  const setTerritories = useSetRecoilState(territoriesState);
+  const setObservations = useSetRecoilState(territoryObservationsState);
+  const setReports = useSetRecoilState(reportsState);
+  const setGroups = useSetRecoilState(groupsState);
+  const setRelPersonPlaces = useSetRecoilState(relsPersonPlaceState);
+
+  const setAll = () => {
+    setPersons([]);
+    setActions([]);
+    setPlaces([]);
+    setComments([]);
+    setPassages([]);
+    setRencontres([]);
+    setTerritories([]);
+    setObservations([]);
+    setReports([]);
+    setGroups([]);
+    setRelPersonPlaces([]);
+  };
+  return setAll;
+};
+
+export default usesetAllCachedDataRecoilStates;

--- a/app/src/scenes/Login/Login.js
+++ b/app/src/scenes/Login/Login.js
@@ -21,6 +21,7 @@ import { currentTeamState, organisationState, teamsState, usersState, userState 
 import { clearCache, appCurrentCacheKey } from '../../services/dataManagement';
 import { refreshTriggerState } from '../../components/Loader';
 import { useIsFocused } from '@react-navigation/native';
+import useResetAllCachedDataRecoilStates from '../../recoil/reset';
 
 const Login = ({ navigation }) => {
   const [authViaCookie, setAuthViaCookie] = useState(false);
@@ -42,6 +43,7 @@ const Login = ({ navigation }) => {
   const setCurrentTeam = useSetRecoilState(currentTeamState);
   const [storageOrganisationId, setStorageOrganisationId] = useMMKVString('organisationId');
   const setRefreshTrigger = useSetRecoilState(refreshTriggerState);
+  const resetAllRecoilStates = useResetAllCachedDataRecoilStates();
 
   const isFocused = useIsFocused();
 
@@ -76,7 +78,8 @@ const Login = ({ navigation }) => {
         API.onLogIn();
         const { organisation } = user;
         if (!!storageOrganisationId && organisation._id !== storageOrganisationId) {
-          clearCache('not same org');
+          await clearCache('not same org');
+          resetAllRecoilStates();
           setLastRefresh(0);
         }
         setStorageOrganisationId(organisation._id);
@@ -180,7 +183,8 @@ const Login = ({ navigation }) => {
       setOrganisation(response.user.organisation);
       // We need to reset cache if organisation has changed.
       if (!!storageOrganisationId && response.user.organisation._id !== storageOrganisationId) {
-        clearCache('again not same org');
+        await clearCache('again not same org');
+        resetAllRecoilStates();
         setLastRefresh(0);
       }
       setStorageOrganisationId(response.user.organisation._id);


### PR DESCRIPTION
bug actuel: quand on change d'organisation, on "additionne" les données des organisations au lieu de les remplacer, parce que on fait bien le clear du cache MMKV mais les states Recoil sont déjà initialisés et on ne les reset pas...

bug présent depuis https://github.com/SocialGouv/mano/commit/e1420a4dc9585818f0e5583d2b052f9f063c0298