### PR TITLE
fix(dashboard): si les passages sont déjà mis à jour côté front mais que le rapport n'est pas encore créé, il faut empêcher de modifier les passages pour ne pas envoyer sur un rapport inexistant

### DIFF
--- a/dashboard/src/scenes/reception/view.js
+++ b/dashboard/src/scenes/reception/view.js
@@ -294,7 +294,7 @@ const Reception = () => {
               {passages.length} passage{passages.length > 1 ? 's' : ''}
             </h5>
             <ButtonCustom onClick={onAddAnonymousPassage} color="primary" icon={plusIcon} title="Passage anonyme" id="add-anonymous-passage" />
-            {!!passages.length && (
+            {!!passages.length && reportCreatedRef.current && (
               <div style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem' }}>
                 <ButtonCustom
                   onClick={() => history.push(`/report/${todaysReport?.date}?tab=passages`)}


### PR DESCRIPTION
See: https://sentry.fabrique.social.gouv.fr/share/issue/3f60e9d7cfd84bcd883d2a4206a0bb62/