### PR TITLE
fix: possibilité de rechiffrer des organisations avec beaucoup de données jusqu'à 1Go

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -55,10 +55,9 @@ app.use(versionCheck);
 // Pre middleware
 app.use(express.urlencoded({ extended: true }));
 app.use((req, res, next) => {
-  const limitedSize = req.path.startsWith("/encrypt") ? "1gb" : "50mb";
+  const limitedSize = req.path.startsWith("/encrypt") ? "350mb" : "50mb";
   express.json({ limit: limitedSize })(req, res, next);
 });
-app.use(express.json({ limit: "50mb" }));
 app.use(helmet());
 app.use(cookieParser());
 


### PR DESCRIPTION
https://trello.com/c/TUGFkdDS/1111-post-encrypt-payloadtoolargeerror-request-entity-too-large

Plusieurs possibilités:

- [x] mettre 1Go juste pour la route encrypt - parce que parait-il la bonne pratique est de mettre un limite plus basse pour ne pas overload le serveur
- [ ] mettre 1Go pour tous
- [ ] mettre plus que 1Go pour tous

À tester sur le serveur de prod j'imagine ? Si testable ?
