### PR TITLE
fix(dashboard): nouveau DataLoader

### DIFF
--- a/api/src/controllers/organisation.js
+++ b/api/src/controllers/organisation.js
@@ -37,8 +37,6 @@ router.get(
   passport.authenticate("user", { session: false }),
   validateUser(["superadmin", "admin", "normal", "restricted-access"]),
   catchErrors(async (req, res, next) => {
-    const startLoadingDate = Date.now();
-
     try {
       z.object({
         organisation: z.string().regex(looseUuidRegex),
@@ -77,7 +75,7 @@ router.get(
     // Medical data is never saved in cache so we always have to download all at every page reload.
     // In other words "after" param is intentionnaly ignored for consultations, treatments and medical files.
     const medicalDataQuery =
-      withAllMedicalData !== "true" ? query : { where: { organisation: req.query.organisation }, paranoid: withDeleted === "true" };
+      withAllMedicalData !== "true" ? query : { where: { organisation: req.query.organisation }, paranoid: withDeleted === "true" ? false : true };
     const consultations = await Consultation.count(medicalDataQuery);
     const medicalFiles = await MedicalFile.count(medicalDataQuery);
     const treatments = await Treatment.count(medicalDataQuery);
@@ -85,20 +83,20 @@ router.get(
     return res.status(200).send({
       ok: true,
       data: {
-        actions,
-        consultations,
-        treatments,
-        comments,
-        passages,
-        rencontres,
-        medicalFiles,
         persons,
         groups,
+        reports,
+        passages,
+        rencontres,
+        actions,
+        territories,
         places,
         relsPersonPlace,
-        territories,
         territoryObservations,
-        reports,
+        comments,
+        consultations,
+        treatments,
+        medicalFiles,
       },
     });
   })

--- a/dashboard/src/app.js
+++ b/dashboard/src/app.js
@@ -195,8 +195,10 @@ export default function ContextedApp() {
   const [recoilKey, setRecoilKey] = useState(0);
   return (
     <RecoilRoot key={recoilKey}>
-      <RecoilNexus />
-      <App resetRecoil={() => setRecoilKey((k) => k + 1)} />
+      <React.Suspense fallback={<div>CHAAARGEMENT</div>}>
+        <RecoilNexus />
+        <App resetRecoil={() => setRecoilKey((k) => k + 1)} />
+      </React.Suspense>
     </RecoilRoot>
   );
 }

--- a/dashboard/src/app.js
+++ b/dashboard/src/app.js
@@ -195,7 +195,7 @@ export default function ContextedApp() {
   const [recoilKey, setRecoilKey] = useState(0);
   return (
     <RecoilRoot key={recoilKey}>
-      <React.Suspense fallback={<div>CHAAARGEMENT</div>}>
+      <React.Suspense fallback={<div></div>}>
         <RecoilNexus />
         <App resetRecoil={() => setRecoilKey((k) => k + 1)} />
       </React.Suspense>

--- a/dashboard/src/components/ActionModal.js
+++ b/dashboard/src/components/ActionModal.js
@@ -612,7 +612,9 @@ function ActionContent({ onClose, action, personId = null, personIds = null, isM
                 .filter(Boolean)
                 .join(' ')}>
               <CommentsModule
-                comments={action?.comments.map((comment) => ({ ...comment, type: 'action', person: action.person }))}
+                comments={action?.comments
+                  .map((comment) => ({ ...comment, type: 'action', person: action.person }))
+                  .sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt))}
                 color="main"
                 canToggleUrgentCheck
                 typeForNewComment="action"

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -131,9 +131,6 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     const organisationId = latestOrganisation._id;
     setOrganisation(latestOrganisation);
     setUser(latestUser);
-    // Get date from server at the very beginning of the loader.
-    const serverDateResponse = await API.get({ path: '/now' });
-    const serverDate = serverDateResponse.data;
     if (initialLoad) {
       await migrateData();
     }
@@ -150,6 +147,11 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     });
 
     if (!statsResponse.ok) return false;
+
+    // Get date from server at the very beginning of the loader.
+    const serverDateResponse = await API.get({ path: '/now' });
+    const serverDate = serverDateResponse.data;
+
     const stats = statsResponse.data;
     let itemsCount =
       0 +

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -141,7 +141,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   */
   async function loadOrRefreshData(isStartingInitialLoad) {
     setIsLoading(true);
-    setFullScreen(isStartingInitialLoad ? true : false);
+    setFullScreen(isStartingInitialLoad);
     setLoadingText(isStartingInitialLoad ? 'Chargement des données' : 'Mise à jour des données');
 
     /*

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -1,5 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
-import styled from 'styled-components';
+import { useEffect } from 'react';
 import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'react-toastify';
 
@@ -27,361 +26,364 @@ import { groupsState } from '../recoil/groups';
 
 // Update to flush cache.
 
-const cacheEffect = ({ onSet }) => {
-  onSet(async (newValue) => {
-    await setCacheItem(dashboardCurrentCacheKey, newValue);
-  });
-};
-
-const loaderTriggerState = atom({ key: 'loaderTriggerState', default: false });
 const isLoadingState = atom({ key: 'isLoadingState', default: false });
 const initialLoadState = atom({ key: 'isInitialLoadState', default: false });
 const fullScreenState = atom({ key: 'fullScreenState', default: true });
-export const lastLoadState = atom({ key: 'lastLoadState', default: null, effects: [cacheEffect] });
+const progressState = atom({ key: 'progressState', default: null });
+const totalState = atom({ key: 'totalState', default: null });
 export const initialLoadingTextState = 'En attente de chargement';
 export const loadingTextState = atom({ key: 'loadingTextState', default: initialLoadingTextState });
+export const lastLoadState = atom({
+  key: 'lastLoadState',
+  default: null,
+  effects: [
+    ({ onSet }) => {
+      onSet(async (newValue) => {
+        await setCacheItem(dashboardCurrentCacheKey, newValue);
+      });
+    },
+  ],
+});
 
 export default function DataLoader() {
-  const [user, setUser] = useRecoilState(userState);
-  const { migrateData } = useDataMigrator();
+  const isLoading = useRecoilValue(isLoadingState);
+  const fullScreen = useRecoilValue(fullScreenState);
+  const loadingText = useRecoilValue(loadingTextState);
+  const progress = useRecoilValue(progressState);
+  const total = useRecoilValue(totalState);
 
-  const [persons, setPersons] = useRecoilState(personsState);
-  const [actions, setActions] = useRecoilState(actionsState);
-  const [consultations, setConsultations] = useRecoilState(consultationsState);
-  const [treatments, setTreatments] = useRecoilState(treatmentsState);
-  const [medicalFiles, setMedicalFiles] = useRecoilState(medicalFileState);
-  const [passages, setPassages] = useRecoilState(passagesState);
-  const [rencontres, setRencontres] = useRecoilState(rencontresState);
-  const [reports, setReports] = useRecoilState(reportsState);
-  const [territories, setTerritories] = useRecoilState(territoriesState);
-  const [places, setPlaces] = useRecoilState(placesState);
-  const [relsPersonPlace, setRelsPersonPlace] = useRecoilState(relsPersonPlaceState);
-  const [territoryObservations, setTerritoryObservations] = useRecoilState(territoryObservationsState);
-  const [comments, setComments] = useRecoilState(commentsState);
-  const [groups, setGroups] = useRecoilState(groupsState);
+  if (!isLoading) return <RandomPicturePreloader />;
+  if (!total && !fullScreen) return null;
 
-  const [loaderTrigger, setLoaderTrigger] = useRecoilState(loaderTriggerState);
-  const [lastLoad, setLastLoad] = useRecoilState(lastLoadState);
-  const [isLoading, setIsLoading] = useRecoilState(isLoadingState);
-  const [fullScreen, setFullScreen] = useRecoilState(fullScreenState);
-  const [loadingText, setLoadingText] = useRecoilState(loadingTextState);
-  const initialLoad = useRecoilValue(initialLoadState);
-  const [organisation, setOrganisation] = useRecoilState(organisationState);
-
-  const [loadList, setLoadList] = useState({ list: [], offset: 0 });
-  const [progressBuffer, setProgressBuffer] = useState(null);
-  const [progress, setProgress] = useState(null);
-  const [total, setTotal] = useState(null);
-
-  useEffect(() => {
-    initLoader();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [progress, total, loaderTrigger, loadList.list.length, isLoading]);
-
-  useEffect(() => {
-    fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [loadList]);
-  useEffect(() => {
-    updateProgress();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [progress, progressBuffer, loadList.list.length]);
-
-  const organisationId = organisation?._id;
-
-  const serverDate = useRef(null);
-
-  // Loader initialization: get data from cache, check stats, init recoils states, and start loader.
-  function initLoader() {
-    if (loadList.list.length > 0) return;
-
-    const shouldStart = progress === null && total === null && loaderTrigger && isLoading;
-    const shouldStop = progress !== null && total !== null && isLoading;
-
-    if (shouldStart) {
-      Promise.resolve()
-        .then(async () => {
-          /*
-            Refresh organisation (and user), to get the latest organisation fields
-            and the latest user roles
-          */
-          const userResponse = await API.get({ path: '/user/me' });
-          if (!userResponse.ok) return resetLoaderOnError();
-          setOrganisation(userResponse.user.organisation);
-          setUser(userResponse.user);
-          // Get date from server at the very beginning of the loader.
-          const serverDateResponse = await API.get({ path: '/now' });
-          serverDate.current = serverDateResponse.data;
-        })
-        .then(() => (initialLoad ? migrateData() : Promise.resolve()))
-        .then(() => getCacheItem(dashboardCurrentCacheKey))
-        .then((lastLoadValue) => {
-          setLastLoad(lastLoadValue || 0);
-          API.get({
-            path: '/organisation/stats',
-            query: {
-              organisation: organisationId,
-              after: lastLoadValue || 0,
-              withDeleted: true,
-              // Medical data is never saved in cache so we always have to download all at every page reload.
-              withAllMedicalData: initialLoad,
-            },
-          }).then(({ data: stats }) => {
-            if (!stats) return;
-            const newList = [];
-            let itemsCount =
-              0 +
-              stats.persons +
-              stats.consultations +
-              stats.actions +
-              stats.treatments +
-              stats.medicalFiles +
-              stats.passages +
-              stats.rencontres +
-              stats.reports +
-              stats.territories +
-              stats.places +
-              stats.relsPersonPlace +
-              stats.territoryObservations +
-              stats.comments +
-              stats.groups;
-
-            if (stats.persons) newList.push('person');
-            if (stats.groups) newList.push('group');
-            if (stats.consultations) newList.push('consultation');
-            if (['admin', 'normal'].includes(user.role)) {
-              if (stats.treatments) newList.push('treatment');
-              if (stats.medicalFiles) newList.push('medicalFile');
-            }
-            if (stats.reports) newList.push('report');
-            if (stats.passages) newList.push('passage');
-            if (stats.rencontres) newList.push('rencontre');
-            if (stats.actions) newList.push('action');
-            if (stats.territories) newList.push('territory');
-            if (stats.places) newList.push('place');
-            if (stats.relsPersonPlace) newList.push('relsPersonPlace');
-            if (stats.territoryObservations) newList.push('territoryObservation');
-            if (stats.comments) newList.push('comment');
-
-            // In case this is not the initial load, we don't have to load from cache again.
-            if (!initialLoad) {
-              startLoader(newList, itemsCount);
-              return;
-            }
-
-            setLoadingText('Récupération des données dans le cache');
-            Promise.resolve()
-              .then(() => getCacheItemDefaultValue('person', []))
-              .then((persons) => setPersons([...persons]))
-              .then(() => getCacheItemDefaultValue('group', []))
-              .then((groups) => setGroups([...groups]))
-              .then(() => getCacheItemDefaultValue('report', []))
-              .then((reports) => setReports([...reports]))
-              .then(() => getCacheItemDefaultValue('passage', []))
-              .then((passages) => setPassages([...passages]))
-              .then(() => getCacheItemDefaultValue('rencontre', []))
-              .then((rencontres) => setRencontres([...rencontres]))
-              .then(() => getCacheItemDefaultValue('action', []))
-              .then((actions) => setActions([...actions]))
-              .then(() => getCacheItemDefaultValue('territory', []))
-              .then((territories) => setTerritories([...territories]))
-              .then(() => getCacheItemDefaultValue('place', []))
-              .then((places) => setPlaces([...places]))
-              .then(() => getCacheItemDefaultValue('relPersonPlace', []))
-              .then((relsPersonPlace) => setRelsPersonPlace([...relsPersonPlace]))
-              .then(() => getCacheItemDefaultValue('territory-observation', []))
-              .then((territoryObservations) => setTerritoryObservations([...territoryObservations]))
-              .then(() => getCacheItemDefaultValue('comment', []))
-              .then((comments) => setComments([...comments]))
-              .then(() => startLoader(newList, itemsCount));
-          });
-        });
-    } else if (shouldStop) stopLoader();
+  if (fullScreen) {
+    return (
+      <div className="tw-absolute tw-inset-0 tw-z-[1000] tw-box-border tw-flex tw-w-full tw-items-center tw-justify-center tw-bg-white">
+        <div className="tw-flex tw-h-[50vh] tw-max-h-[50vw] tw-w-[50vw] tw-max-w-[50vh] tw-flex-col tw-items-center tw-justify-center">
+          <RandomPicture />
+          <ProgressBar progress={progress} total={total} loadingText={loadingText} />
+        </div>
+      </div>
+    );
   }
 
-  // Fetch data from API, handle loader progress.
-  async function fetchData() {
-    if (loadList.list.length === 0) return;
+  return (
+    <div className="tw-absolute tw-top-0 tw-left-0 tw-z-[1000] tw-box-border tw-w-full">
+      <ProgressBar progress={progress} total={total} loadingText={loadingText} />
+    </div>
+  );
+}
 
-    const [current] = loadList.list;
+export function useDataLoader(options = { refreshOnMount: false }) {
+  const [fullScreen, setFullScreen] = useRecoilState(fullScreenState);
+  const [isLoading, setIsLoading] = useRecoilState(isLoadingState);
+  const [initialLoad, setInitialLoad] = useRecoilState(initialLoadState);
+  const setLoadingText = useSetRecoilState(loadingTextState);
+  const setLastLoad = useSetRecoilState(lastLoadState);
+
+  const setUser = useSetRecoilState(userState);
+  const setOrganisation = useSetRecoilState(organisationState);
+  const { migrateData } = useDataMigrator();
+
+  const setPersons = useSetRecoilState(personsState);
+  const setActions = useSetRecoilState(actionsState);
+  const setConsultations = useSetRecoilState(consultationsState);
+  const setTreatments = useSetRecoilState(treatmentsState);
+  const setMedicalFiles = useSetRecoilState(medicalFileState);
+  const setPassages = useSetRecoilState(passagesState);
+  const setRencontres = useSetRecoilState(rencontresState);
+  const setReports = useSetRecoilState(reportsState);
+  const setTerritories = useSetRecoilState(territoriesState);
+  const setPlaces = useSetRecoilState(placesState);
+  const setRelsPersonPlace = useSetRecoilState(relsPersonPlaceState);
+  const setTerritoryObservations = useSetRecoilState(territoryObservationsState);
+  const setComments = useSetRecoilState(commentsState);
+  const setGroups = useSetRecoilState(groupsState);
+  const setProgress = useSetRecoilState(progressState);
+  const setTotal = useSetRecoilState(totalState);
+
+  useEffect(function refreshOnMountEffect() {
+    if (options.refreshOnMount && !isLoading) loadOrRefreshData(false);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  async function loadOrRefreshData(isStartingInitialLoad) {
+    setIsLoading(true);
+    setFullScreen(isStartingInitialLoad ? true : false);
+    setInitialLoad(isStartingInitialLoad ? true : false);
+    setLoadingText(setInitialLoad ? 'Chargement des données' : 'Mise à jour des données');
+
+    /*
+    Refresh organisation (and user), to get the latest organisation fields
+    and the latest user roles
+  */
+    const userResponse = await API.get({ path: '/user/me' });
+    if (!userResponse.ok) return resetLoaderOnError();
+    const latestOrganisation = userResponse.user.organisation;
+    const latestUser = userResponse.user;
+    const organisationId = latestOrganisation._id;
+    setOrganisation(latestOrganisation);
+    setUser(latestUser);
+    // Get date from server at the very beginning of the loader.
+    const serverDateResponse = await API.get({ path: '/now' });
+    const serverDate = serverDateResponse.data;
+    if (initialLoad) {
+      await migrateData();
+    }
+    const lastLoadValueCached = await getCacheItem(dashboardCurrentCacheKey);
+    const lastLoadValue = lastLoadValueCached || 0;
+    setLastLoad(lastLoadValue);
+
+    const statsResponse = await API.get({
+      path: '/organisation/stats',
+      query: {
+        organisation: organisationId,
+        after: lastLoadValue,
+        withDeleted: true,
+        // Medical data is never saved in cache so we always have to download all at every page reload.
+        withAllMedicalData: initialLoad,
+      },
+    });
+
+    if (!statsResponse.ok) return false;
+    const stats = statsResponse.data;
+    let itemsCount =
+      0 +
+      stats.persons +
+      stats.consultations +
+      stats.actions +
+      stats.treatments +
+      stats.medicalFiles +
+      stats.passages +
+      stats.rencontres +
+      stats.reports +
+      stats.territories +
+      stats.places +
+      stats.relsPersonPlace +
+      stats.territoryObservations +
+      stats.comments +
+      stats.groups;
+
+    setProgress(0);
+    setTotal(itemsCount);
+
     const query = {
       organisation: organisationId,
       limit: String(10000),
-      page: String(loadList.offset),
-      after: lastLoad,
-      withDeleted: Boolean(lastLoad),
+      after: lastLoadValue,
+      withDeleted: Boolean(lastLoadValue),
     };
 
-    function handleMore(hasMore) {
-      if (hasMore) setLoadList({ list: loadList.list, offset: loadList.offset + 1 });
-      else setLoadList({ list: loadList.list.slice(1), offset: 0 });
-    }
-
-    if (current === 'person') {
+    if (stats.persons > 0) {
       setLoadingText('Chargement des personnes');
-      const res = await API.get({ path: '/person', query });
-      if (!res.data) return resetLoaderOnError();
-      setPersons(
-        res.hasMore
-          ? mergeItems(persons, res.decryptedData)
-          : mergeItems(persons, res.decryptedData)
-              .map((p) => ({ ...p, followedSince: p.followedSince || p.createdAt }))
-              .sort((p1, p2) => (p1.name || '').localeCompare(p2.name || ''))
-      );
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'group') {
-      setLoadingText('Chargement des familles');
-      const res = await API.get({ path: '/group', query });
-      if (!res.data) return resetLoaderOnError();
-      setGroups(() => {
-        const mergedItems = mergeItems(groups, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        if (mergedItems.length > groups.length) {
-          return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-        }
-        return mergedItems;
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'consultation') {
-      setLoadingText('Chargement des consultations');
-      const res = await API.get({ path: '/consultation', query: { ...query, after: initialLoad ? 0 : lastLoad } });
-      if (!res.data) return resetLoaderOnError();
-      setConsultations(
-        res.hasMore ? mergeItems(consultations, res.decryptedData) : mergeItems(consultations, res.decryptedData).map(formatConsultation)
-      );
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'treatment') {
-      setLoadingText('Chargement des traitements');
-      const res = await API.get({ path: '/treatment', query: { ...query, after: initialLoad ? 0 : lastLoad } });
-      if (!res.data) return resetLoaderOnError();
-      setTreatments(mergeItems(treatments, res.decryptedData));
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'medicalFile') {
-      setLoadingText('Chargement des fichiers médicaux');
-      const res = await API.get({ path: '/medical-file', query: { ...query, after: initialLoad ? 0 : lastLoad } });
-      if (!res.data) return resetLoaderOnError();
-      setMedicalFiles(mergeItems(medicalFiles, res.decryptedData));
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'report') {
-      setLoadingText('Chargement des rapports');
-      const res = await API.get({ path: '/report', query });
-      if (!res.data) return resetLoaderOnError();
-      setReports(
-        res.hasMore
-          ? mergeItems(reports, res.decryptedData)
-          : mergeItems(reports, res.decryptedData)
-              // This line should be removed when `clean-reports-with-no-team-nor-date` migration has run on all organisations.
-              .filter((r) => !!r.team && !!r.date)
-      );
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'passage') {
-      setLoadingText('Chargement des passages');
-      const res = await API.get({ path: '/passage', query });
-      if (!res.data) return resetLoaderOnError();
-      setPassages(() => {
-        const mergedItems = mergeItems(passages, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'rencontre') {
-      setLoadingText('Chargement des rencontres');
-      const res = await API.get({ path: '/rencontre', query });
-      if (!res.data) return resetLoaderOnError();
-      setRencontres(() => {
-        const mergedItems = mergeItems(rencontres, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'action') {
-      setFullScreen(false);
-      setLoadingText('Chargement des actions');
-      const res = await API.get({ path: '/action', query });
-      if (!res.data) return resetLoaderOnError();
-      setActions(mergeItems(actions, res.decryptedData));
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'territory') {
-      setLoadingText('Chargement des territoires');
-      const res = await API.get({ path: '/territory', query });
-      if (!res.data) return resetLoaderOnError();
-      setTerritories(() => {
-        const mergedItems = mergeItems(territories, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'place') {
-      setLoadingText('Chargement des lieux');
-      const res = await API.get({ path: '/place', query });
-      if (!res.data) return resetLoaderOnError();
-      setPlaces(() => {
-        const mergedItems = mergeItems(places, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'relsPersonPlace') {
-      setLoadingText('Chargement des relations personne-lieu');
-      const res = await API.get({ path: '/relPersonPlace', query });
-      if (!res.data) return resetLoaderOnError();
-      setRelsPersonPlace(() => {
-        const mergedItems = mergeItems(relsPersonPlace, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'territoryObservation') {
-      setLoadingText('Chargement des observations de territoire');
-      const res = await API.get({ path: '/territory-observation', query });
-      if (!res.data) return resetLoaderOnError();
-      setTerritoryObservations(() => {
-        const mergedItems = mergeItems(territoryObservations, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.observedAt || b.createdAt) - new Date(a.observedAt || a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
-    } else if (current === 'comment') {
-      setLoadingText('Chargement des commentaires');
-      const res = await API.get({ path: '/comment', query });
-      if (!res.data) return resetLoaderOnError();
-      setComments(() => {
-        const mergedItems = mergeItems(comments, res.decryptedData);
-        if (res.hasMore) return mergedItems;
-        return mergedItems.sort((a, b) => new Date(b.date || b.createdAt) - new Date(a.date || a.createdAt));
-      });
-      handleMore(res.hasMore);
-      setProgressBuffer(res.data.length);
+      const cachedPersons = await getCacheItemDefaultValue('person', []);
+      setPersons([...cachedPersons]);
+      async function loadPersons(page = 0) {
+        const res = await API.get({ path: '/person', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setPersons((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadPersons(page + 1);
+        return true;
+      }
+      const personSuccess = await loadPersons(0);
+      if (!personSuccess) return false;
     }
-  }
+    if (stats.groups > 0) {
+      setLoadingText('Chargement des familles');
+      const cachedGroups = await getCacheItemDefaultValue('group', []);
+      setGroups([...cachedGroups]);
+      async function loadGroups(page = 0) {
+        const res = await API.get({ path: '/group', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setGroups((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadGroups(page + 1);
+        return true;
+      }
+      const groupsSuccess = await loadGroups(0);
+      if (!groupsSuccess) return false;
+    }
+    if (stats.reports > 0) {
+      setLoadingText('Chargement des comptes-rendus');
+      const cachedReports = await getCacheItemDefaultValue('report', []);
+      setReports([...cachedReports]);
+      async function loadReports(page = 0) {
+        const res = await API.get({ path: '/report', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setReports((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadReports(page + 1);
+        return true;
+      }
+      const reportsSuccess = await loadReports(0);
+      if (!reportsSuccess) return false;
+    }
+    if (stats.passages > 0) {
+      setLoadingText('Chargement des passages');
+      const cachedPassages = await getCacheItemDefaultValue('passage', []);
+      setPassages([...cachedPassages]);
+      async function loadPassages(page = 0) {
+        const res = await API.get({ path: '/passage', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setPassages((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadPassages(page + 1);
+        return true;
+      }
+      const passagesSuccess = await loadPassages(0);
+      if (!passagesSuccess) return false;
+    }
+    if (stats.rencontres > 0) {
+      setLoadingText('Chargement des rencontres');
+      const cachedRencontres = await getCacheItemDefaultValue('rencontre', []);
+      setRencontres([...cachedRencontres]);
+      async function loadRencontres(page = 0) {
+        const res = await API.get({ path: '/rencontre', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setRencontres((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadRencontres(page + 1);
+        return true;
+      }
+      const rencontresSuccess = await loadRencontres(0);
+      if (!rencontresSuccess) return false;
+    }
+    if (stats.actions > 0) {
+      setLoadingText('Chargement des actions');
+      const cachedActions = await getCacheItemDefaultValue('action', []);
+      setActions([...cachedActions]);
+      async function loadActions(page = 0) {
+        const res = await API.get({ path: '/action', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setActions((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadActions(page + 1);
+        return true;
+      }
+      const actionsSuccess = await loadActions(0);
+      if (!actionsSuccess) return false;
+    }
+    if (stats.territories > 0) {
+      setLoadingText('Chargement des territoires');
+      const cachedTerritories = await getCacheItemDefaultValue('territory', []);
+      setTerritories([...cachedTerritories]);
+      async function loadTerritories(page = 0) {
+        const res = await API.get({ path: '/territory', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setTerritories((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadTerritories(page + 1);
+        return true;
+      }
+      const territoriesSuccess = await loadTerritories(0);
+      if (!territoriesSuccess) return false;
+    }
+    if (stats.places > 0) {
+      setLoadingText('Chargement des lieux');
+      const cachedPlaces = await getCacheItemDefaultValue('place', []);
+      setPlaces([...cachedPlaces]);
+      async function loadPlaces(page = 0) {
+        const res = await API.get({ path: '/place', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setPlaces((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadPlaces(page + 1);
+        return true;
+      }
+      const placesSuccess = await loadPlaces(0);
+      if (!placesSuccess) return false;
+    }
+    if (stats.relsPersonPlace > 0) {
+      setLoadingText('Chargement des relations personne-lieu');
+      const cachedRelPersonPlace = await getCacheItemDefaultValue('relPersonPlace', []);
+      setRelsPersonPlace([...cachedRelPersonPlace]);
+      async function loadRelPersonPlaces(page = 0) {
+        const res = await API.get({ path: '/relPersonPlace', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setRelsPersonPlace((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadRelPersonPlaces(page + 1);
+        return true;
+      }
+      const relsPersonPlacesSuccess = await loadRelPersonPlaces(0);
+      if (!relsPersonPlacesSuccess) return false;
+    }
+    if (stats.territoryObservations > 0) {
+      setLoadingText('Chargement des observations de territoire');
+      const cachedObservations = await getCacheItemDefaultValue('territory-observation', []);
+      setTerritoryObservations([...cachedObservations]);
+      async function loadObservations(page = 0) {
+        const res = await API.get({ path: '/territory-observation', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setTerritoryObservations((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadObservations(page + 1);
+        return true;
+      }
+      const territoryObservationsSuccess = await loadObservations(0);
+      if (!territoryObservationsSuccess) return false;
+    }
+    if (stats.comments > 0) {
+      setLoadingText('Chargement des commentaires');
+      const cachedComments = await getCacheItemDefaultValue('comment', []);
+      setComments([...cachedComments]);
+      async function loadComments(page = 0) {
+        const res = await API.get({ path: '/comment', query: { ...query, page: String(page) } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setComments((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadComments(page + 1);
+        return true;
+      }
+      const commentsSuccess = await loadComments(0);
+      if (!commentsSuccess) return false;
+    }
+    if (stats.consultations > 0) {
+      setLoadingText('Chargement des consultations');
+      async function loadConsultations(page = 0) {
+        const res = await API.get({ path: '/consultation', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setConsultations((items) => mergeItems(items, res.decryptedData, formatConsultation));
+        if (res.hasMore) return loadConsultations(page + 1);
+        return true;
+      }
+      const consultationsSuccess = await loadConsultations(0);
+      if (!consultationsSuccess) return false;
+    }
+    if (stats.treatments > 0) {
+      setLoadingText('Chargement des traitements');
+      async function loadTreatments(page = 0) {
+        const res = await API.get({ path: '/treatment', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setTreatments((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadTreatments(page + 1);
+        return true;
+      }
+      const treatmentsSuccess = await loadTreatments(0);
+      if (!treatmentsSuccess) return false;
+    }
+    if (stats.medicalFiles > 0) {
+      setLoadingText('Chargement des fichiers médicaux');
+      async function loadMedicalFiles(page = 0) {
+        const res = await API.get({ path: '/medical-file', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
+        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        setProgress((p) => p + res.data.length);
+        setMedicalFiles((items) => mergeItems(items, res.decryptedData));
+        if (res.hasMore) return loadMedicalFiles(page + 1);
+        return true;
+      }
+      const medicalFilesSuccess = await loadMedicalFiles(0);
+      if (!medicalFilesSuccess) return false;
+    }
 
-  function startLoader(list, itemsCount) {
-    setLoadList({ list, offset: 0 });
-    setLoaderTrigger(false);
-    setProgress(0);
-    setTotal(itemsCount);
-  }
-
-  function stopLoader() {
     setIsLoading(false);
-    setLastLoad(serverDate.current);
+    setLastLoad(serverDate);
     setLoadingText('En attente de chargement');
-    setProgressBuffer(null);
     setProgress(null);
     setTotal(null);
+    return true;
   }
 
   async function resetLoaderOnError() {
@@ -393,64 +395,7 @@ export default function DataLoader() {
       onClose: () => window.location.replace('/auth'),
       autoClose: 5000,
     });
-  }
-
-  function updateProgress() {
-    if (!loadList.list.length) return;
-
-    if (progressBuffer !== null) {
-      setProgress((progress || 0) + progressBuffer);
-      setProgressBuffer(null);
-    }
-  }
-
-  if (!isLoading) return <RandomPicturePreloader />;
-  if (!total && !fullScreen) return null;
-
-  if (fullScreen) {
-    return (
-      <FullScreenContainer>
-        <InsideContainer>
-          <RandomPicture />
-          <ProgressBar progress={progress} total={total} loadingText={loadingText} />
-        </InsideContainer>
-      </FullScreenContainer>
-    );
-  }
-
-  return (
-    <Container>
-      <ProgressBar progress={progress} total={total} loadingText={loadingText} />
-    </Container>
-  );
-}
-
-export function useDataLoader(options = { refreshOnMount: false }) {
-  const [fullScreen, setFullScreen] = useRecoilState(fullScreenState);
-  const [isLoading, setIsLoading] = useRecoilState(isLoadingState);
-  const setLoaderTrigger = useSetRecoilState(loaderTriggerState);
-  const setInitialLoad = useSetRecoilState(initialLoadState);
-  const setLoadingText = useSetRecoilState(loadingTextState);
-  const setLastLoad = useSetRecoilState(lastLoadState);
-
-  useEffect(function refreshOnMountEffect() {
-    if (options.refreshOnMount && !isLoading) refresh();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
-
-  function refresh() {
-    setIsLoading(true);
-    setFullScreen(false);
-    setInitialLoad(false);
-    setLoaderTrigger(true);
-    setLoadingText('Mise à jour des données');
-  }
-  function load() {
-    setIsLoading(true);
-    setFullScreen(true);
-    setInitialLoad(true);
-    setLoaderTrigger(true);
-    setLoadingText('Chargement des données');
+    return false;
   }
 
   async function resetCache() {
@@ -459,54 +404,35 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   }
 
   return {
-    refresh,
-    load,
+    refresh: () => loadOrRefreshData(false),
+    startInitialLoad: () => loadOrRefreshData(true),
     resetCache,
     isLoading: Boolean(isLoading),
     isFullScreen: Boolean(fullScreen),
   };
 }
 
-export const mergeItems = (oldItems, newItems = []) => {
+export function mergeItems(oldItems, newItems = [], formatNewItemsFunction) {
+  const newItemsCleanedAndFormatted = [];
   const newItemIds = {};
+
   for (const newItem of newItems) {
     newItemIds[newItem._id] = true;
+    if (newItem.deletedAt) continue;
+    if (formatNewItemsFunction) {
+      newItemsCleanedAndFormatted.push(formatNewItemsFunction(newItem));
+    } else {
+      newItemsCleanedAndFormatted.push(newItem);
+    }
   }
-  const oldItemsPurged = oldItems.filter((item) => !newItemIds[item._id] && !item.deletedAt);
-  return [...oldItemsPurged, ...newItems.filter((item) => !item.deletedAt)];
-};
 
-const FullScreenContainer = styled.div`
-  width: 100%;
-  z-index: 1000;
-  position: absolute;
-  top: 0;
-  left: 0;
-  bottom: 0;
-  right: 0;
-  box-sizing: border-box;
-  background-color: #fff;
-  display: flex;
-  justify-content: center;
-  align-items: center;
-`;
+  const oldItemsPurged = [];
+  for (const oldItem of oldItems) {
+    if (oldItem.deletedAt) continue;
+    if (!newItemIds[oldItem._id]) {
+      oldItemsPurged.push(oldItem);
+    }
+  }
 
-const InsideContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  width: 50vw;
-  max-width: 50vh;
-  height: 50vh;
-  max-height: 50vw;
-  justify-content: center;
-  align-items: center;
-`;
-
-const Container = styled.div`
-  width: 100%;
-  z-index: 1000;
-  position: absolute;
-  top: 0;
-  left: 0;
-  box-sizing: border-box;
-`;
+  return [...oldItemsPurged, ...newItemsCleanedAndFormatted];
+}

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -164,9 +164,11 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       stats.relsPersonPlace +
       stats.territoryObservations +
       stats.comments +
-      stats.consultations +
-      stats.treatments +
-      stats.medicalFiles;
+      stats.consultations;
+
+    if (['admin', 'normal'].includes(latestUser.role)) {
+      itemsCount += stats.treatments + stats.medicalFiles;
+    }
 
     setProgress(0);
     setTotal(itemsCount);
@@ -358,7 +360,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const consultationsSuccess = await loadConsultations(0);
       if (!consultationsSuccess) return false;
     }
-    if (stats.treatments > 0) {
+    if (['admin', 'normal'].includes(latestUser.role) && stats.treatments > 0) {
       let newItems = [];
       setLoadingText('Chargement des traitements');
       async function loadTreatments(page = 0) {
@@ -373,7 +375,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const treatmentsSuccess = await loadTreatments(0);
       if (!treatmentsSuccess) return false;
     }
-    if (stats.medicalFiles > 0) {
+    if (['admin', 'normal'].includes(latestUser.role) && stats.medicalFiles > 0) {
       let newItems = [];
       setLoadingText('Chargement des fichiers médicaux');
       async function loadMedicalFiles(page = 0) {

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -3,6 +3,7 @@ import { atom, selector, useRecoilState, useRecoilValue, useSetRecoilState } fro
 import { toast } from 'react-toastify';
 
 import { personsState } from '../recoil/persons';
+import { groupsState } from '../recoil/groups';
 import { treatmentsState } from '../recoil/treatments';
 import { actionsState } from '../recoil/actions';
 import { medicalFileState } from '../recoil/medicalFiles';
@@ -22,7 +23,6 @@ import API from '../services/api';
 import { RandomPicture, RandomPicturePreloader } from './LoaderRandomPicture';
 import ProgressBar from './LoaderProgressBar';
 import useDataMigrator from './DataMigrator';
-import { groupsState } from '../recoil/groups';
 
 // Update to flush cache.
 
@@ -94,20 +94,20 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   const setOrganisation = useSetRecoilState(organisationState);
   const { migrateData } = useDataMigrator();
 
-  const setPersons = useSetRecoilState(personsState);
-  const setGroups = useSetRecoilState(groupsState);
-  const setReports = useSetRecoilState(reportsState);
-  const setPassages = useSetRecoilState(passagesState);
-  const setRencontres = useSetRecoilState(rencontresState);
-  const setActions = useSetRecoilState(actionsState);
-  const setTerritories = useSetRecoilState(territoriesState);
-  const setPlaces = useSetRecoilState(placesState);
-  const setRelsPersonPlace = useSetRecoilState(relsPersonPlaceState);
-  const setTerritoryObservations = useSetRecoilState(territoryObservationsState);
-  const setComments = useSetRecoilState(commentsState);
-  const setConsultations = useSetRecoilState(consultationsState);
-  const setTreatments = useSetRecoilState(treatmentsState);
-  const setMedicalFiles = useSetRecoilState(medicalFileState);
+  const [persons, setPersons] = useRecoilState(personsState);
+  const [groups, setGroups] = useRecoilState(groupsState);
+  const [reports, setReports] = useRecoilState(reportsState);
+  const [passages, setPassages] = useRecoilState(passagesState);
+  const [rencontres, setRencontres] = useRecoilState(rencontresState);
+  const [actions, setActions] = useRecoilState(actionsState);
+  const [territories, setTerritories] = useRecoilState(territoriesState);
+  const [places, setPlaces] = useRecoilState(placesState);
+  const [relsPersonPlace, setRelsPersonPlace] = useRecoilState(relsPersonPlaceState);
+  const [territoryObservations, setTerritoryObservations] = useRecoilState(territoryObservationsState);
+  const [comments, setComments] = useRecoilState(commentsState);
+  const [consultations, setConsultations] = useRecoilState(consultationsState);
+  const [treatments, setTreatments] = useRecoilState(treatmentsState);
+  const [medicalFiles, setMedicalFiles] = useRecoilState(medicalFileState);
 
   useEffect(function refreshOnMountEffect() {
     if (options.refreshOnMount && !isLoading) loadOrRefreshData(false);
@@ -168,8 +168,6 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       stats.treatments +
       stats.medicalFiles;
 
-    console.log('stats', stats, 'itemsCount', itemsCount);
-
     setProgress(0);
     setTotal(itemsCount);
 
@@ -186,11 +184,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       async function loadPersons(page = 0) {
         const res = await API.get({ path: '/person', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
-        console.log('Persons', page, res.data.length);
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPersons(page + 1);
-        setPersons((items) => mergeItems(items, newItems));
+        setPersons(mergeItems(persons, newItems));
         return true;
       }
       const personSuccess = await loadPersons(0);
@@ -205,7 +202,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadGroups(page + 1);
-        setGroups((items) => mergeItems(items, newItems));
+        setGroups(mergeItems(groups, newItems));
         return true;
       }
       const groupsSuccess = await loadGroups(0);
@@ -220,7 +217,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadReports(page + 1);
-        setReports((items) => mergeItems(items, newItems, { filterNewItemsFunction: (r) => !!r.team && !!r.date }));
+        setReports(mergeItems(reports, newItems, { filterNewItemsFunction: (r) => !!r.team && !!r.date }));
         return true;
       }
       const reportsSuccess = await loadReports(0);
@@ -235,7 +232,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPassages(page + 1);
-        setPassages((items) => mergeItems(items, newItems));
+        setPassages(mergeItems(passages, newItems));
         return true;
       }
       const passagesSuccess = await loadPassages(0);
@@ -250,7 +247,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadRencontres(page + 1);
-        setRencontres((items) => mergeItems(items, newItems));
+        setRencontres(mergeItems(rencontres, newItems));
         return true;
       }
       const rencontresSuccess = await loadRencontres(0);
@@ -265,7 +262,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadActions(page + 1);
-        setActions((items) => mergeItems(items, newItems));
+        setActions(mergeItems(actions, newItems));
         return true;
       }
       const actionsSuccess = await loadActions(0);
@@ -280,7 +277,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadTerritories(page + 1);
-        setTerritories((items) => mergeItems(items, newItems));
+        setTerritories(mergeItems(territories, newItems));
         return true;
       }
       const territoriesSuccess = await loadTerritories(0);
@@ -295,7 +292,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPlaces(page + 1);
-        setPlaces((items) => mergeItems(items, newItems));
+        setPlaces(mergeItems(places, newItems));
         return true;
       }
       const placesSuccess = await loadPlaces(0);
@@ -310,7 +307,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadRelPersonPlaces(page + 1);
-        setRelsPersonPlace((items) => mergeItems(items, newItems));
+        setRelsPersonPlace(mergeItems(relsPersonPlace, newItems));
         return true;
       }
       const relsPersonPlacesSuccess = await loadRelPersonPlaces(0);
@@ -325,7 +322,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadObservations(page + 1);
-        setTerritoryObservations((items) => mergeItems(items, newItems));
+        setTerritoryObservations(mergeItems(territoryObservations, newItems));
         return true;
       }
       const territoryObservationsSuccess = await loadObservations(0);
@@ -340,7 +337,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadComments(page + 1);
-        setComments((items) => mergeItems(items, newItems));
+        setComments(mergeItems(comments, newItems));
         return true;
       }
       const commentsSuccess = await loadComments(0);
@@ -355,7 +352,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadConsultations(page + 1);
-        setConsultations((items) => mergeItems(items, newItems, { formatNewItemsFunction: formatConsultation }));
+        setConsultations(mergeItems(consultations, newItems, { formatNewItemsFunction: formatConsultation }));
         return true;
       }
       const consultationsSuccess = await loadConsultations(0);
@@ -370,7 +367,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadTreatments(page + 1);
-        setTreatments((items) => mergeItems(items, newItems));
+        setTreatments(mergeItems(treatments, newItems));
         return true;
       }
       const treatmentsSuccess = await loadTreatments(0);
@@ -385,7 +382,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadMedicalFiles(page + 1);
-        setMedicalFiles((items) => mergeItems(items, newItems));
+        setMedicalFiles(mergeItems(medicalFiles, newItems));
         return true;
       }
       const medicalFilesSuccess = await loadMedicalFiles(0);

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -1,5 +1,5 @@
 import { useEffect } from 'react';
-import { atom, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { atom, selector, useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import { toast } from 'react-toastify';
 
 import { personsState } from '../recoil/persons';
@@ -17,7 +17,7 @@ import { consultationsState, formatConsultation } from '../recoil/consultations'
 import { commentsState } from '../recoil/comments';
 import { organisationState, userState } from '../recoil/auth';
 
-import { clearCache, dashboardCurrentCacheKey, getCacheItem, getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { clearCache, dashboardCurrentCacheKey, getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
 import API from '../services/api';
 import { RandomPicture, RandomPicturePreloader } from './LoaderRandomPicture';
 import ProgressBar from './LoaderProgressBar';
@@ -35,7 +35,13 @@ export const initialLoadingTextState = 'En attente de chargement';
 export const loadingTextState = atom({ key: 'loadingTextState', default: initialLoadingTextState });
 export const lastLoadState = atom({
   key: 'lastLoadState',
-  default: null,
+  default: selector({
+    key: 'lastLoadState/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue(dashboardCurrentCacheKey, 0);
+      return cache;
+    },
+  }),
   effects: [
     ({ onSet }) => {
       onSet(async (newValue) => {
@@ -80,28 +86,28 @@ export function useDataLoader(options = { refreshOnMount: false }) {
   const [isLoading, setIsLoading] = useRecoilState(isLoadingState);
   const [initialLoad, setInitialLoad] = useRecoilState(initialLoadState);
   const setLoadingText = useSetRecoilState(loadingTextState);
-  const setLastLoad = useSetRecoilState(lastLoadState);
+  const [lastLoadValue, setLastLoad] = useRecoilState(lastLoadState);
+  const setProgress = useSetRecoilState(progressState);
+  const setTotal = useSetRecoilState(totalState);
 
   const setUser = useSetRecoilState(userState);
   const setOrganisation = useSetRecoilState(organisationState);
   const { migrateData } = useDataMigrator();
 
   const setPersons = useSetRecoilState(personsState);
-  const setActions = useSetRecoilState(actionsState);
-  const setConsultations = useSetRecoilState(consultationsState);
-  const setTreatments = useSetRecoilState(treatmentsState);
-  const setMedicalFiles = useSetRecoilState(medicalFileState);
+  const setGroups = useSetRecoilState(groupsState);
+  const setReports = useSetRecoilState(reportsState);
   const setPassages = useSetRecoilState(passagesState);
   const setRencontres = useSetRecoilState(rencontresState);
-  const setReports = useSetRecoilState(reportsState);
+  const setActions = useSetRecoilState(actionsState);
   const setTerritories = useSetRecoilState(territoriesState);
   const setPlaces = useSetRecoilState(placesState);
   const setRelsPersonPlace = useSetRecoilState(relsPersonPlaceState);
   const setTerritoryObservations = useSetRecoilState(territoryObservationsState);
   const setComments = useSetRecoilState(commentsState);
-  const setGroups = useSetRecoilState(groupsState);
-  const setProgress = useSetRecoilState(progressState);
-  const setTotal = useSetRecoilState(totalState);
+  const setConsultations = useSetRecoilState(consultationsState);
+  const setTreatments = useSetRecoilState(treatmentsState);
+  const setMedicalFiles = useSetRecoilState(medicalFileState);
 
   useEffect(function refreshOnMountEffect() {
     if (options.refreshOnMount && !isLoading) loadOrRefreshData(false);
@@ -131,9 +137,6 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     if (initialLoad) {
       await migrateData();
     }
-    const lastLoadValueCached = await getCacheItem(dashboardCurrentCacheKey);
-    const lastLoadValue = lastLoadValueCached || 0;
-    setLastLoad(lastLoadValue);
 
     const statsResponse = await API.get({
       path: '/organisation/stats',
@@ -151,19 +154,19 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     let itemsCount =
       0 +
       stats.persons +
-      stats.consultations +
-      stats.actions +
-      stats.treatments +
-      stats.medicalFiles +
+      stats.groups +
+      stats.reports +
       stats.passages +
       stats.rencontres +
-      stats.reports +
+      stats.actions +
       stats.territories +
       stats.places +
       stats.relsPersonPlace +
       stats.territoryObservations +
       stats.comments +
-      stats.groups;
+      stats.consultations +
+      stats.treatments +
+      stats.medicalFiles;
 
     console.log('stats', stats, 'itemsCount', itemsCount);
 
@@ -177,206 +180,212 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       withDeleted: Boolean(lastLoadValue),
     };
 
-    setLoadingText('Chargement des personnes');
-    const cachedPersons = await getCacheItemDefaultValue('person', []);
-    setPersons([...cachedPersons]);
     if (stats.persons > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des personnes');
       async function loadPersons(page = 0) {
         const res = await API.get({ path: '/person', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         console.log('Persons', page, res.data.length);
         setProgress((p) => p + res.data.length);
-        setPersons((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPersons(page + 1);
+        setPersons((items) => mergeItems(items, newItems));
         return true;
       }
       const personSuccess = await loadPersons(0);
       if (!personSuccess) return false;
     }
-    setLoadingText('Chargement des familles');
-    const cachedGroups = await getCacheItemDefaultValue('group', []);
-    setGroups([...cachedGroups]);
     if (stats.groups > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des familles');
       async function loadGroups(page = 0) {
         const res = await API.get({ path: '/group', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setGroups((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadGroups(page + 1);
+        setGroups((items) => mergeItems(items, newItems));
         return true;
       }
       const groupsSuccess = await loadGroups(0);
       if (!groupsSuccess) return false;
     }
-    setLoadingText('Chargement des comptes-rendus');
-    const cachedReports = await getCacheItemDefaultValue('report', []);
-    setReports([...cachedReports]);
     if (stats.reports > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des comptes-rendus');
       async function loadReports(page = 0) {
         const res = await API.get({ path: '/report', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setReports((items) => mergeItems(items, res.decryptedData, { filterNewItemsFunction: (r) => !!r.team && !!r.date }));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadReports(page + 1);
+        setReports((items) => mergeItems(items, newItems, { filterNewItemsFunction: (r) => !!r.team && !!r.date }));
         return true;
       }
       const reportsSuccess = await loadReports(0);
       if (!reportsSuccess) return false;
     }
-    setLoadingText('Chargement des passages');
-    const cachedPassages = await getCacheItemDefaultValue('passage', []);
-    setPassages([...cachedPassages]);
     if (stats.passages > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des passages');
       async function loadPassages(page = 0) {
         const res = await API.get({ path: '/passage', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setPassages((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPassages(page + 1);
+        setPassages((items) => mergeItems(items, newItems));
         return true;
       }
       const passagesSuccess = await loadPassages(0);
       if (!passagesSuccess) return false;
     }
-    setLoadingText('Chargement des rencontres');
-    const cachedRencontres = await getCacheItemDefaultValue('rencontre', []);
-    setRencontres([...cachedRencontres]);
     if (stats.rencontres > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des rencontres');
       async function loadRencontres(page = 0) {
         const res = await API.get({ path: '/rencontre', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setRencontres((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadRencontres(page + 1);
+        setRencontres((items) => mergeItems(items, newItems));
         return true;
       }
       const rencontresSuccess = await loadRencontres(0);
       if (!rencontresSuccess) return false;
     }
-    setLoadingText('Chargement des actions');
-    const cachedActions = await getCacheItemDefaultValue('action', []);
-    setActions([...cachedActions]);
     if (stats.actions > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des actions');
       async function loadActions(page = 0) {
         const res = await API.get({ path: '/action', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setActions((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadActions(page + 1);
+        setActions((items) => mergeItems(items, newItems));
         return true;
       }
       const actionsSuccess = await loadActions(0);
       if (!actionsSuccess) return false;
     }
-    setLoadingText('Chargement des territoires');
-    const cachedTerritories = await getCacheItemDefaultValue('territory', []);
-    setTerritories([...cachedTerritories]);
     if (stats.territories > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des territoires');
       async function loadTerritories(page = 0) {
         const res = await API.get({ path: '/territory', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setTerritories((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadTerritories(page + 1);
+        setTerritories((items) => mergeItems(items, newItems));
         return true;
       }
       const territoriesSuccess = await loadTerritories(0);
       if (!territoriesSuccess) return false;
     }
-    setLoadingText('Chargement des lieux');
-    const cachedPlaces = await getCacheItemDefaultValue('place', []);
-    setPlaces([...cachedPlaces]);
     if (stats.places > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des lieux');
       async function loadPlaces(page = 0) {
         const res = await API.get({ path: '/place', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setPlaces((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPlaces(page + 1);
+        setPlaces((items) => mergeItems(items, newItems));
         return true;
       }
       const placesSuccess = await loadPlaces(0);
       if (!placesSuccess) return false;
     }
-    setLoadingText('Chargement des relations personne-lieu');
-    const cachedRelPersonPlace = await getCacheItemDefaultValue('relPersonPlace', []);
-    setRelsPersonPlace([...cachedRelPersonPlace]);
     if (stats.relsPersonPlace > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des relations personne-lieu');
       async function loadRelPersonPlaces(page = 0) {
         const res = await API.get({ path: '/relPersonPlace', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setRelsPersonPlace((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadRelPersonPlaces(page + 1);
+        setRelsPersonPlace((items) => mergeItems(items, newItems));
         return true;
       }
       const relsPersonPlacesSuccess = await loadRelPersonPlaces(0);
       if (!relsPersonPlacesSuccess) return false;
     }
-    setLoadingText('Chargement des observations de territoire');
-    const cachedObservations = await getCacheItemDefaultValue('territory-observation', []);
-    setTerritoryObservations([...cachedObservations]);
     if (stats.territoryObservations > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des observations de territoire');
       async function loadObservations(page = 0) {
         const res = await API.get({ path: '/territory-observation', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setTerritoryObservations((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadObservations(page + 1);
+        setTerritoryObservations((items) => mergeItems(items, newItems));
         return true;
       }
       const territoryObservationsSuccess = await loadObservations(0);
       if (!territoryObservationsSuccess) return false;
     }
-    setLoadingText('Chargement des commentaires');
-    const cachedComments = await getCacheItemDefaultValue('comment', []);
-    setComments([...cachedComments]);
     if (stats.comments > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des commentaires');
       async function loadComments(page = 0) {
         const res = await API.get({ path: '/comment', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setComments((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadComments(page + 1);
+        setComments((items) => mergeItems(items, newItems));
         return true;
       }
       const commentsSuccess = await loadComments(0);
       if (!commentsSuccess) return false;
     }
-    setLoadingText('Chargement des consultations');
     if (stats.consultations > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des consultations');
       async function loadConsultations(page = 0) {
         const res = await API.get({ path: '/consultation', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setConsultations((items) => mergeItems(items, res.decryptedData, { formatNewItemsFunction: formatConsultation }));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadConsultations(page + 1);
+        setConsultations((items) => mergeItems(items, newItems, { formatNewItemsFunction: formatConsultation }));
         return true;
       }
       const consultationsSuccess = await loadConsultations(0);
       if (!consultationsSuccess) return false;
     }
-    setLoadingText('Chargement des traitements');
     if (stats.treatments > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des traitements');
       async function loadTreatments(page = 0) {
         const res = await API.get({ path: '/treatment', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setTreatments((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadTreatments(page + 1);
+        setTreatments((items) => mergeItems(items, newItems));
         return true;
       }
       const treatmentsSuccess = await loadTreatments(0);
       if (!treatmentsSuccess) return false;
     }
-    setLoadingText('Chargement des fichiers médicaux');
     if (stats.medicalFiles > 0) {
+      let newItems = [];
+      setLoadingText('Chargement des fichiers médicaux');
       async function loadMedicalFiles(page = 0) {
         const res = await API.get({ path: '/medical-file', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
-        setMedicalFiles((items) => mergeItems(items, res.decryptedData));
+        newItems.push(...res.decryptedData);
         if (res.hasMore) return loadMedicalFiles(page + 1);
+        setMedicalFiles((items) => mergeItems(items, newItems));
         return true;
       }
       const medicalFilesSuccess = await loadMedicalFiles(0);

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -52,6 +52,8 @@ export default function DataLoader() {
   const progress = useRecoilValue(progressState);
   const total = useRecoilValue(totalState);
 
+  console.log(loadingText, 'progress', progress, 'total', total, '%', progress / total);
+
   if (!isLoading) return <RandomPicturePreloader />;
   if (!total && !fullScreen) return null;
 
@@ -163,23 +165,26 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       stats.comments +
       stats.groups;
 
+    console.log('stats', stats, 'itemsCount', itemsCount);
+
     setProgress(0);
     setTotal(itemsCount);
 
     const query = {
       organisation: organisationId,
-      limit: String(10000),
+      limit: String(1000),
       after: lastLoadValue,
       withDeleted: Boolean(lastLoadValue),
     };
 
+    setLoadingText('Chargement des personnes');
+    const cachedPersons = await getCacheItemDefaultValue('person', []);
+    setPersons([...cachedPersons]);
     if (stats.persons > 0) {
-      setLoadingText('Chargement des personnes');
-      const cachedPersons = await getCacheItemDefaultValue('person', []);
-      setPersons([...cachedPersons]);
       async function loadPersons(page = 0) {
         const res = await API.get({ path: '/person', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
+        console.log('Persons', page, res.data.length);
         setProgress((p) => p + res.data.length);
         setPersons((items) => mergeItems(items, res.decryptedData));
         if (res.hasMore) return loadPersons(page + 1);
@@ -188,10 +193,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const personSuccess = await loadPersons(0);
       if (!personSuccess) return false;
     }
+    setLoadingText('Chargement des familles');
+    const cachedGroups = await getCacheItemDefaultValue('group', []);
+    setGroups([...cachedGroups]);
     if (stats.groups > 0) {
-      setLoadingText('Chargement des familles');
-      const cachedGroups = await getCacheItemDefaultValue('group', []);
-      setGroups([...cachedGroups]);
       async function loadGroups(page = 0) {
         const res = await API.get({ path: '/group', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -203,10 +208,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const groupsSuccess = await loadGroups(0);
       if (!groupsSuccess) return false;
     }
+    setLoadingText('Chargement des comptes-rendus');
+    const cachedReports = await getCacheItemDefaultValue('report', []);
+    setReports([...cachedReports]);
     if (stats.reports > 0) {
-      setLoadingText('Chargement des comptes-rendus');
-      const cachedReports = await getCacheItemDefaultValue('report', []);
-      setReports([...cachedReports]);
       async function loadReports(page = 0) {
         const res = await API.get({ path: '/report', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -218,10 +223,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const reportsSuccess = await loadReports(0);
       if (!reportsSuccess) return false;
     }
+    setLoadingText('Chargement des passages');
+    const cachedPassages = await getCacheItemDefaultValue('passage', []);
+    setPassages([...cachedPassages]);
     if (stats.passages > 0) {
-      setLoadingText('Chargement des passages');
-      const cachedPassages = await getCacheItemDefaultValue('passage', []);
-      setPassages([...cachedPassages]);
       async function loadPassages(page = 0) {
         const res = await API.get({ path: '/passage', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -233,10 +238,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const passagesSuccess = await loadPassages(0);
       if (!passagesSuccess) return false;
     }
+    setLoadingText('Chargement des rencontres');
+    const cachedRencontres = await getCacheItemDefaultValue('rencontre', []);
+    setRencontres([...cachedRencontres]);
     if (stats.rencontres > 0) {
-      setLoadingText('Chargement des rencontres');
-      const cachedRencontres = await getCacheItemDefaultValue('rencontre', []);
-      setRencontres([...cachedRencontres]);
       async function loadRencontres(page = 0) {
         const res = await API.get({ path: '/rencontre', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -248,10 +253,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const rencontresSuccess = await loadRencontres(0);
       if (!rencontresSuccess) return false;
     }
+    setLoadingText('Chargement des actions');
+    const cachedActions = await getCacheItemDefaultValue('action', []);
+    setActions([...cachedActions]);
     if (stats.actions > 0) {
-      setLoadingText('Chargement des actions');
-      const cachedActions = await getCacheItemDefaultValue('action', []);
-      setActions([...cachedActions]);
       async function loadActions(page = 0) {
         const res = await API.get({ path: '/action', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -263,10 +268,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const actionsSuccess = await loadActions(0);
       if (!actionsSuccess) return false;
     }
+    setLoadingText('Chargement des territoires');
+    const cachedTerritories = await getCacheItemDefaultValue('territory', []);
+    setTerritories([...cachedTerritories]);
     if (stats.territories > 0) {
-      setLoadingText('Chargement des territoires');
-      const cachedTerritories = await getCacheItemDefaultValue('territory', []);
-      setTerritories([...cachedTerritories]);
       async function loadTerritories(page = 0) {
         const res = await API.get({ path: '/territory', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -278,10 +283,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const territoriesSuccess = await loadTerritories(0);
       if (!territoriesSuccess) return false;
     }
+    setLoadingText('Chargement des lieux');
+    const cachedPlaces = await getCacheItemDefaultValue('place', []);
+    setPlaces([...cachedPlaces]);
     if (stats.places > 0) {
-      setLoadingText('Chargement des lieux');
-      const cachedPlaces = await getCacheItemDefaultValue('place', []);
-      setPlaces([...cachedPlaces]);
       async function loadPlaces(page = 0) {
         const res = await API.get({ path: '/place', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -293,10 +298,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const placesSuccess = await loadPlaces(0);
       if (!placesSuccess) return false;
     }
+    setLoadingText('Chargement des relations personne-lieu');
+    const cachedRelPersonPlace = await getCacheItemDefaultValue('relPersonPlace', []);
+    setRelsPersonPlace([...cachedRelPersonPlace]);
     if (stats.relsPersonPlace > 0) {
-      setLoadingText('Chargement des relations personne-lieu');
-      const cachedRelPersonPlace = await getCacheItemDefaultValue('relPersonPlace', []);
-      setRelsPersonPlace([...cachedRelPersonPlace]);
       async function loadRelPersonPlaces(page = 0) {
         const res = await API.get({ path: '/relPersonPlace', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -308,10 +313,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const relsPersonPlacesSuccess = await loadRelPersonPlaces(0);
       if (!relsPersonPlacesSuccess) return false;
     }
+    setLoadingText('Chargement des observations de territoire');
+    const cachedObservations = await getCacheItemDefaultValue('territory-observation', []);
+    setTerritoryObservations([...cachedObservations]);
     if (stats.territoryObservations > 0) {
-      setLoadingText('Chargement des observations de territoire');
-      const cachedObservations = await getCacheItemDefaultValue('territory-observation', []);
-      setTerritoryObservations([...cachedObservations]);
       async function loadObservations(page = 0) {
         const res = await API.get({ path: '/territory-observation', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -323,10 +328,10 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const territoryObservationsSuccess = await loadObservations(0);
       if (!territoryObservationsSuccess) return false;
     }
+    setLoadingText('Chargement des commentaires');
+    const cachedComments = await getCacheItemDefaultValue('comment', []);
+    setComments([...cachedComments]);
     if (stats.comments > 0) {
-      setLoadingText('Chargement des commentaires');
-      const cachedComments = await getCacheItemDefaultValue('comment', []);
-      setComments([...cachedComments]);
       async function loadComments(page = 0) {
         const res = await API.get({ path: '/comment', query: { ...query, page: String(page) } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -338,8 +343,8 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const commentsSuccess = await loadComments(0);
       if (!commentsSuccess) return false;
     }
+    setLoadingText('Chargement des consultations');
     if (stats.consultations > 0) {
-      setLoadingText('Chargement des consultations');
       async function loadConsultations(page = 0) {
         const res = await API.get({ path: '/consultation', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -351,8 +356,8 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const consultationsSuccess = await loadConsultations(0);
       if (!consultationsSuccess) return false;
     }
+    setLoadingText('Chargement des traitements');
     if (stats.treatments > 0) {
-      setLoadingText('Chargement des traitements');
       async function loadTreatments(page = 0) {
         const res = await API.get({ path: '/treatment', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();
@@ -364,8 +369,8 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       const treatmentsSuccess = await loadTreatments(0);
       if (!treatmentsSuccess) return false;
     }
+    setLoadingText('Chargement des fichiers médicaux');
     if (stats.medicalFiles > 0) {
-      setLoadingText('Chargement des fichiers médicaux');
       async function loadMedicalFiles(page = 0) {
         const res = await API.get({ path: '/medical-file', query: { ...query, page: String(page), after: initialLoad ? 0 : lastLoadValue } });
         if (!res.ok || !res.data.length) return resetLoaderOnError();

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -212,7 +212,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des personnes');
       async function loadPersons(page = 0) {
         const res = await API.get({ path: '/person', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPersons(page + 1);
@@ -227,7 +227,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des familles');
       async function loadGroups(page = 0) {
         const res = await API.get({ path: '/group', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadGroups(page + 1);
@@ -242,7 +242,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des comptes-rendus');
       async function loadReports(page = 0) {
         const res = await API.get({ path: '/report', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadReports(page + 1);
@@ -257,7 +257,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des passages');
       async function loadPassages(page = 0) {
         const res = await API.get({ path: '/passage', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPassages(page + 1);
@@ -272,7 +272,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des rencontres');
       async function loadRencontres(page = 0) {
         const res = await API.get({ path: '/rencontre', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadRencontres(page + 1);
@@ -287,7 +287,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des actions');
       async function loadActions(page = 0) {
         const res = await API.get({ path: '/action', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadActions(page + 1);
@@ -302,7 +302,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des territoires');
       async function loadTerritories(page = 0) {
         const res = await API.get({ path: '/territory', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadTerritories(page + 1);
@@ -317,7 +317,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des lieux');
       async function loadPlaces(page = 0) {
         const res = await API.get({ path: '/place', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadPlaces(page + 1);
@@ -332,7 +332,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des relations personne-lieu');
       async function loadRelPersonPlaces(page = 0) {
         const res = await API.get({ path: '/relPersonPlace', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadRelPersonPlaces(page + 1);
@@ -347,7 +347,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des observations de territoire');
       async function loadObservations(page = 0) {
         const res = await API.get({ path: '/territory-observation', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadObservations(page + 1);
@@ -362,7 +362,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des commentaires');
       async function loadComments(page = 0) {
         const res = await API.get({ path: '/comment', query: { ...query, page: String(page) } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadComments(page + 1);
@@ -380,7 +380,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
           path: '/consultation',
           query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue },
         });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadConsultations(page + 1);
@@ -395,7 +395,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
       setLoadingText('Chargement des traitements');
       async function loadTreatments(page = 0) {
         const res = await API.get({ path: '/treatment', query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue } });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadTreatments(page + 1);
@@ -413,7 +413,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
           path: '/medical-file',
           query: { ...query, page: String(page), after: isStartingInitialLoad ? 0 : lastLoadValue },
         });
-        if (!res.ok || !res.data.length) return resetLoaderOnError();
+        if (!res.ok) return resetLoaderOnError();
         setProgress((p) => p + res.data.length);
         newItems.push(...res.decryptedData);
         if (res.hasMore) return loadMedicalFiles(page + 1);

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -156,7 +156,8 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     setOrganisation(latestOrganisation);
     setUser(latestUser);
     if (isStartingInitialLoad) {
-      await migrateData(latestOrganisation);
+      const migrationIsSuccessful = await migrateData(latestOrganisation);
+      if (!migrationIsSuccessful) return resetLoaderOnError();
     }
 
     const statsResponse = await API.get({

--- a/dashboard/src/components/DataLoader.js
+++ b/dashboard/src/components/DataLoader.js
@@ -58,8 +58,6 @@ export default function DataLoader() {
   const progress = useRecoilValue(progressState);
   const total = useRecoilValue(totalState);
 
-  console.log(loadingText, 'progress', progress, 'total', total, '%', progress / total);
-
   if (!isLoading) return <RandomPicturePreloader />;
   if (!total && !fullScreen) return null;
 
@@ -158,7 +156,7 @@ export function useDataLoader(options = { refreshOnMount: false }) {
     setOrganisation(latestOrganisation);
     setUser(latestUser);
     if (isStartingInitialLoad) {
-      await migrateData();
+      await migrateData(latestOrganisation);
     }
 
     const statsResponse = await API.get({

--- a/dashboard/src/components/DataMigrator.js
+++ b/dashboard/src/components/DataMigrator.js
@@ -1,4 +1,4 @@
-import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
 import { mappedIdsToLabels, prepareActionForEncryption } from '../recoil/actions';
 import { organisationState, userState } from '../recoil/auth';
 import { usePreparePersonForEncryption } from '../recoil/persons';
@@ -17,16 +17,15 @@ const LOADING_TEXT = 'Mise à jour des données de votre organisation…';
 export default function useDataMigrator() {
   const setLoadingText = useSetRecoilState(loadingTextState);
   const user = useRecoilValue(userState);
-  const [organisation, setOrganisation] = useRecoilState(organisationState);
-
-  const organisationId = organisation?._id;
+  const setOrganisation = useSetRecoilState(organisationState);
 
   const preparePersonForEncryption = usePreparePersonForEncryption();
 
   return {
     // One "if" for each migration.
     // `migrationLastUpdateAt` should be set after each migration and send in every PUT/POST/PATCH request to server.
-    migrateData: async () => {
+    migrateData: async (organisation) => {
+      const organisationId = organisation?._id;
       let migrationLastUpdateAt = organisation.migrationLastUpdateAt;
       /*
       // Example of migration:

--- a/dashboard/src/components/DataMigrator.js
+++ b/dashboard/src/components/DataMigrator.js
@@ -49,6 +49,8 @@ export default function useDataMigrator() {
         if (response.ok) {
           setOrganisation(response.organisation);
           migrationLastUpdateAt = response.organisation.migrationLastUpdateAt;
+        else {
+          return false;
         }
       }
       // End of example of migration.
@@ -108,8 +110,11 @@ export default function useDataMigrator() {
         if (response.ok) {
           setOrganisation(response.organisation);
           migrationLastUpdateAt = response.organisation.migrationLastUpdateAt;
+        } else {
+          return false;
         }
       }
+      return true;
     },
   };
 }

--- a/dashboard/src/recoil/actions.js
+++ b/dashboard/src/recoil/actions.js
@@ -1,4 +1,4 @@
-import { setCacheItem } from '../services/dataManagement';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
 import { atom, selector } from 'recoil';
 import { organisationState } from './auth';
 import { looseUuidRegex } from '../utils';
@@ -8,7 +8,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'action';
 export const actionsState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'action/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('action', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/comments.js
+++ b/dashboard/src/recoil/comments.js
@@ -1,5 +1,5 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector } from 'recoil';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -7,7 +7,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'comment';
 export const commentsState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'comment/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('comment', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/groups.ts
+++ b/dashboard/src/recoil/groups.ts
@@ -1,12 +1,18 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom, selectorFamily } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector, selectorFamily } from 'recoil';
 import type { GroupInstance } from '../types/group';
 import type { UUIDV4 } from '../types/uuid';
 
 const collectionName = 'group';
 export const groupsState = atom<GroupInstance[]>({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'group/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('group', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/passages.js
+++ b/dashboard/src/recoil/passages.js
@@ -1,5 +1,5 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector } from 'recoil';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -7,7 +7,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'passage';
 export const passagesState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'passage/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('passage', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/persons.ts
+++ b/dashboard/src/recoil/persons.ts
@@ -1,4 +1,4 @@
-import { setCacheItem } from '../services/dataManagement';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
 import { atom, selector, useRecoilValue } from 'recoil';
 import { organisationState } from './auth';
 import { toast } from 'react-toastify';
@@ -9,7 +9,13 @@ import type { PredefinedField, CustomField } from '../types/field';
 const collectionName = 'person';
 export const personsState = atom<PersonInstance[]>({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'person/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('person', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/places.js
+++ b/dashboard/src/recoil/places.js
@@ -1,5 +1,5 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector } from 'recoil';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -7,7 +7,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'place';
 export const placesState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'place/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('place', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/relPersonPlace.js
+++ b/dashboard/src/recoil/relPersonPlace.js
@@ -1,5 +1,5 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector } from 'recoil';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -7,7 +7,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'relPersonPlace';
 export const relsPersonPlaceState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'relPersonPlace/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('relPersonPlace', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/rencontres.js
+++ b/dashboard/src/recoil/rencontres.js
@@ -1,5 +1,5 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector } from 'recoil';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -7,7 +7,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'rencontre';
 export const rencontresState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'rencontre/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('rencontre', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/reports.js
+++ b/dashboard/src/recoil/reports.js
@@ -1,4 +1,4 @@
-import { setCacheItem } from '../services/dataManagement';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
 import { atom, selector } from 'recoil';
 import { capture } from '../services/sentry';
 import { organisationState } from './auth';
@@ -8,7 +8,13 @@ import { toast } from 'react-toastify';
 const collectionName = 'report';
 export const reportsState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'report/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('report', []);
+      return cache;
+    },
+  }),
   effects: [
     ({ onSet }) =>
       onSet(async (newValue) => {

--- a/dashboard/src/recoil/selectors.js
+++ b/dashboard/src/recoil/selectors.js
@@ -102,6 +102,7 @@ export const itemsGroupedByPersonSelector = selector({
       originalPersonsObject[person._id] = { name: person.name, _id: person._id };
       personsObject[person._id] = {
         ...person,
+        followedSince: person.followedSince || person.createdAt,
         userPopulated: usersObject[person.user],
         formattedBirthDate: formatBirthDate(person.birthdate),
         age: formatAge(person.birthdate),

--- a/dashboard/src/recoil/territory.js
+++ b/dashboard/src/recoil/territory.js
@@ -1,5 +1,5 @@
-import { setCacheItem } from '../services/dataManagement';
-import { atom } from 'recoil';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
+import { atom, selector } from 'recoil';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -7,7 +7,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'territory';
 export const territoriesState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'territory/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('territory', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -1,6 +1,6 @@
 import { organisationState } from './auth';
 import { atom, selector } from 'recoil';
-import { setCacheItem } from '../services/dataManagement';
+import { getCacheItemDefaultValue, setCacheItem } from '../services/dataManagement';
 import { looseUuidRegex } from '../utils';
 import { toast } from 'react-toastify';
 import { capture } from '../services/sentry';
@@ -8,7 +8,13 @@ import { capture } from '../services/sentry';
 const collectionName = 'territory-observation';
 export const territoryObservationsState = atom({
   key: collectionName,
-  default: [],
+  default: selector({
+    key: 'territory-observation/default',
+    get: async () => {
+      const cache = await getCacheItemDefaultValue('territory-observation', []);
+      return cache;
+    },
+  }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
 

--- a/dashboard/src/scenes/auth/signin.js
+++ b/dashboard/src/scenes/auth/signin.js
@@ -28,7 +28,7 @@ const SignIn = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [loading, setLoading] = useState(true);
   const [authViaCookie, setAuthViaCookie] = useState(false);
-  const { load: runDataLoader, isLoading, resetCache } = useDataLoader();
+  const { startInitialLoad, isLoading, resetCache } = useDataLoader();
   const setToken = useSetRecoilState(authTokenState);
 
   const [signinForm, setSigninForm] = useState({ email: '', password: '', orgEncryptionKey: DEFAULT_ORGANISATION_KEY || '' });
@@ -45,7 +45,7 @@ const SignIn = () => {
     }
   }, [history, organisation, isLoading, isDesktop]);
 
-  const onSigninValidated = async () => runDataLoader();
+  const onSigninValidated = () => startInitialLoad();
 
   const onLogout = async () => {
     await API.logout();

--- a/dashboard/src/scenes/person/Places.js
+++ b/dashboard/src/scenes/person/Places.js
@@ -40,6 +40,11 @@ const PersonPlaces = ({ person }) => {
     return personPlaces.length !== new Set(personPlaces).size;
   }, [person.relsPersonPlace]);
 
+  const sortedPlaces = useMemo(() => {
+    if (!person.relsPersonPlace?.length) return [];
+    return [...person.relsPersonPlace]?.sort((a, b) => new Date(b.createdAt) - new Date(a.createdAt));
+  }, [person.relsPersonPlace]);
+
   return (
     <>
       <div className="tw-my-10 tw-flex tw-items-center tw-gap-2">
@@ -74,7 +79,7 @@ const PersonPlaces = ({ person }) => {
             </tr>
           </thead>
           <tbody className="small">
-            {person.relsPersonPlace?.map((relPersonPlace) => {
+            {sortedPlaces?.map((relPersonPlace) => {
               const { place: placeId, createdAt, user } = relPersonPlace;
               const place = places.find((p) => p._id === placeId);
               return (

--- a/dashboard/src/scenes/report/view.js
+++ b/dashboard/src/scenes/report/view.js
@@ -348,7 +348,8 @@ const View = () => {
             { referenceStartDay: dateString, referenceEndDay: dateString },
             currentTeam?.nightSession ? 12 : 0
           );
-        }),
+        })
+        .sort((a, b) => new Date(b.observedAt || b.createdAt) - new Date(a.observedAt || a.createdAt)),
     [dateString, selectedTeamsObject, territoryObservations]
   );
 

--- a/dashboard/src/scenes/territory-observations/list.js
+++ b/dashboard/src/scenes/territory-observations/list.js
@@ -15,7 +15,13 @@ const List = ({ territory = {} }) => {
   const [observation, setObservation] = useState({});
   const [openObservationModale, setOpenObservationModale] = useState(null);
 
-  const observations = useMemo(() => territoryObservations.filter((obs) => obs.territory === territory._id), [territory._id, territoryObservations]);
+  const observations = useMemo(
+    () =>
+      territoryObservations
+        .filter((obs) => obs.territory === territory._id)
+        .sort((a, b) => new Date(b.observedAt || b.createdAt) - new Date(a.observedAt || a.createdAt)),
+    [territory._id, territoryObservations]
+  );
 
   if (!observations) return null;
 

--- a/e2e/activate_passages_rencontres.spec.ts
+++ b/e2e/activate_passages_rencontres.spec.ts
@@ -78,7 +78,7 @@ test("test", async ({ page }) => {
 
   await page.getByRole("link", { name: "Statistiques" }).click();
   await page.getByRole("button", { name: "Passages" }).click();
-  await expect(page.getByText("Nombre de passages ?Non-anonyme375%Anonyme125%Total4100%Non-anonymeAnonyme3 (75%")).toBeVisible();
+  await expect(page.getByText("Nombre de passages ?Non-anonyme375%Anonyme125%Total4100%AnonymeNon-anonyme1 (25%")).toBeVisible();
 
   await expect(page.getByRole("button", { name: "Rencontres" })).not.toBeVisible();
 


### PR DESCRIPTION
proposition:

### cache

Le dataloader ne gère pas le cache: c'est géré par Recoil à 100%, avec une valeur par défault `async` et un effect `onSet`. Ainsi, le dataloader ne gère que les states recoil.

Exemple: 
```js
export const territoriesState = atom({
   key:'territory',
   default: selector({
     key: 'territory/default',
     get: async () => {
       const cache = await getCacheItemDefaultValue('territory', []);
       return cache;
     },
   }),
   effects: [({ onSet }) => onSet(async (newValue) => setCacheItem(collectionName, newValue))],
 });
```


### téléchargement des batchs de données

un exemple est plus parlant, reproduit pour chaque table

```js
      let newItems = [];
      setLoadingText('Chargement des personnes');
      async function loadPersons(page = 0) {
        const res = await API.get({ path: '/person', query: { ...query, page: String(page) } });
        if (!res.ok || !res.data.length) return resetLoaderOnError();
        setProgress((p) => p + res.data.length);
        newItems.push(...res.decryptedData);
        if (res.hasMore) return loadPersons(page + 1);
        setPersons(mergeItems(persons, newItems));
        return true;
      }
      const personSuccess = await loadPersons(0);
      if (!personSuccess) return false;
```

avantage niveau performances
- on appelle une seule fois par table `mergeItems`
- on appelle une seule fois par table le recoil setter

### mois de bugs ?

je ne sais pas...
il faudrait imaginer pourquoi parfois on a des problèmes de cache avec le loader actuel, qu'on arrive jamais à reproduire de notre côté.
- j'ai imaginé que la requête `/organisation/stats` pouvait parfois être trop longue, qui fait que pendant cette requête, des données sont créées qui ne seront jamais prises en compte -> j'ai bougé `API.get({ path: '/now' });` après cette requête de stats, ce qui fait que le risque est un peu diminué ?
- j'ai modifié le `withDeleted` parce que je n'ai pas compris pourquoi on voulait les éléments supprimés SEULEMENT si le `lastRefresh > 0`. C'est moi qui ait mis ça au début, mais là je ne comprends pas la logique, donc j'ai mis `withDeleted: true` tout le temps.
- je n'ai pas d'autre explication


voilà, à part ça je ne vois pas grand chose d'autre à rajouter pour l'instant.

ouvert aux critiques/remarques/améliorations/etc. !