### PR TITLE
fix: observations metadata

### DIFF
--- a/api/src/controllers/migration.js
+++ b/api/src/controllers/migration.js
@@ -89,7 +89,7 @@ router.put(
         }
         // End of example of migration.
         */
-        if (req.params.migrationName === "reformat-observedAt-observations") {
+        if (req.params.migrationName === "reformat-observedAt-observations-fixed") {
           try {
             z.array(
               z.object({

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -22,13 +22,12 @@ export const customFieldsObsSelector = selector({
   key: 'customFieldsObsSelector',
   get: ({ get }) => {
     const organisation = get(organisationState);
-    if (!organisation) return defaultCustomFields;
     if (Array.isArray(organisation.customFieldsObs)) return organisation.customFieldsObs;
     return defaultCustomFields;
   },
 });
 
-const defaultCustomFields = [
+export const defaultCustomFields = [
   {
     name: 'personsMale',
     label: 'Nombre de personnes non connues hommes rencontrées',

--- a/dashboard/src/scenes/auth/signin.js
+++ b/dashboard/src/scenes/auth/signin.js
@@ -69,6 +69,7 @@ const SignIn = () => {
         window.localStorage.setItem('mano-organisationId', organisation._id);
         setOrganisation(organisation);
         setUserName(user.name);
+        setUser(user);
         if (!!organisation.encryptionEnabled && !['superadmin'].includes(user.role)) setShowEncryption(true);
       }
 
@@ -108,6 +109,8 @@ const SignIn = () => {
       if (organisation._id !== window.localStorage.getItem('mano-organisationId')) {
         await resetCache();
       }
+      setOrganisation(organisation);
+      setUser(user);
       if (!!organisation.encryptionEnabled && !showEncryption && !['superadmin'].includes(user.role)) {
         setShowEncryption(true);
         return setIsSubmitting(false);
@@ -115,12 +118,10 @@ const SignIn = () => {
       if (token) setToken(token);
       setSessionInitialTimestamp(Date.now());
       window.localStorage.setItem('mano-organisationId', organisation._id);
-      setOrganisation(organisation);
       if (!['superadmin'].includes(user.role) && !!signinForm.orgEncryptionKey) {
         const encryptionIsValid = await setOrgEncryptionKey(signinForm.orgEncryptionKey.trim(), organisation);
         if (!encryptionIsValid) return setIsSubmitting(false);
       }
-      setUser(user);
       // now login !
       // superadmin
       if (['superadmin'].includes(user.role)) {


### PR DESCRIPTION
PR "intéressante"parce qu'elle fait suite à un gros bug semaine dernière.

Contexte: j'avais fait une migration sur les observations de territoire parce que j'avais remarqué que certaines n'avaient pas de `observedAt`, d'autrews avaient un timestamp au lieu d'une date ISO, etc. donc pour harmoniser le tout, j'avais fait une migration... qui a foutu un sacré bazar: toutes les données custos avaient disparues !

j'ai compris pourquoi: c'est à cause de ce fichu `batch state` de react (https://react.dev/learn/queueing-a-series-of-state-updates#react-batches-state-updates)

qui faisait qu'au moment d'appeler [`const customFieldsObs = useRecoilValue(customFieldsObsSelector);`](https://github.com/SocialGouv/mano/blob/933ac50b070afd27ed6dbe7c39dcc3dd27755c89/dashboard/src/components/DataMigrator.js#L32), l'organisation n'était pas encore dans le state recoil (PS: aucun rapport mais avec zustand on n'aurait pas ce problème je pense)

cette PR fixe le problème et relance la migration, avec laquelle j'espère sans trop savoir pourquoi résoudre le problème de stats https://trello.com/c/8zAAkkVg/1308-bug-ema-emos-statistiques-dobservations-qui-matchent-pas

n'empêche que ça fait mal au cerveau