### PR TITLE
chore: deactivate playwright on merge

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,8 +1,8 @@
 name: Playwright Tests
 on:
-  push:
-    branches: [main]
-    tags-ignore: [v*]
+  # push:
+  #   branches: [main]
+  #   tags-ignore: [v*]
   pull_request:
     branches: [main]
 jobs:


### PR DESCRIPTION
pourquoi ?
- parce que les tests ne sont pas bloquants quand on déploie en prod de toutes façons
- parce que les tests nous intéressent surtout quand on fait une PR
- parce que quand on pousse directement sur `main`, dans les faits on s'en fiche des tests puisque c'est un hotfix qu'on veut être déployé avec ou sans tests
- parce que quand j'ai besoin d'envoyer un truc rapidement en prod comme il y a deux minutes, j'annule le workflow parce qu'il m'ennuie dans ce cas précis
- parce qu'en plus ça fait du bien à la planète de supprimer un truc dont on ne se sert pas

qu'en dis-tu ?
