### PR TITLE
fix: retirer la ligne Total des champs multi-choix

### DIFF
--- a/dashboard/src/scenes/stats/Actions.js
+++ b/dashboard/src/scenes/stats/Actions.js
@@ -1,8 +1,8 @@
 import React, { useMemo, useState } from 'react';
-import { CustomResponsivePie } from './charts';
+import { CustomResponsiveBar, CustomResponsivePie } from './charts';
 import { mappedIdsToLabels } from '../../recoil/actions';
 import SelectCustom from '../../components/SelectCustom';
-import { getPieData } from './utils';
+import { getMultichoiceBarData, getPieData } from './utils';
 import { ModalBody, ModalContainer, ModalFooter, ModalHeader } from '../../components/tailwind/Modal';
 import ActionsSortableList from '../../components/ActionsSortableList';
 
@@ -125,17 +125,18 @@ const ActionsStats = ({
           setGroupSlice(newGroupSlice);
         }}
       />
-      <CustomResponsivePie
+      <CustomResponsiveBar
         title="Répartition des actions par catégorie"
         help={`Si une action a plusieurs catégories, elle est comptabilisée dans chaque catégorie.\n\nAinsi, le total affiché peut être supérieur au nombre total d'actions.`}
-        originalDatasetLength={originalDatasetLength}
-        data={getPieData(actionsWithDetailedGroupAndCategories, 'category', { isMultiChoice: true, options: allCategories })}
-        isMultiChoice
-        field="category"
         onItemClick={(newCategorySlice) => {
           setActionsModalOpened(true);
           setCategorySlice(newCategorySlice);
         }}
+        isMultiChoice
+        originalDatasetLength={originalDatasetLength}
+        axisTitleY="Actions"
+        axisTitleX="Catégorie"
+        data={getMultichoiceBarData(actionsWithDetailedGroupAndCategories, 'category')}
       />
       <SelectedActionsModal
         open={actionsModalOpened}

