### PR TITLE
fix(dashboard): on affiche la stat d'un champ custo de consultation quel que soit la section à laquelle il appartient

### DIFF
--- a/dashboard/src/scenes/stats/Consultations.js
+++ b/dashboard/src/scenes/stats/Consultations.js
@@ -45,7 +45,7 @@ const ConsultationsStats = ({ consultations, personsWithConsultations, filterBas
           <div key={c.name}>
             <h4 className="tw-my-8 tw-mx-0 tw-text-xl tw-text-black75">Statistiques des consultations de type « {c.name} »</h4>
             <CustomFieldsStats
-              data={consultations.filter((d) => d.type === c.name)}
+              data={consultations}
               customFields={c.fields}
               help={(label) => `${label.capitalize()} des consultations réalisées dans la période définie.`}
               totalTitleForMultiChoice={<span className="tw-font-bold">Nombre de consultations concernées</span>}


### PR DESCRIPTION
- on crée un champ custo de consultation dans la section "Section 1"
- on crée une consultation de type "Section 1" et on renmplit ce champ custo
- on déplace le champ custo dans la section "Section 2" mais la consultation créée reste dans la section "Section 1"

Avant: dans les statistiques, le champ custo de cette consultation n'est pas pris en compte
Après: dans les statistiques, le champ custo de cette consultation est pris en compte
