### PR TITLE
fix: format observedAt proprement pour éviter un bug de tri dans les statistiques

### DIFF
--- a/dashboard/src/components/DataMigrator.js
+++ b/dashboard/src/components/DataMigrator.js
@@ -77,9 +77,12 @@ export default function useDataMigrator() {
         }).then((res) => res.decryptedData || []);
 
         const newObservations = observationsRes.map((e) => {
+          const observedAt = !isNaN(Number(e.observedAt)) // i.e. is timestamp
+            ? dayjsInstance(Number(e.observedAt)).toISOString()
+            : dayjsInstance(e.observedAt ?? e.createdAt).toISOString();
           return {
             ...e,
-            observedAt: dayjsInstance(e.observedAt ?? e.createdAt),
+            observedAt,
           };
         });
 

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -22,6 +22,7 @@ export const customFieldsObsSelector = selector({
   key: 'customFieldsObsSelector',
   get: ({ get }) => {
     const organisation = get(organisationState);
+    if (!organisation) return defaultCustomFields;
     if (Array.isArray(organisation.customFieldsObs)) return organisation.customFieldsObs;
     return defaultCustomFields;
   },


### PR DESCRIPTION
j'ai un excerpt des données d'une organisation pour laquelle li y a un bug notoire de statistiques d'observations de territoires (https://trello.com/c/8zAAkkVg)
il se trouve que certaines observations ont un timestamp en guise de valeur de `observedAt`, d'autre rien du tout, d'autre une date ISO
c'est probable que le bug soit lié à ce problème

j'ai essayé rapidement de reproduire le problème, je n'ai pas réussi - je n'ai pas le temps de me pencher plus sur l'historique git ou quoique ce soit, donc j'abandonne

en revanche je suis optimiste pour la résolution du bug des stats