--- a/dashboard/src/scenes/stats/Actions.js
+++ b/dashboard/src/scenes/stats/Actions.js
@@ -7,6 +7,7 @@ import { ModalBody, ModalContainer, ModalFooter, ModalHeader } from '../../compo
 import ActionsSortableList from '../../components/ActionsSortableList';
 
 const ActionsStats = ({
+  originalDatasetLength,
   setActionsStatuses,
   actionsStatuses,
   setActionsCategories,
@@ -127,7 +128,9 @@ const ActionsStats = ({
       <CustomResponsivePie
         title="Répartition des actions par catégorie"
         help={`Si une action a plusieurs catégories, elle est comptabilisée dans chaque catégorie.\n\nAinsi, le total affiché peut être supérieur au nombre total d'actions.`}
-        data={getPieData(actionsWithDetailedGroupAndCategories, 'category', { options: allCategories })}
+        originalDatasetLength={originalDatasetLength}
+        data={getPieData(actionsWithDetailedGroupAndCategories, 'category', { isMultiChoice: true, options: allCategories })}
+        isMultiChoice
         field="category"
         onItemClick={(newCategorySlice) => {
           setActionsModalOpened(true);

--- a/dashboard/src/scenes/stats/Actions.js
+++ b/dashboard/src/scenes/stats/Actions.js
@@ -7,7 +7,6 @@ import { ModalBody, ModalContainer, ModalFooter, ModalHeader } from '../../compo
 import ActionsSortableList from '../../components/ActionsSortableList';
 
 const ActionsStats = ({
-  originalDatasetLength,
   setActionsStatuses,
   actionsStatuses,
   setActionsCategories,
@@ -133,7 +132,6 @@ const ActionsStats = ({
           setCategorySlice(newCategorySlice);
         }}
         isMultiChoice
-        originalDatasetLength={originalDatasetLength}
         axisTitleY="Actions"
         axisTitleX="Catégorie"
         data={getMultichoiceBarData(actionsWithDetailedGroupAndCategories, 'category')}

--- a/dashboard/src/scenes/stats/CustomFieldsStats.js
+++ b/dashboard/src/scenes/stats/CustomFieldsStats.js
@@ -61,10 +61,8 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
           help={help?.(field.label.capitalize())}
           onItemClick={onSliceClick ? (newSlice) => onSliceClick?.(newSlice, field.name) : undefined}
           key={field.name}
-          isMultiChoice={field.type === 'multi-choice'}
           originalDatasetLength={data.length}
           data={getPieData(data, field.name, {
-            isMultiChoice: field.type === 'multi-choice',
             options: field.options,
             isBoolean: field.type === 'boolean',
           })}

--- a/dashboard/src/scenes/stats/CustomFieldsStats.js
+++ b/dashboard/src/scenes/stats/CustomFieldsStats.js
@@ -60,7 +60,13 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
           help={help?.(field.label.capitalize())}
           onItemClick={onSliceClick ? (newSlice) => onSliceClick?.(newSlice, field.name) : undefined}
           key={field.name}
-          data={getPieData(data, field.name, { options: field.options, isBoolean: field.type === 'boolean' })}
+          isMultiChoice={field.type === 'multi-choice'}
+          originalDatasetLength={data.length}
+          data={getPieData(data, field.name, {
+            isMultiChoice: field.type === 'multi-choice',
+            options: field.options,
+            isBoolean: field.type === 'boolean',
+          })}
         />
       ))}
     </>

--- a/dashboard/src/scenes/stats/CustomFieldsStats.js
+++ b/dashboard/src/scenes/stats/CustomFieldsStats.js
@@ -61,7 +61,6 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
           help={help?.(field.label.capitalize())}
           onItemClick={onSliceClick ? (newSlice) => onSliceClick?.(newSlice, field.name) : undefined}
           key={field.name}
-          originalDatasetLength={data.length}
           data={getPieData(data, field.name, {
             options: field.options,
             isBoolean: field.type === 'boolean',
@@ -76,7 +75,6 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
             onItemClick={onSliceClick ? (newSlice) => onSliceClick?.(newSlice, field.name) : undefined}
             key={field.name}
             isMultiChoice
-            originalDatasetLength={data.length}
             axisTitleY="File active"
             axisTitleX={field.name}
             data={getMultichoiceBarData(data, field.name, { options: field.options })}

--- a/dashboard/src/scenes/stats/CustomFieldsStats.js
+++ b/dashboard/src/scenes/stats/CustomFieldsStats.js
@@ -1,9 +1,9 @@
 import { useRecoilValue } from 'recoil';
 import { currentTeamState } from '../../recoil/auth';
-import { CustomResponsivePie } from './charts';
+import { CustomResponsiveBar, CustomResponsivePie } from './charts';
 import { BlockDateWithTime, BlockTotal } from './Blocks';
 import Card from '../../components/Card';
-import { getPieData } from './utils';
+import { getMultichoiceBarData, getPieData } from './utils';
 
 function getColsSize(totalCols) {
   if (totalCols === 1) return 'full';
@@ -22,7 +22,8 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
 
   const customFieldsNumber = customFieldsInStats.filter((field) => ['number'].includes(field.type));
   const customFieldsDate = customFieldsInStats.filter((field) => ['date', 'date-with-time'].includes(field.type));
-  const customFieldsResponsivePie = customFieldsInStats.filter((field) => ['boolean', 'yes-no', 'enum', 'multi-choice'].includes(field.type));
+  const customFieldsResponsivePie = customFieldsInStats.filter((field) => ['boolean', 'yes-no', 'enum'].includes(field.type));
+  const customFieldsResponsiveBar = customFieldsInStats.filter((field) => ['multi-choice'].includes(field.type));
 
   const totalCols = customFieldsNumber.length + customFieldsDate.length + additionalCols.length;
 
@@ -69,6 +70,21 @@ const CustomFieldsStats = ({ customFields, data, additionalCols = [], dataTestId
           })}
         />
       ))}
+      {customFieldsResponsiveBar.map((field) => {
+        return (
+          <CustomResponsiveBar
+            title={field.label}
+            help={help?.(field.label.capitalize())}
+            onItemClick={onSliceClick ? (newSlice) => onSliceClick?.(newSlice, field.name) : undefined}
+            key={field.name}
+            isMultiChoice
+            originalDatasetLength={data.length}
+            axisTitleY="File active"
+            axisTitleX={field.name}
+            data={getMultichoiceBarData(data, field.name, { options: field.options })}
+          />
+        );
+      })}
     </>
   );
 };

--- a/dashboard/src/scenes/stats/Persons.js
+++ b/dashboard/src/scenes/stats/Persons.js
@@ -124,9 +124,12 @@ const PersonStats = ({
             personsForStats.filter((p) => !!p.outOfActiveList)
           );
         }}
+        isMultiChoice
+        originalDatasetLength={personsForStats.filter((p) => !!p.outOfActiveList).length}
         data={getPieData(
           personsForStats.filter((p) => !!p.outOfActiveList),
-          'outOfActiveListReasons'
+          'outOfActiveListReasons',
+          { isMultiChoice: true }
         )}
       />
       <CustomFieldsStats

--- a/dashboard/src/scenes/stats/Persons.js
+++ b/dashboard/src/scenes/stats/Persons.js
@@ -5,7 +5,7 @@ import { utils, writeFile } from 'xlsx';
 import { useLocalStorage } from '../../services/useLocalStorage';
 import { CustomResponsiveBar, CustomResponsivePie } from './charts';
 import Filters, { filterData } from '../../components/Filters';
-import { getDuration, getPieData } from './utils';
+import { getDuration, getMultichoiceBarData, getPieData } from './utils';
 import Card from '../../components/Card';
 import { capture } from '../../services/sentry';
 import { Block } from './Blocks';
@@ -113,9 +113,8 @@ const PersonStats = ({
         data={getPieData(personsForStats, 'outOfActiveList', { isBoolean: true })}
         help={`${title} dans la période définie, sorties de la file active. La date de sortie de la file active n'est pas nécessairement dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des personnes.`}
       />
-      <CustomResponsivePie
+      <CustomResponsiveBar
         title="Raison de sortie de file active"
-        field="outOfActiveListReasons"
         help={`Raisons de sortie de file active des ${title} dans la période définie, sorties de la file active. La date de sortie de la file active n'est pas nécessairement dans la période définie.\n\nSi aucune période n'est définie, on considère l'ensemble des personnes.`}
         onItemClick={(newSlice) => {
           onSliceClick(
@@ -126,10 +125,11 @@ const PersonStats = ({
         }}
         isMultiChoice
         originalDatasetLength={personsForStats.filter((p) => !!p.outOfActiveList).length}
-        data={getPieData(
+        axisTitleY="File active"
+        axisTitleX="Raison de sortie de file active"
+        data={getMultichoiceBarData(
           personsForStats.filter((p) => !!p.outOfActiveList),
-          'outOfActiveListReasons',
-          { isMultiChoice: true }
+          'outOfActiveListReasons'
         )}
       />
       <CustomFieldsStats
@@ -288,6 +288,8 @@ export const AgeRangeBar = ({ persons, onItemClick }) => {
   const dataCount = Object.keys(data)
     .filter((key) => data[key]?.length > 0)
     .map((key) => ({ name: key, [key]: data[key]?.length }));
+
+  console.log('dataCount', dataCount);
 
   return (
     <CustomResponsiveBar

--- a/dashboard/src/scenes/stats/Persons.js
+++ b/dashboard/src/scenes/stats/Persons.js
@@ -124,7 +124,6 @@ const PersonStats = ({
           );
         }}
         isMultiChoice
-        originalDatasetLength={personsForStats.filter((p) => !!p.outOfActiveList).length}
         axisTitleY="File active"
         axisTitleX="Raison de sortie de file active"
         data={getMultichoiceBarData(

--- a/dashboard/src/scenes/stats/Persons.js
+++ b/dashboard/src/scenes/stats/Persons.js
@@ -288,8 +288,6 @@ export const AgeRangeBar = ({ persons, onItemClick }) => {
     .filter((key) => data[key]?.length > 0)
     .map((key) => ({ name: key, [key]: data[key]?.length }));
 
-  console.log('dataCount', dataCount);
-
   return (
     <CustomResponsiveBar
       title="Tranche d'âges"

--- a/dashboard/src/scenes/stats/charts.js
+++ b/dashboard/src/scenes/stats/charts.js
@@ -3,8 +3,8 @@ import { ResponsivePie } from '@nivo/pie';
 import { ResponsiveBar } from '@nivo/bar';
 import HelpButtonAndModal from '../../components/HelpButtonAndModal';
 
-export const CustomResponsivePie = ({ data = [], title, onItemClick, help }) => {
-  const total = data.reduce((sum, item) => sum + item.value, 0);
+export const CustomResponsivePie = ({ isMultiChoice, originalDatasetLength, data = [], title, onItemClick, help }) => {
+  const total = isMultiChoice ? originalDatasetLength : data.reduce((sum, item) => sum + item.value, 0);
 
   const onClick = ({ id }) => {
     if (!onItemClick) return;
@@ -37,18 +37,20 @@ export const CustomResponsivePie = ({ data = [], title, onItemClick, help }) => 
                   {total ? <td className="tw-border tw-border-zinc-400 tw-text-center">{`${Math.round((value / total) * 1000) / 10}%`}</td> : <></>}
                 </tr>
               ))}
-            <tr>
-              <td className="tw-border tw-border-zinc-400 tw-font-bold">Total</td>
-              <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">{total}</td>
-              {total ? <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">100%</td> : <></>}
-            </tr>
+            {!isMultiChoice && (
+              <tr>
+                <td className="tw-border tw-border-zinc-400 tw-font-bold">Total</td>
+                <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">{total}</td>
+                {total ? <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">100%</td> : <></>}
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
       <div
         className={[
           'tw-flex tw-h-80 tw-max-w-[50%] tw-basis-1/2 tw-items-center tw-justify-center tw-font-bold print:tw-w-[600px] print:tw-max-w-[55%] print:!tw-grow print:!tw-basis-0',
-          !!onItemClick ? '[&_path]:tw-cursor-pointer' : '',
+          onItemClick ? '[&_path]:tw-cursor-pointer' : '',
         ].join(' ')}>
         <ResponsivePie
           data={total ? data : []}

--- a/dashboard/src/scenes/stats/charts.js
+++ b/dashboard/src/scenes/stats/charts.js
@@ -3,8 +3,8 @@ import { ResponsivePie } from '@nivo/pie';
 import { ResponsiveBar } from '@nivo/bar';
 import HelpButtonAndModal from '../../components/HelpButtonAndModal';
 
-export const CustomResponsivePie = ({ isMultiChoice, originalDatasetLength, data = [], title, onItemClick, help }) => {
-  const total = isMultiChoice ? originalDatasetLength : data.reduce((sum, item) => sum + item.value, 0);
+export const CustomResponsivePie = ({ data = [], title, onItemClick, help }) => {
+  const total = data.reduce((sum, item) => sum + item.value, 0);
 
   const onClick = ({ id }) => {
     if (!onItemClick) return;
@@ -37,13 +37,11 @@ export const CustomResponsivePie = ({ isMultiChoice, originalDatasetLength, data
                   {total ? <td className="tw-border tw-border-zinc-400 tw-text-center">{`${Math.round((value / total) * 1000) / 10}%`}</td> : <></>}
                 </tr>
               ))}
-            {!isMultiChoice && (
-              <tr>
-                <td className="tw-border tw-border-zinc-400 tw-font-bold">Total</td>
-                <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">{total}</td>
-                {total ? <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">100%</td> : <></>}
-              </tr>
-            )}
+            <tr>
+              <td className="tw-border tw-border-zinc-400 tw-font-bold">Total</td>
+              <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">{total}</td>
+              {total ? <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">100%</td> : <></>}
+            </tr>
           </tbody>
         </table>
       </div>
@@ -79,11 +77,15 @@ export const CustomResponsivePie = ({ isMultiChoice, originalDatasetLength, data
 
 const getItemValue = (item) => Object.values(item)[1];
 
-export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axisTitleX, axisTitleY, help }) => {
-  const total = data.reduce((sum, item) => sum + getItemValue(item), 0);
+export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axisTitleX, axisTitleY, isMultiChoice, originalDatasetLength, help }) => {
+  if (!categories) {
+    categories = data.map((cat) => cat.name);
+  }
+  const total = isMultiChoice ? originalDatasetLength : data.reduce((sum, item) => sum + item.value, 0);
 
   const onClick = ({ id }) => {
     if (!onItemClick) return;
+    console.log('id', id);
     onItemClick(id);
   };
 
@@ -104,11 +106,13 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
                 <td className="tw-border tw-border-zinc-400 tw-p-1 tw-text-center">{`${Math.round((getItemValue(item) / total) * 1000) / 10}%`}</td>
               </tr>
             ))}
-            <tr>
-              <td className="tw-border tw-border-zinc-400 tw-p-1 tw-font-bold">Total</td>
-              <td className="tw-border tw-border-zinc-400 tw-p-1 tw-text-center tw-font-bold">{total}</td>
-              <td className="tw-border tw-border-zinc-400 tw-p-1 tw-text-center tw-font-bold">100%</td>
-            </tr>
+            {!isMultiChoice && (
+              <tr>
+                <td className="tw-border tw-border-zinc-400 tw-font-bold">Total</td>
+                <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">{total}</td>
+                {total ? <td className="tw-border tw-border-zinc-400 tw-text-center tw-font-bold">100%</td> : <></>}
+              </tr>
+            )}
           </tbody>
         </table>
       </div>
@@ -124,6 +128,7 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
           indexBy="name"
           margin={{ top: 40, right: 0, bottom: 50, left: 60 }}
           padding={0.3}
+          maxValue={originalDatasetLength}
           valueScale={{ type: 'linear' }}
           indexScale={{ type: 'band', round: true }}
           colors={{ scheme: 'set2' }}
@@ -133,10 +138,10 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
           axisBottom={{
             tickSize: 5,
             tickPadding: 5,
-            tickRotation: 0,
+            tickRotation: -15,
             legend: axisTitleX,
             legendPosition: 'middle',
-            legendOffset: 35,
+            legendOffset: 45,
           }}
           axisLeft={{
             tickSize: 5,

--- a/dashboard/src/scenes/stats/charts.js
+++ b/dashboard/src/scenes/stats/charts.js
@@ -78,8 +78,19 @@ export const CustomResponsivePie = ({ data = [], title, onItemClick, help }) => 
 const getItemValue = (item) => Object.values(item)[1];
 
 export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axisTitleX, axisTitleY, isMultiChoice, originalDatasetLength, help }) => {
+  // if we have too many categories with small data, we see nothing in the chart
+  // so we filter this way:
+  // - keep the first 15 categories whatever
+  // - keep the others only if they represent more than 1% of the total
+  const chartData = data
+    .filter((c) => c.name !== 'Non renseigné')
+    .filter((item, index) => {
+      if (index < 15) return true;
+      return item[item.name] / originalDatasetLength > 0.01;
+    });
+  const showWarning = chartData.length < data.filter((c) => c.name !== 'Non renseigné').length;
   if (!categories) {
-    categories = data.map((cat) => cat.name);
+    categories = chartData.map((cat) => cat.name);
   }
   const total = isMultiChoice ? originalDatasetLength : data.reduce((sum, item) => sum + item.value, 0);
 
@@ -118,15 +129,22 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
       </div>
       <div
         className={[
-          'tw-flex tw-h-80 tw-max-w-[50%] tw-basis-1/2 tw-items-center tw-justify-center tw-font-bold print:tw-w-[600px] print:tw-max-w-[60%] print:!tw-grow print:!tw-basis-0',
+          'tw-relative tw-flex tw-h-80 tw-max-w-[50%] tw-basis-1/2 tw-items-center tw-justify-center tw-font-bold print:tw-w-[600px] print:tw-max-w-[60%] print:!tw-grow print:!tw-basis-0',
           !!onItemClick ? '[&_rect]:tw-cursor-pointer' : '',
         ].join(' ')}>
+        {!!showWarning && (
+          <div className="tw-l-0 tw-r-0 tw-absolute tw-top-0 -tw-mt-5">
+            <p className="tw-m-0 tw-mx-auto tw-w-3/4 tw-text-center tw-text-xs tw-font-normal tw-text-gray-500">
+              On n'affiche sur le graphique que les 15 premières catégories, et les autres seulement si elles représentent plus de 1% des données.
+            </p>
+          </div>
+        )}
         <ResponsiveBar
-          data={data.filter((c) => c.name !== 'Non renseigné')}
-          keys={categories.filter((c) => c !== 'Non renseigné')}
+          data={chartData}
+          keys={categories}
           onClick={onClick}
           indexBy="name"
-          margin={{ top: 40, right: 0, bottom: 50, left: 60 }}
+          margin={{ top: 10, right: 0, bottom: 60, left: 60 }}
           padding={0.3}
           maxValue={originalDatasetLength}
           valueScale={{ type: 'linear' }}
@@ -136,12 +154,16 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
           axisTop={null}
           axisRight={null}
           axisBottom={{
-            tickSize: 5,
+            tickSize: 2,
             tickPadding: 5,
             tickRotation: -15,
             legend: axisTitleX,
             legendPosition: 'middle',
-            legendOffset: 45,
+            legendOffset: 50,
+            legendTextStyle: {
+              fontSize: 12,
+              fontWeight: 'normal',
+            },
           }}
           axisLeft={{
             tickSize: 5,
@@ -154,23 +176,6 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
           labelSkipWidth={0}
           labelSkipHeight={0}
           labelTextColor={{ from: 'color', modifiers: [['darker', 1.6]] }}
-          legends={[
-            {
-              dataFrom: 'keys',
-              anchor: 'bottom-right',
-              direction: 'column',
-              justify: false,
-              translateX: 120,
-              translateY: 0,
-              itemsSpacing: 2,
-              itemWidth: 100,
-              itemHeight: 20,
-              itemDirection: 'left-to-right',
-              itemOpacity: 0.85,
-              symbolSize: 20,
-              effects: [{ on: 'hover', style: { itemOpacity: 1 } }],
-            },
-          ]}
           animate={true}
           motionStiffness={90}
           motionDamping={15}

--- a/dashboard/src/scenes/stats/charts.js
+++ b/dashboard/src/scenes/stats/charts.js
@@ -89,7 +89,7 @@ export const CustomResponsiveBar = ({ title, data, categories, onItemClick, axis
   }
   // data is already
   const total = useMemo(() => {
-    if (!isMultiChoice) return data.reduce((sum, item) => sum + item.value, 0);
+    if (!isMultiChoice) return data.reduce((sum, item) => sum + getItemValue(item), 0);
     // if we have multiple choice, data is sorted already in getMultichoiceBarData
     const biggestItem = chartData[0]; // { name: 'A name', ['A name']: 123 }
     const biggestItemValue = biggestItem[biggestItem.name];

--- a/dashboard/src/scenes/stats/index.js
+++ b/dashboard/src/scenes/stats/index.js
@@ -500,6 +500,7 @@ const Stats = () => {
         {!!organisation.receptionEnabled && activeTab === 'Services' && <ServicesStats period={period} teamIds={selectedTeams.map((e) => e?._id)} />}
         {activeTab === 'Actions' && (
           <ActionsStats
+            originalDatasetLength={actionsFilteredByStatus.length}
             setActionsStatuses={setActionsStatuses}
             actionsStatuses={actionsStatuses}
             setActionsCategories={setActionsCategories}

--- a/dashboard/src/scenes/stats/index.js
+++ b/dashboard/src/scenes/stats/index.js
@@ -500,7 +500,6 @@ const Stats = () => {
         {!!organisation.receptionEnabled && activeTab === 'Services' && <ServicesStats period={period} teamIds={selectedTeams.map((e) => e?._id)} />}
         {activeTab === 'Actions' && (
           <ActionsStats
-            originalDatasetLength={actionsFilteredByStatus.length}
             setActionsStatuses={setActionsStatuses}
             actionsStatuses={actionsStatuses}
             setActionsCategories={setActionsCategories}

--- a/dashboard/src/scenes/stats/utils.js
+++ b/dashboard/src/scenes/stats/utils.js
@@ -90,3 +90,35 @@ export const getPieData = (source, key, { options = null, isBoolean = false, isM
     .map((key) => ({ id: key, label: key, value: data[key] }))
     .filter((d) => d.value > 0);
 };
+
+const initOptions = (options) => {
+  const objoptions = { 'Non renseigné': [] };
+  for (const cat of options) {
+    objoptions[cat] = [];
+  }
+  return objoptions;
+};
+
+export const getMultichoiceBarData = (source, key, { options = [], debug = false } = {}) => {
+  options = initOptions(options);
+
+  const reducedDataPerOption = source.reduce((newData, item) => {
+    if (!item[key] || !item[key].length) {
+      newData['Non renseigné'].push(item);
+      return newData;
+    }
+    const choices = typeof item[key] === 'string' ? item[key].split(',') : item[key];
+    for (const choice of choices) {
+      if (!newData[choice]) newData[choice] = [];
+      newData[choice].push(item);
+    }
+    return newData;
+  }, options);
+
+  const barData = Object.keys(reducedDataPerOption)
+    .filter((key) => reducedDataPerOption[key]?.length > 0)
+    .map((key) => ({ name: key, [key]: reducedDataPerOption[key]?.length }))
+    .sort((a, b) => (b[b.name] > a[a.name] ? 1 : -1));
+
+  return barData;
+};

--- a/dashboard/src/scenes/stats/utils.js
+++ b/dashboard/src/scenes/stats/utils.js
@@ -38,7 +38,7 @@ export const getDuration = (timestampFromNow) => {
   return [Math.round(inYears), 'années'];
 };
 
-export const getPieData = (source, key, { options = null, isBoolean = false, isMultiChoice = false, debug = false } = {}) => {
+export const getPieData = (source, key, { options = null, isBoolean = false, debug = false } = {}) => {
   const data = source.reduce(
     (newData, item) => {
       if (isBoolean) {
@@ -64,11 +64,6 @@ export const getPieData = (source, key, { options = null, isBoolean = false, isM
             if (!newData[unregisteredOption]) newData[unregisteredOption] = 0;
             newData[unregisteredOption]++;
           }
-        }
-        if (isMultiChoice && Array.isArray(item[key]) && item[key].length > 1) {
-          const selectedChoices = options.filter((o) => item[key].includes(o)).join(' + ');
-          if (!newData[selectedChoices]) newData[selectedChoices] = 0;
-          newData[selectedChoices]++;
         }
         return newData;
       }

--- a/dashboard/src/scenes/stats/utils.js
+++ b/dashboard/src/scenes/stats/utils.js
@@ -74,13 +74,6 @@ export const getPieData = (source, key, { options = null, isBoolean = false, deb
     { 'Non renseigné': 0, Oui: 0, Non: 0 }
   );
 
-  if (options && options.length) {
-    const keysWithValue = Object.keys(data);
-    return [...options.filter((o) => keysWithValue.includes(o)), ...keysWithValue.filter((k) => !options.includes(k))]
-      .map((key) => ({ id: key, label: key, value: data[key] }))
-      .filter((d) => d.value > 0);
-  }
-
   return Object.keys(data)
     .map((key) => ({ id: key, label: key, value: data[key] }))
     .filter((d) => d.value > 0);

--- a/dashboard/src/scenes/stats/utils.js
+++ b/dashboard/src/scenes/stats/utils.js
@@ -38,7 +38,7 @@ export const getDuration = (timestampFromNow) => {
   return [Math.round(inYears), 'années'];
 };
 
-export const getPieData = (source, key, { options = null, isBoolean = false, debug = false } = {}) => {
+export const getPieData = (source, key, { options = null, isBoolean = false, isMultiChoice = false, debug = false } = {}) => {
   const data = source.reduce(
     (newData, item) => {
       if (isBoolean) {

--- a/dashboard/src/scenes/stats/utils.js
+++ b/dashboard/src/scenes/stats/utils.js
@@ -65,6 +65,11 @@ export const getPieData = (source, key, { options = null, isBoolean = false, isM
             newData[unregisteredOption]++;
           }
         }
+        if (isMultiChoice && Array.isArray(item[key]) && item[key].length > 1) {
+          const selectedChoices = options.filter((o) => item[key].includes(o)).join(' + ');
+          if (!newData[selectedChoices]) newData[selectedChoices] = 0;
+          newData[selectedChoices]++;
+        }
         return newData;
       }
       if (!newData[item[key]]) newData[item[key]] = 0;
@@ -73,6 +78,14 @@ export const getPieData = (source, key, { options = null, isBoolean = false, isM
     },
     { 'Non renseigné': 0, Oui: 0, Non: 0 }
   );
+
+  if (options && options.length) {
+    const keysWithValue = Object.keys(data);
+    return [...options.filter((o) => keysWithValue.includes(o)), ...keysWithValue.filter((k) => !options.includes(k))]
+      .map((key) => ({ id: key, label: key, value: data[key] }))
+      .filter((d) => d.value > 0);
+  }
+
   return Object.keys(data)
     .map((key) => ({ id: key, label: key, value: data[key] }))
     .filter((d) => d.value > 0);


### PR DESCRIPTION
Dans cette PR qui concerne l'affichage des tableaux de stats pour les champs multi-choix
- on retire la ligne Total pour les champs multi-choix
- on affiche aussi les lignes qui combinent plusieurs multi-choix (exemple: si je consomme du crack et du cannabis, il y aura trois lignes: "crack", "cannabis" et "crack + cannabis"). Problème: on peut avoir plus de 200 lignes parfois, vu le nombre de combinaisons possibles... doit-on le laisser ?

TODO:
- fixer le click sur une ligne de combinaison de multi-choix, qui ne sélectionne plus les personnes concernées