### PR TITLE
fix(dashboard): date d'interaction dans le futur

### DIFF
--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -15,6 +15,8 @@ import { treatmentsState } from './treatments';
 import { rencontresState } from './rencontres';
 import { groupsState } from './groups';
 
+const today = new Date().toISOString();
+
 const usersObjectSelector = selector({
   key: 'usersObjectSelector',
   get: ({ get }) => {
@@ -247,9 +249,13 @@ export const itemsGroupedByPersonSelector = selector({
         // If we do not filter them, when comparing for date periods in stats, we would have to check for undefined,
         // otherwise we would have a bug that consider everybody "person suivies" in every period.
       ].filter((i) => Boolean(i));
-      personsObject[personId].lastUpdateCheckForGDPR = personsObject[personId].interactions[0];
-    }
 
+      let i = 0;
+      while (i < personsObject[personId].interactions.length && personsObject[personId].interactions[i].slice(0, 10) > today.slice(0, 10)) {
+        i++;
+      }
+      personsObject[personId].lastUpdateCheckForGDPR = personsObject[personId].interactions[i];
+    }
     return personsObject;
   },
 });


### PR DESCRIPTION
Certaines dates d'interactions étaient dans le futur, à cause des attributs dueAt qui sont stockés dans le tableau des interactions. 

J'ai préféré itérer sur le tableau des interactions afin d'ignorer les dates qui était dans le future lors de la mise à jour de la variable LastUpdateCehckForGDPR. Comme ça ces dates restent dans le tableau mais ne s'affichent que lorsque la date du jour est plus ancienne. 
Je ne suis pas sure que slice () soit la meilleur solution pour eviter la comparaison des heures mais si vous avez une autre soluce alors cool !! 

Il y a un autre soucis mais à voir plus tard, si je créais un commentaire (exemple mais cela le fait pour tout), la date de dernière intération change mais si je le supprime, elle revient a l'ancienne date d'interaction. Il n'y a donc plus trace de cette interaction. d'après ce que j'ai compris, Guillaume voulait que la date d'intéraction représente n'importe quel modifications sur le dossier, la suppression devrait en faire partie ? J'attends vos retours merci.