### PR TITLE
fix: retire les données potentiellement sensibles de sentry

### DIFF
--- a/api/src/controllers/organisation.js
+++ b/api/src/controllers/organisation.js
@@ -27,7 +27,6 @@ const {
 const mailservice = require("../utils/mailservice");
 const validateUser = require("../middleware/validateUser");
 const { looseUuidRegex, customFieldSchema, positiveIntegerRegex } = require("../utils");
-const { capture } = require("../sentry");
 const { serializeOrganisation } = require("../utils/data-serializer");
 const { defaultSocialCustomFields, defaultMedicalCustomFields } = require("../utils/custom-fields/person");
 const { mailBienvenueHtml } = require("../utils/mail-bienvenue");

--- a/api/src/utils/mailservice.js
+++ b/api/src/utils/mailservice.js
@@ -33,7 +33,7 @@ const sendEmail = async (address, subject, text, html) => {
     }),
   });
   if (!emailSentResponse.ok) {
-    capture(new Error("Email not sent"), { extra: { address, subject, text, response: emailSentResponse } });
+    capture(new Error("Email not sent"), { extra: { address, subject, response: emailSentResponse } });
   }
   return emailSentResponse;
 };

--- a/app/src/recoil/actions.js
+++ b/app/src/recoil/actions.js
@@ -76,7 +76,7 @@ export const prepareActionForEncryption = (action) => {
       "L'action n'a pas été sauvegardée car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { action } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/auth.js
+++ b/app/src/recoil/auth.js
@@ -4,7 +4,15 @@ import { atom } from 'recoil';
 export const userState = atom({
   key: 'userState',
   default: null,
-  effects: [({ onSet }) => onSet((user) => Sentry.setUser(user))],
+  effects: [
+    ({ onSet }) =>
+      onSet((user) =>
+        Sentry.setUser({
+          id: user?._id,
+          email: user?.email,
+        })
+      ),
+  ],
 });
 
 export const organisationState = atom({
@@ -26,5 +34,5 @@ export const usersState = atom({
 export const currentTeamState = atom({
   key: 'currentTeamState',
   default: null,
-  effects: [({ onSet }) => onSet((currentTeam) => Sentry.setContext('currentTeam', currentTeam))],
+  effects: [({ onSet }) => onSet((currentTeam) => Sentry.setTag('currentTeam', currentTeam?._id ?? ''))],
 });

--- a/app/src/recoil/comments.js
+++ b/app/src/recoil/comments.js
@@ -28,7 +28,7 @@ export const prepareCommentForEncryption = (comment) => {
       "Le commentaire n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { comment } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/consultations.js
+++ b/app/src/recoil/consultations.js
@@ -76,7 +76,7 @@ export const prepareConsultationForEncryption = (customFieldsConsultations) => (
       "La consultation n'a pas été sauvegardée car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { consultation } });
+    capture(error);
     throw error;
   }
   const consultationTypeCustomFields = customFieldsConsultations.find((consult) => consult.name === consultation.type)?.fields || [];

--- a/app/src/recoil/medicalFiles.js
+++ b/app/src/recoil/medicalFiles.js
@@ -30,7 +30,7 @@ export const prepareMedicalFileForEncryption = (customFieldsMedicalFile) => (med
       "Le dossier médical n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { medicalFile } });
+    capture(error);
     throw error;
   }
   const encryptedFieldsIncludingCustom = [...customFieldsMedicalFile.map((f) => f.name), ...encryptedFields];

--- a/app/src/recoil/passages.js
+++ b/app/src/recoil/passages.js
@@ -29,7 +29,7 @@ export const preparePassageForEncryption = (passage) => {
       "Le passage n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { passage } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/persons.js
+++ b/app/src/recoil/persons.js
@@ -116,7 +116,7 @@ export const usePreparePersonForEncryption = () => {
         "La personne n'a pas été sauvegardée car son format était incorrect.",
         "Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { person } });
+      capture(error);
       throw error;
     }
     const encryptedFields = personFields.filter((f) => f.encrypted).map((f) => f.name);

--- a/app/src/recoil/places.js
+++ b/app/src/recoil/places.js
@@ -25,7 +25,7 @@ export const preparePlaceForEncryption = (place) => {
       "Le lieu n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { place } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/relPersonPlace.js
+++ b/app/src/recoil/relPersonPlace.js
@@ -28,7 +28,7 @@ export const prepareRelPersonPlaceForEncryption = (relPersonPlace) => {
       "La relation entre le lieu et la personne n'a pas été sauvegardée car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { relPersonPlace } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/rencontres.js
+++ b/app/src/recoil/rencontres.js
@@ -31,7 +31,7 @@ export const prepareRencontreForEncryption = (rencontre) => {
       "La rencontre n'a pas été sauvegardée car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { rencontre } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/reports.js
+++ b/app/src/recoil/reports.js
@@ -43,7 +43,7 @@ export const prepareReportForEncryption = (report) => {
       "Le compte-rendu n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { report } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/territory.js
+++ b/app/src/recoil/territory.js
@@ -25,7 +25,7 @@ export const prepareTerritoryForEncryption = (territory) => {
       "Le territoire n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { territory } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/recoil/territoryObservations.js
+++ b/app/src/recoil/territoryObservations.js
@@ -101,7 +101,7 @@ export const prepareObsForEncryption = (customFields) => (obs) => {
       "L'observation n'a pas été sauvegardée car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { obs } });
+    capture(error);
     throw error;
   }
   const encryptedFields = [...customFields.map((f) => f.name), ...compulsoryEncryptedFields];

--- a/app/src/recoil/treatments.js
+++ b/app/src/recoil/treatments.js
@@ -33,7 +33,7 @@ export const prepareTreatmentForEncryption = (treatment) => {
       "Le traitement n'a pas été sauvegardé car son format était incorrect.",
       "Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
     );
-    capture(error, { extra: { treatment } });
+    capture(error);
     throw error;
   }
   const decrypted = {};

--- a/app/src/scenes/Actions/Action.js
+++ b/app/src/scenes/Actions/Action.js
@@ -232,7 +232,7 @@ const Action = ({ navigation, route }) => {
       if (!!newAction.completedAt) await createReportAtDateIfNotExist(newAction.completedAt);
       return response;
     } catch (error) {
-      capture(error, { extra: { message: 'error in updating action', action } });
+      capture(error, { extra: { message: 'error in updating action' } });
       return { ok: false, error: error.message };
     }
   };

--- a/dashboard/src/components/CommentsGeneric.js
+++ b/dashboard/src/components/CommentsGeneric.js
@@ -13,7 +13,6 @@ import { FullScreenIcon } from '../assets/icons/FullScreenIcon';
 import DatePicker from './DatePicker';
 import { outOfBoundariesDate } from '../services/date';
 import AutoResizeTextarea from './AutoresizeTextArea';
-import { capture } from '../services/sentry';
 import UserName from './UserName';
 import CustomFieldDisplay from './CustomFieldDisplay';
 
@@ -229,14 +228,6 @@ function CommentsTable({ comments, onDisplayComment, onEditComment, onAddComment
         <tbody className="small">
           {(comments || []).map((comment, i) => {
             if (!comment.type) throw new Error('type is required');
-            if (comment.type === 'person' && !comment.person) {
-              capture(new Error('person is required'), { extra: { comment } });
-              return null;
-            }
-            if (comment.type === 'action' && !comment.action) {
-              capture(new Error('action is required'), { extra: { comment } });
-              return null;
-            }
             return (
               <tr key={comment._id} className={[`tw-bg-${color} tw-w-full`, i % 2 ? 'tw-bg-opacity-0' : 'tw-bg-opacity-5'].join(' ')}>
                 <td
@@ -298,38 +289,34 @@ function CommentsTable({ comments, onDisplayComment, onEditComment, onAddComment
                           className="tw-ml-auto tw-block"
                           onClick={(e) => {
                             e.stopPropagation();
-                            try {
-                              const searchParams = new URLSearchParams(location.search);
-                              switch (comment.type) {
-                                case 'action':
-                                  searchParams.set('actionId', comment.action);
-                                  history.push(`?${searchParams.toString()}`);
-                                  break;
-                                case 'person':
-                                  history.push(`/person/${comment.person}`);
-                                  break;
-                                case 'passage':
-                                  history.push(`/person/${comment.person}?passageId=${comment.passage}`);
-                                  break;
-                                case 'rencontre':
-                                  history.push(`/person/${comment.person}?rencontreId=${comment.rencontre}`);
-                                  break;
-                                case 'consultation':
-                                  searchParams.set('consultationId', comment.consultation._id);
-                                  history.push(`?${searchParams.toString()}`);
-                                  break;
-                                case 'treatment':
-                                  searchParams.set('treatmentId', comment.treatment._id);
-                                  history.push(`?${searchParams.toString()}`);
-                                  break;
-                                case 'medical-file':
-                                  history.push(`/person/${comment.person}?tab=Dossier+Médical`);
-                                  break;
-                                default:
-                                  break;
-                              }
-                            } catch (errorLoadingComment) {
-                              capture(errorLoadingComment, { extra: { message: 'error loading comment tag button', comment } });
+                            const searchParams = new URLSearchParams(location.search);
+                            switch (comment.type) {
+                              case 'action':
+                                searchParams.set('actionId', comment.action);
+                                history.push(`?${searchParams.toString()}`);
+                                break;
+                              case 'person':
+                                history.push(`/person/${comment.person}`);
+                                break;
+                              case 'passage':
+                                history.push(`/person/${comment.person}?passageId=${comment.passage}`);
+                                break;
+                              case 'rencontre':
+                                history.push(`/person/${comment.person}?rencontreId=${comment.rencontre}`);
+                                break;
+                              case 'consultation':
+                                searchParams.set('consultationId', comment.consultation._id);
+                                history.push(`?${searchParams.toString()}`);
+                                break;
+                              case 'treatment':
+                                searchParams.set('treatmentId', comment.treatment._id);
+                                history.push(`?${searchParams.toString()}`);
+                                break;
+                              case 'medical-file':
+                                history.push(`/person/${comment.person}?tab=Dossier+Médical`);
+                                break;
+                              default:
+                                break;
                             }
                           }}>
                           <div className="tw-rounded tw-border tw-border-blue-900 tw-bg-blue-900/10 tw-px-1">

--- a/dashboard/src/components/DocumentsGeneric.tsx
+++ b/dashboard/src/components/DocumentsGeneric.tsx
@@ -469,7 +469,7 @@ function AddDocumentInput({ personId, onAddDocuments }: AddDocumentInputProps) {
             file: fileToUpload,
           });
           if (!docResponse.ok || !docResponse.data) {
-            capture('Error uploading document', { extra: { docResponse } });
+            capture('Error uploading document', { extra: { docResponseError: docResponse.error } });
             toast.error(`Une erreur est survenue lors de l'envoi du document ${fileToUpload?.filename}`);
             return;
           }

--- a/dashboard/src/recoil/actions.js
+++ b/dashboard/src/recoil/actions.js
@@ -83,7 +83,7 @@ export const prepareActionForEncryption = (action, { checkRequiredFields = true 
       toast.error(
         "L'action n'a pas été sauvegardée car son format était incorrect. Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { action } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/auth.ts
+++ b/dashboard/src/recoil/auth.ts
@@ -7,7 +7,15 @@ import type { TeamInstance } from '../types/team';
 export const userState = atom<UserInstance | null>({
   key: 'userState',
   default: null,
-  effects: [({ onSet }) => onSet((user) => AppSentry.setUser(user))],
+  effects: [
+    ({ onSet }) =>
+      onSet((user) =>
+        AppSentry.setUser({
+          id: user?._id,
+          email: user?.email,
+        })
+      ),
+  ],
 });
 
 export const userAuthentifiedState = selector<UserInstance>({
@@ -52,6 +60,7 @@ export const usersState = atom<UserInstance[]>({
 export const currentTeamState = atom<TeamInstance | null>({
   key: 'currentTeamState',
   default: null,
+  effects: [({ onSet }) => onSet((currentTeam) => AppSentry.setTag('currentTeam', currentTeam?._id ?? ''))],
 });
 
 export const currentTeamAuthentifiedState = selector<TeamInstance>({

--- a/dashboard/src/recoil/comments.js
+++ b/dashboard/src/recoil/comments.js
@@ -35,7 +35,7 @@ export const prepareCommentForEncryption = (comment, { checkRequiredFields = tru
       toast.error(
         "Le commentaire n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { comment } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/consultations.ts
+++ b/dashboard/src/recoil/consultations.ts
@@ -82,7 +82,7 @@ export const prepareConsultationForEncryption =
         toast.error(
           "La consultation n'a pas été sauvegardée car son format était incorrect. Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
         );
-        capture(error, { extra: { consultation } });
+        capture(error);
         throw error;
       }
     }

--- a/dashboard/src/recoil/medicalFiles.ts
+++ b/dashboard/src/recoil/medicalFiles.ts
@@ -35,7 +35,7 @@ export const prepareMedicalFileForEncryption =
         toast.error(
           "Le dossier médical n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
         );
-        capture(error, { extra: { medicalFile } });
+        capture(error);
         throw error;
       }
     }

--- a/dashboard/src/recoil/passages.js
+++ b/dashboard/src/recoil/passages.js
@@ -36,7 +36,7 @@ export const preparePassageForEncryption = (passage, { checkRequiredFields = tru
       toast.error(
         "Le passage n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { passage } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/persons.ts
+++ b/dashboard/src/recoil/persons.ts
@@ -149,7 +149,7 @@ export const usePreparePersonForEncryption = () => {
         toast.error(
           "La personne n'a pas été sauvegardée car son format était incorrect. Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
         );
-        capture(error, { extra: { person } });
+        capture(error);
         throw error;
       }
     }

--- a/dashboard/src/recoil/places.js
+++ b/dashboard/src/recoil/places.js
@@ -32,7 +32,7 @@ export const preparePlaceForEncryption = (place, { checkRequiredFields = true } 
       toast.error(
         "Le lieu n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { place } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/relPersonPlace.js
+++ b/dashboard/src/recoil/relPersonPlace.js
@@ -35,7 +35,7 @@ export const prepareRelPersonPlaceForEncryption = (relPersonPlace, { checkRequir
       toast.error(
         "Le lieu n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { relPersonPlace } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/rencontres.js
+++ b/dashboard/src/recoil/rencontres.js
@@ -38,7 +38,7 @@ export const prepareRencontreForEncryption = (rencontre, { checkRequiredFields =
       toast.error(
         "La rencontre n'a pas été sauvegardée car son format était incorrect. Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { rencontre } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/reports.js
+++ b/dashboard/src/recoil/reports.js
@@ -84,7 +84,7 @@ export const prepareReportForEncryption = (report, { checkRequiredFields = true 
       toast.error(
         "Le compte-rendu n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { report } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/territory.js
+++ b/dashboard/src/recoil/territory.js
@@ -32,7 +32,7 @@ export const prepareTerritoryForEncryption = (territory, { checkRequiredFields =
       toast.error(
         "Le territoire n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { territory } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/recoil/territoryObservations.js
+++ b/dashboard/src/recoil/territoryObservations.js
@@ -110,7 +110,7 @@ export const prepareObsForEncryption =
         toast.error(
           "L'observation n'a pas été sauvegardée car son format était incorrect. Vous pouvez vérifier son contenu et tenter de la sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
         );
-        capture(error, { extra: { obs } });
+        capture(error);
         throw error;
       }
     }

--- a/dashboard/src/recoil/treatments.ts
+++ b/dashboard/src/recoil/treatments.ts
@@ -47,7 +47,7 @@ export const prepareTreatmentForEncryption = (treatment: TreatmentInstance, { ch
       toast.error(
         "Le traitement n'a pas été sauvegardé car son format était incorrect. Vous pouvez vérifier son contenu et tenter de le sauvegarder à nouveau. L'équipe technique a été prévenue et va travailler sur un correctif."
       );
-      capture(error, { extra: { treatment } });
+      capture(error);
       throw error;
     }
   }

--- a/dashboard/src/scenes/person/components/PersonDocuments.tsx
+++ b/dashboard/src/scenes/person/components/PersonDocuments.tsx
@@ -153,7 +153,7 @@ const PersonDocuments = ({ person }: PersonDocumentsProps) => {
           toast.success(documentOrFolder.type === 'document' ? 'Document mis à jour' : 'Dossier mis à jour');
         } else {
           toast.error('Erreur lors de la mise à jour du document, vous pouvez contactez le support');
-          capture('Error while updating treatment document', { _person, document });
+          capture('Error while updating treatment document', { personResponseError: personResponse.error });
         }
       }}
       onAddDocuments={async (newDocuments) => {

--- a/dashboard/src/scenes/person/components/PersonDocumentsMedical.tsx
+++ b/dashboard/src/scenes/person/components/PersonDocumentsMedical.tsx
@@ -153,7 +153,7 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             return true;
           } else {
             toast.error('Erreur lors de la suppression du document, vous pouvez contactez le support');
-            capture('Error while deleting treatment document', { treatment, document, treatmentResponse });
+            capture('Error while deleting treatment document', { treatmentResponse });
           }
         }
         if (documentOrFolder.linkedItem.type === 'consultation') {
@@ -178,7 +178,7 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             return true;
           } else {
             toast.error('Erreur lors de la suppression du document, vous pouvez contactez le support');
-            capture('Error while deleting consultation document', { consultation, document, consultationResponse });
+            capture('Error while deleting consultation document', { consultationResponse });
           }
         }
         if (documentOrFolder.linkedItem.type === 'medical-file') {
@@ -202,7 +202,7 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             return true;
           } else {
             toast.error('Erreur lors de la suppression du document, vous pouvez contactez le support');
-            capture('Error while deleting medical file document', { medicalFile, document, medicalFileResponse });
+            capture('Error while deleting medical file document', { medicalFileResponse });
           }
         }
         return false;
@@ -237,7 +237,7 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             toast.success('Document mis à jour');
           } else {
             toast.error('Erreur lors de la mise à jour du document, vous pouvez contactez le support');
-            capture('Error while updating treatment document', { treatment, document, treatmentResponse });
+            capture('Error while updating treatment document', { treatmentResponse });
           }
         }
         if (documentOrFolder.linkedItem.type === 'consultation') {
@@ -269,7 +269,7 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             toast.success('Document mis à jour');
           } else {
             toast.error('Erreur lors de la mise à jour du document, vous pouvez contactez le support');
-            capture('Error while updating consultation document', { consultation, document, consultationResponse });
+            capture('Error while updating consultation document', { consultationResponse });
           }
         }
         if (documentOrFolder.linkedItem.type === 'medical-file') {
@@ -300,7 +300,7 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             toast.success('Document mis à jour');
           } else {
             toast.error('Erreur lors de la mise à jour du document, vous pouvez contactez le support');
-            capture('Error while updating medical file document', { medicalFile, document, medicalFileResponse });
+            capture('Error while updating medical file document', { medicalFileResponse });
           }
         }
       }}
@@ -365,12 +365,12 @@ const PersonDocumentsMedical = ({ person }: PersonDocumentsProps) => {
             return true;
           } else {
             toast.error('Erreur lors de la mise à jour des documents, vous pouvez contactez le support');
-            capture('Error while updating medical file documents reorder', { nextDocuments, medicalDocumentsResponse });
+            capture('Error while updating medical file documents reorder', { medicalDocumentsResponse });
           }
           return false;
         } catch (e) {
           toast.error('Erreur lors de la mise à jour des documents, vous pouvez contactez le support');
-          capture(e, { nextDocuments, message: 'Error while updating documents order' });
+          capture(e, { message: 'Error while updating documents order' });
         }
         return false;
       }}

--- a/dashboard/src/scenes/reception/view.js
+++ b/dashboard/src/scenes/reception/view.js
@@ -196,7 +196,7 @@ const Reception = () => {
       }
       setAddingPassage(false);
     } catch (e) {
-      capture(e, { extra: { selectedPersons, currentTeam }, user });
+      capture(e, { extra: { selectedPersons: selectedPersons.map((p) => p._id), currentTeam }, user });
       toast.error("Désolé une erreur est survenue, l'équipe technique est prévenue");
     }
   };

--- a/dashboard/src/scenes/report/view-old.js
+++ b/dashboard/src/scenes/report/view-old.js
@@ -1454,32 +1454,28 @@ const CommentCreatedAt = ({ date, comments, medical }) => {
           data={data}
           noData="Pas de commentaire ajouté ce jour"
           onRowClick={(comment) => {
-            try {
-              const searchParams = new URLSearchParams(history.location.search);
-              switch (comment.type) {
-                case 'action':
-                  searchParams.set('actionId', comment.action._id);
-                  history.push(`?${searchParams.toString()}`);
-                  break;
-                case 'person':
-                  history.push(`/person/${comment.person._id}`);
-                  break;
-                case 'consultation':
-                  searchParams.set('consultationId', comment.consultation._id);
-                  history.push(`?${searchParams.toString()}`);
-                  break;
-                case 'treatment':
-                  searchParams.set('treatmentId', comment.treatment._id);
-                  history.push(`?${searchParams.toString()}`);
-                  break;
-                case 'medical-file':
-                  history.push(`/person/${comment.person._id}?tab=Dossier+Médical`);
-                  break;
-                default:
-                  break;
-              }
-            } catch (errorLoadingComment) {
-              capture(errorLoadingComment, { extra: { message: 'error loading comment from report', comment, date } });
+            const searchParams = new URLSearchParams(history.location.search);
+            switch (comment.type) {
+              case 'action':
+                searchParams.set('actionId', comment.action._id);
+                history.push(`?${searchParams.toString()}`);
+                break;
+              case 'person':
+                history.push(`/person/${comment.person._id}`);
+                break;
+              case 'consultation':
+                searchParams.set('consultationId', comment.consultation._id);
+                history.push(`?${searchParams.toString()}`);
+                break;
+              case 'treatment':
+                searchParams.set('treatmentId', comment.treatment._id);
+                history.push(`?${searchParams.toString()}`);
+                break;
+              case 'medical-file':
+                history.push(`/person/${comment.person._id}?tab=Dossier+Médical`);
+                break;
+              default:
+                break;
             }
           }}
           rowKey="_id"

--- a/dashboard/src/scenes/search/index.js
+++ b/dashboard/src/scenes/search/index.js
@@ -6,7 +6,6 @@ import ActionStatus from '../../components/ActionStatus';
 import Table from '../../components/table';
 import Observation from '../territory-observations/view';
 import dayjs from 'dayjs';
-import { capture } from '../../services/sentry';
 import UserName from '../../components/UserName';
 import Search from '../../components/search';
 import TagTeam from '../../components/TagTeam';
@@ -646,11 +645,7 @@ const Comments = ({ comments }) => {
       data={comments}
       noData="Pas de commentaire"
       onRowClick={(comment) => {
-        try {
-          history.push(`/${comment.type}/${comment[comment.type]._id}`);
-        } catch (errorLoadingComment) {
-          capture(errorLoadingComment, { extra: { message: 'error loading comment from search', comment } });
-        }
+        history.push(`/${comment.type}/${comment[comment.type]._id}`);
       }}
       rowKey="_id"
       columns={[

--- a/dashboard/src/scenes/stats/Blocks.js
+++ b/dashboard/src/scenes/stats/Blocks.js
@@ -1,5 +1,4 @@
 import { getDuration } from './utils';
-import { capture } from '../../services/sentry';
 import Card from '../../components/Card';
 
 export const Block = ({ data, title = 'Nombre de personnes suivies', help = null }) => (
@@ -24,28 +23,23 @@ export const BlockDateWithTime = ({ data, field, help }) => {
 const twoDecimals = (number) => Math.round(number * 100) / 100;
 
 export const BlockTotal = ({ title, unit, data, field, help }) => {
-  try {
-    if (!data.length) {
-      return <Card title={title} unit={unit} count={0} help={help} />;
-    }
-    const dataWithOnlyNumbers = data.filter((item) => Boolean(item[field])).filter((e) => !isNaN(Number(e[field])));
-    const total = dataWithOnlyNumbers.reduce((total, item) => total + Number(item[field]), 0);
-    const avg = total / dataWithOnlyNumbers.length;
-    return (
-      <Card
-        title={title}
-        unit={unit}
-        count={twoDecimals(total)}
-        help={help}
-        children={
-          <span className="font-weight-normal">
-            Moyenne: <strong>{isNaN(avg) ? '-' : twoDecimals(avg)}</strong>
-          </span>
-        }
-      />
-    );
-  } catch (errorBlockTotal) {
-    capture('error block total', errorBlockTotal, { title, unit, data, field });
+  if (!data.length) {
+    return <Card title={title} unit={unit} count={0} help={help} />;
   }
-  return null;
+  const dataWithOnlyNumbers = data.filter((item) => Boolean(item[field])).filter((e) => !isNaN(Number(e[field])));
+  const total = dataWithOnlyNumbers.reduce((total, item) => total + Number(item[field]), 0);
+  const avg = total / dataWithOnlyNumbers.length;
+  return (
+    <Card
+      title={title}
+      unit={unit}
+      count={twoDecimals(total)}
+      help={help}
+      children={
+        <span className="font-weight-normal">
+          Moyenne: <strong>{isNaN(avg) ? '-' : twoDecimals(avg)}</strong>
+        </span>
+      }
+    />
+  );
 };

--- a/dashboard/src/services/api.js
+++ b/dashboard/src/services/api.js
@@ -58,7 +58,7 @@ export const encryptItem = async (item) => {
       decryptDBItem({ encryptedContent, encryptedEntityKey }, hashedOrgEncryptionKey);
     } catch (e) {
       // TODO: remove when debug is done
-      capture('error decrypting item after encrypting', { extra: { e, item } });
+      capture('error decrypting item after encrypting', { extra: { e, item: item._id } });
     }
 
     item.encrypted = encryptedContent;


### PR DESCRIPTION
Remarque: tous les `capture` que j'ai touché n'ont pas été remontés dans Sentry depuis au moins 90 jours, et certains ne l'ont jamais été
Remarque 2: là normalement, on a plus AUCUNE donnée potentiellement sensible dans sentry - qu'on s'était donné le droit de remonter pour mieux débugger, en période de rodage