### PR TITLE
feat: new package name com.androidfabrique

### DIFF
--- a/app/android/app/build.gradle
+++ b/app/android/app/build.gradle
@@ -96,9 +96,9 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
-    namespace "com.mano"
+    namespace "com.manofabrique"
     defaultConfig {
-        applicationId "com.mano"
+        applicationId "com.manofabrique"
         minSdkVersion rootProject.ext.minSdkVersion
         targetSdkVersion rootProject.ext.targetSdkVersion
         multiDexEnabled true

--- a/app/android/app/src/androidTest/AndroidManifest.xml
+++ b/app/android/app/src/androidTest/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools" package="com.mano">
+    xmlns:tools="http://schemas.android.com/tools" package="com.manofabrique">
 
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW"/>
 

--- a/app/android/app/src/androidTest/java/com/manofabrique/DetoxTest.java
+++ b/app/android/app/src/androidTest/java/com/manofabrique/DetoxTest.java
@@ -1,5 +1,5 @@
 // Replace "com.example" here and below with your app's package name from the top of MainActivity.java
-package com.mano;
+package com.manofabrique;
 
 import com.wix.detox.Detox;
 import com.wix.detox.config.DetoxConfig;
@@ -29,7 +29,7 @@ public class DetoxTest {
         DetoxConfig detoxConfig = new DetoxConfig();
         detoxConfig.idlePolicyConfig.masterTimeoutSec = 90;
         detoxConfig.idlePolicyConfig.idleResourceTimeoutSec = 60;
-        detoxConfig.rnContextLoadTimeoutSec = (com.mano.BuildConfig.DEBUG ? 180 : 60);
+        detoxConfig.rnContextLoadTimeoutSec = (com.manofabrique.BuildConfig.DEBUG ? 180 : 60);
 
         Detox.runTests(mActivityRule, detoxConfig);
     }

--- a/app/android/app/src/debug/java/com/manofabrique/ReactNativeFlipper.java
+++ b/app/android/app/src/debug/java/com/manofabrique/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.mano;
+package com.manofabrique;
 
 import android.content.Context;
 import com.facebook.flipper.android.AndroidFlipperClient;

--- a/app/android/app/src/main/java/com/manofabrique/MainActivity.java
+++ b/app/android/app/src/main/java/com/manofabrique/MainActivity.java
@@ -1,4 +1,4 @@
-package com.mano;
+package com.manofabrique;
 
 import com.facebook.react.ReactActivity;
 import com.facebook.react.ReactActivityDelegate;

--- a/app/android/app/src/main/java/com/manofabrique/MainApplication.java
+++ b/app/android/app/src/main/java/com/manofabrique/MainApplication.java
@@ -1,4 +1,4 @@
-package com.mano;
+package com.manofabrique;
 
 import android.app.Application;
 import com.facebook.react.PackageList;

--- a/app/android/app/src/release/java/com/manofabrique/ReactNativeFlipper.java
+++ b/app/android/app/src/release/java/com/manofabrique/ReactNativeFlipper.java
@@ -4,7 +4,7 @@
  * <p>This source code is licensed under the MIT license found in the LICENSE file in the root
  * directory of this source tree.
  */
-package com.mano;
+package com.manofabrique;
 
 import android.content.Context;
 import com.facebook.react.ReactInstanceManager;

--- a/app/app.json
+++ b/app/app.json
@@ -6,7 +6,7 @@
     "buildName": "2.37.5"
   },
   "bundle": {
-    "android": "com.mano",
-    "ios": "com.mano"
+    "android": "com.manofabrique",
+    "ios": "com.manofabrique"
   }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -14,7 +14,7 @@
     "detox-build-and-test": "npm run detox-build && npm run detox-test",
     "android-clean-start": "npm run clean:android && react-native run-android",
     "postinstall": "pod install --project-directory=ios/ && npx jetify",
-    "clean:android": "cd android && ./gradlew clean && cd ../ && adb uninstall com.mano",
+    "clean:android": "cd android && ./gradlew clean && cd ../ && adb uninstall com.manofabrique",
     "build:android": "cd android && ./gradlew clean && ./gradlew bundleRelease && cd ../",
     "build:android-apk": "cd android && ./gradlew clean && ./gradlew assembleRelease && cd ../",
     "build:android-apk-preproduction": "echo -p \"please update either .env.production with the preproduction values until we found a better solution 🥸\" && cd android && ./gradlew clean && ./gradlew assembleRelease && cd ../",

--- a/app/publish-release-to-github.js
+++ b/app/publish-release-to-github.js
@@ -8,7 +8,7 @@ const mobileAppVersion = require('./package.json').version;
 
 const publishAppToLatestTag = async () => {
   const result = await exec(
-    `gh release create m${mobileAppVersion} ./android/app/build/outputs/apk/release/app-release.apk ./app.json --target main`
+    `gh release create manofabrique${mobileAppVersion} ./android/app/build/outputs/apk/release/app-release.apk ./app.json --target main`
   );
 
   if (result.stderr?.length) {
@@ -19,7 +19,7 @@ const publishAppToLatestTag = async () => {
     console.log(chalk.green('Success uploading app:'), chalk.green(result.stdout));
   }
 
-  console.log(chalk.yellow('Transfer completed 😬: https://mano-app.fabrique.social.gouv.fr/download'));
+  console.log(chalk.yellow('Transfer completed 😬: https://mano-app.fabrique.social.gouv.fr/download-com.manofabrique'));
 };
 
 publishAppToLatestTag();


### PR DESCRIPTION
[DISCLAIMER] 
Avec le code présent, qu'il faut rebase sur main à chaque deploy de l'app, on édite une app mano avec l'identifier `com.manofabrique`au lieu de `com.mano`



Problème à résoudre:
> A priori, il y a une autre application sur le Google Play de l’éditeur « Microvelt » qui s’appelle également MANO, ce qui rentre en conflit avec la vôtre.
Il faudrait attribuer à votre MANO, une variante de nom pour éviter ce type de conflit.

Cette application est comme mano: pas sur les stores.
Mais du coup ça clash avec celle-là.

**Donc avec le code présent, qu'il faut rebase sur main à chaque deploy de l'app, on édite une app mano avec l'identifier `com.manofabrique`au lieu de `com.mano`**
