### PR TITLE
fix: suppression du bruit dans sentry quand un rapport a failli être créé en double mano-ee

### DIFF
--- a/api/src/models/report.js
+++ b/api/src/models/report.js
@@ -20,6 +20,18 @@ module.exports = (sequelize, DataTypes) => {
     }
   }
 
-  Report.init(schema, { sequelize, modelName: "Report", freezeTableName: true, timestamps: true, paranoid: true });
+  Report.init(schema, {
+    sequelize,
+    modelName: "Report",
+    freezeTableName: true,
+    timestamps: true,
+    paranoid: true,
+    indexes: [
+      {
+        unique: true,
+        fields: ["organisation", "team", "date"],
+      },
+    ],
+  });
   return Report;
 };


### PR DESCRIPTION
See: https://sentry.fabrique.social.gouv.fr/organizations/incubateur/issues/96541/?project=52&query=is%3Aunresolved

Sequelize doit être mis au courant que la contrainte existe sinon il ne s'en rend pas compte on dirait